### PR TITLE
fix(bolt): honor database scoped rollback

### DIFF
--- a/pkg/bolt/server.go
+++ b/pkg/bolt/server.go
@@ -1906,7 +1906,7 @@ func (s *Session) handleBegin(data []byte) error {
 		if dbName == "" {
 			dbName = s.server.dbManager.DefaultDatabaseName()
 		}
-		txExec, err := s.getExecutorForDatabase(dbName)
+		txExec, err := s.getTransactionalExecutorForDatabase(dbName)
 		if err != nil {
 			return s.sendFailure("Neo.ClientError.Database.DatabaseNotFound",
 				fmt.Sprintf("Database '%s' not found: %v", dbName, err))
@@ -2372,10 +2372,6 @@ func (s *Session) getExecutorForDatabase(dbName string) (QueryExecutor, error) {
 		return nil, fmt.Errorf("database manager not available")
 	}
 
-	type authAwareStorageResolver interface {
-		GetStorageWithAuth(name string, authToken string) (storage.Engine, error)
-	}
-
 	useAuthScopedResolver := false
 	if resolver, ok := s.server.dbManager.(authAwareStorageResolver); ok && strings.TrimSpace(s.forwardedAuthHeader) != "" {
 		_ = resolver
@@ -2391,57 +2387,9 @@ func (s *Session) getExecutorForDatabase(dbName string) (QueryExecutor, error) {
 		s.server.executorsMu.RUnlock()
 	}
 
-	var (
-		storageEngine storage.Engine
-		err           error
-	)
-	if resolver, ok := s.server.dbManager.(authAwareStorageResolver); ok && useAuthScopedResolver {
-		storageEngine, err = resolver.GetStorageWithAuth(dbName, s.forwardedAuthHeader)
-	} else {
-		storageEngine, err = s.server.dbManager.GetStorage(dbName)
-	}
+	executor, err := s.newDatabaseScopedCypherExecutor(dbName, useAuthScopedResolver)
 	if err != nil {
 		return nil, err
-	}
-
-	// Create Cypher executor scoped to this database
-	executor := cypher.NewStorageExecutor(storageEngine)
-
-	// Inherit shared embedder configuration from the server's base executor so
-	// Bolt multi-database sessions can run string vector queries
-	// (db.index.vector.queryNodes(..., $text)) just like HTTP/GraphQL paths.
-	if baseAdapter, ok := s.server.executor.(*boltQueryExecutorAdapter); ok && baseAdapter != nil && baseAdapter.executor != nil {
-		if emb := baseAdapter.executor.GetEmbedder(); emb != nil {
-			executor.SetEmbedder(emb)
-		}
-	}
-	// Allow the server's root executor to fully configure DB-scoped Bolt
-	// executors (embedder/search/inference/callbacks) so Bolt and HTTP share
-	// the same runtime behavior.
-	type databaseExecutorConfigurator interface {
-		ConfigureDatabaseExecutor(exec *cypher.StorageExecutor, dbName string, storageEngine storage.Engine)
-	}
-	if cfg, ok := s.server.executor.(databaseExecutorConfigurator); ok && cfg != nil {
-		cfg.ConfigureDatabaseExecutor(executor, dbName, storageEngine)
-	}
-	// Production Bolt wiring uses cmd/nornicdb DBQueryExecutor directly rather
-	// than boltQueryExecutorAdapter. Support that path via a narrow interface.
-	type baseCypherExecutorProvider interface {
-		BaseCypherExecutor() *cypher.StorageExecutor
-	}
-	if provider, ok := s.server.executor.(baseCypherExecutorProvider); ok && provider != nil {
-		if baseExec := provider.BaseCypherExecutor(); baseExec != nil {
-			if emb := baseExec.GetEmbedder(); emb != nil {
-				executor.SetEmbedder(emb)
-			}
-		}
-	}
-
-	// Wire database manager support when the underlying manager is available so
-	// USE/SHOW/CREATE/ALTER/DROP database commands share the same semantics as
-	// HTTP/GraphQL execution paths.
-	if mgr, ok := s.server.dbManager.(*multidb.DatabaseManager); ok {
-		executor.SetDatabaseManager(&boltDatabaseManagerAdapter{manager: mgr})
 	}
 
 	dbExecutor := &boltQueryExecutorAdapter{executor: executor}
@@ -2461,6 +2409,72 @@ func (s *Session) getExecutorForDatabase(dbName string) (QueryExecutor, error) {
 	s.server.executorsMu.Unlock()
 
 	return dbExecutor, nil
+}
+
+type authAwareStorageResolver interface {
+	GetStorageWithAuth(name string, authToken string) (storage.Engine, error)
+}
+
+type databaseExecutorConfigurator interface {
+	ConfigureDatabaseExecutor(exec *cypher.StorageExecutor, dbName string, storageEngine storage.Engine)
+}
+
+type baseCypherExecutorProvider interface {
+	BaseCypherExecutor() *cypher.StorageExecutor
+}
+
+func (s *Session) getTransactionalExecutorForDatabase(dbName string) (QueryExecutor, error) {
+	if s.server == nil || s.server.dbManager == nil {
+		return nil, fmt.Errorf("database manager not available")
+	}
+	useAuthScopedResolver := false
+	if resolver, ok := s.server.dbManager.(authAwareStorageResolver); ok && strings.TrimSpace(s.forwardedAuthHeader) != "" {
+		_ = resolver
+		useAuthScopedResolver = true
+	}
+	executor, err := s.newDatabaseScopedCypherExecutor(dbName, useAuthScopedResolver)
+	if err != nil {
+		return nil, err
+	}
+	return &transactionalBoltQueryExecutorAdapter{
+		boltQueryExecutorAdapter: boltQueryExecutorAdapter{executor: executor},
+	}, nil
+}
+
+func (s *Session) newDatabaseScopedCypherExecutor(dbName string, useAuthScopedResolver bool) (*cypher.StorageExecutor, error) {
+	var (
+		storageEngine storage.Engine
+		err           error
+	)
+	if resolver, ok := s.server.dbManager.(authAwareStorageResolver); ok && useAuthScopedResolver {
+		storageEngine, err = resolver.GetStorageWithAuth(dbName, s.forwardedAuthHeader)
+	} else {
+		storageEngine, err = s.server.dbManager.GetStorage(dbName)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	executor := cypher.NewStorageExecutor(storageEngine)
+	if baseAdapter, ok := s.server.executor.(*boltQueryExecutorAdapter); ok && baseAdapter != nil && baseAdapter.executor != nil {
+		if emb := baseAdapter.executor.GetEmbedder(); emb != nil {
+			executor.SetEmbedder(emb)
+		}
+	}
+	if cfg, ok := s.server.executor.(databaseExecutorConfigurator); ok && cfg != nil {
+		cfg.ConfigureDatabaseExecutor(executor, dbName, storageEngine)
+	}
+	if provider, ok := s.server.executor.(baseCypherExecutorProvider); ok && provider != nil {
+		if baseExec := provider.BaseCypherExecutor(); baseExec != nil {
+			if emb := baseExec.GetEmbedder(); emb != nil {
+				executor.SetEmbedder(emb)
+			}
+		}
+	}
+	if mgr, ok := s.server.dbManager.(*multidb.DatabaseManager); ok {
+		executor.SetDatabaseManager(&boltDatabaseManagerAdapter{manager: mgr})
+	}
+	return executor, nil
 }
 
 // boltDatabaseManagerAdapter wraps multidb.DatabaseManager to implement
@@ -2626,4 +2640,54 @@ func (a *boltQueryExecutorAdapter) Execute(ctx context.Context, query string, pa
 		Rows:     result.Rows,
 		Metadata: result.Metadata,
 	}, nil
+}
+
+// transactionalBoltQueryExecutorAdapter owns one database-scoped explicit
+// transaction executor. It is intentionally not cached across sessions.
+type transactionalBoltQueryExecutorAdapter struct {
+	boltQueryExecutorAdapter
+
+	mu   sync.Mutex
+	inTx bool
+}
+
+func (a *transactionalBoltQueryExecutorAdapter) Execute(ctx context.Context, query string, params map[string]any) (*QueryResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.boltQueryExecutorAdapter.Execute(ctx, query, params)
+}
+
+func (a *transactionalBoltQueryExecutorAdapter) BeginTransaction(ctx context.Context, _ map[string]any) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.inTx {
+		return nil
+	}
+	if _, err := a.boltQueryExecutorAdapter.Execute(ctx, "BEGIN", nil); err != nil {
+		return err
+	}
+	a.inTx = true
+	return nil
+}
+
+func (a *transactionalBoltQueryExecutorAdapter) CommitTransaction(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.inTx {
+		return nil
+	}
+	_, err := a.boltQueryExecutorAdapter.Execute(ctx, "COMMIT", nil)
+	a.inTx = false
+	return err
+}
+
+func (a *transactionalBoltQueryExecutorAdapter) RollbackTransaction(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.inTx {
+		return nil
+	}
+	_, err := a.boltQueryExecutorAdapter.Execute(ctx, "ROLLBACK", nil)
+	a.inTx = false
+	return err
 }

--- a/pkg/bolt/server_dbmanager_integration_test.go
+++ b/pkg/bolt/server_dbmanager_integration_test.go
@@ -83,10 +83,7 @@ func TestDatabaseManagerBoltNeo4jDriverExecuteWriteRollsBackPriorWrites(t *testi
 	t.Cleanup(func() {
 		_ = server.Close()
 	})
-	go func() {
-		_ = server.ListenAndServe()
-	}()
-	port := waitForBoltTestPort(t, server)
+	port := startBoltTestServer(t, server)
 
 	ctx := context.Background()
 	driver, err := neo4jdriver.NewDriverWithContext(
@@ -144,10 +141,7 @@ func TestDatabaseManagerBoltNeo4jDriverExecuteWritePrefixesGeneratedNodeIDs(t *t
 	t.Cleanup(func() {
 		_ = server.Close()
 	})
-	go func() {
-		_ = server.ListenAndServe()
-	}()
-	port := waitForBoltTestPort(t, server)
+	port := startBoltTestServer(t, server)
 
 	ctx := context.Background()
 	driver, err := neo4jdriver.NewDriverWithContext(
@@ -209,10 +203,7 @@ func TestDatabaseManagerBoltNeo4jDriverExecuteWritePrefixesCanonicalUnwindIDs(t 
 	t.Cleanup(func() {
 		_ = server.Close()
 	})
-	go func() {
-		_ = server.ListenAndServe()
-	}()
-	port := waitForBoltTestPort(t, server)
+	port := startBoltTestServer(t, server)
 
 	ctx := context.Background()
 	driver, err := neo4jdriver.NewDriverWithContext(
@@ -311,19 +302,58 @@ func databaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {
 	return exec
 }
 
-func waitForBoltTestPort(t *testing.T, server *Server) int {
+func startBoltTestServer(t *testing.T, server *Server) int {
 	t.Helper()
+
+	port := reserveBoltTestPort(t)
+	server.config.Port = port
+
+	listenErrCh := make(chan error, 1)
+	go func() {
+		listenErrCh <- server.ListenAndServe()
+	}()
+
+	address := fmt.Sprintf("127.0.0.1:%d", port)
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if server.listener != nil {
-			addr, ok := server.listener.Addr().(*net.TCPAddr)
-			require.True(t, ok)
-			return addr.Port
+		select {
+		case err := <-listenErrCh:
+			require.NoError(t, err)
+		default:
+		}
+
+		conn, err := net.DialTimeout("tcp", address, 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return port
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("timed out waiting for Bolt test listener")
-	return 0
+
+	select {
+	case err := <-listenErrCh:
+		require.NoError(t, err)
+	default:
+	}
+	t.Fatalf("timed out waiting for Bolt test listener on %s", address)
+	return -1
+}
+
+func reserveBoltTestPort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	require.Greater(t, addr.Port, 0)
+	port := addr.Port
+	require.NoError(t, listener.Close())
+	return port
 }
 
 func transactionalDatabaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {

--- a/pkg/bolt/server_dbmanager_integration_test.go
+++ b/pkg/bolt/server_dbmanager_integration_test.go
@@ -2,8 +2,12 @@ package bolt
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/orneryd/nornicdb/pkg/cypher"
 	"github.com/orneryd/nornicdb/pkg/embed"
 	"github.com/orneryd/nornicdb/pkg/multidb"
@@ -27,6 +31,341 @@ func TestSessionGetExecutorForDatabase_WiresDatabaseManagerCommands(t *testing.T
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotEmpty(t, res.Rows)
+}
+
+func TestSessionGetExecutorForDatabase_RollbackRemovesDatabaseScopedWrites(t *testing.T) {
+	store := storage.NewNamespacedEngine(storage.NewMemoryEngine(), "nornic")
+	exec := transactionalDatabaseScopedExecutor(t, store)
+	txExec, ok := exec.(TransactionalExecutor)
+	require.True(t, ok, "database-scoped Bolt executor must support real explicit transactions")
+
+	ctx := context.Background()
+	require.NoError(t, txExec.BeginTransaction(ctx, nil))
+	_, err := txExec.Execute(ctx, "CREATE (n:TxProbe {id: 'clean-rollback'})", nil)
+	require.NoError(t, err)
+	require.NoError(t, txExec.RollbackTransaction(ctx))
+
+	count := databaseScopedNodeCount(t, exec, "clean-rollback")
+	require.Equal(t, int64(0), count)
+}
+
+func TestSessionGetExecutorForDatabase_RollbackAfterStatementFailureRemovesPriorWrites(t *testing.T) {
+	store := storage.NewNamespacedEngine(storage.NewMemoryEngine(), "nornic")
+	exec := transactionalDatabaseScopedExecutor(t, store)
+	txExec, ok := exec.(TransactionalExecutor)
+	require.True(t, ok, "database-scoped Bolt executor must support real explicit transactions")
+
+	ctx := context.Background()
+	require.NoError(t, txExec.BeginTransaction(ctx, nil))
+	_, err := txExec.Execute(ctx, "CREATE (n:TxProbe {id: 'failed-statement-rollback'})", nil)
+	require.NoError(t, err)
+	_, err = txExec.Execute(ctx, "THIS IS NOT CYPHER", nil)
+	require.Error(t, err)
+	require.NoError(t, txExec.RollbackTransaction(ctx))
+
+	count := databaseScopedNodeCount(t, exec, "failed-statement-rollback")
+	require.Equal(t, int64(0), count)
+}
+
+func TestDatabaseManagerBoltNeo4jDriverExecuteWriteRollsBackPriorWrites(t *testing.T) {
+	store := storage.NewNamespacedEngine(storage.NewMemoryEngine(), "nornic")
+	mgr := &mockDBManager{
+		stores: map[string]storage.Engine{
+			"nornic": store,
+		},
+		defaultDB: "nornic",
+	}
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+	go func() {
+		_ = server.ListenAndServe()
+	}()
+	port := waitForBoltTestPort(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = session.Close(ctx)
+	}()
+
+	_, err = session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, runErr := tx.Run(ctx, "CREATE (n:TxProbe {id: $id})", map[string]any{"id": "driver-rollback"})
+		if runErr != nil {
+			return nil, runErr
+		}
+		if _, consumeErr := result.Consume(ctx); consumeErr != nil {
+			return nil, consumeErr
+		}
+		result, runErr = tx.Run(ctx, "THIS IS NOT CYPHER", nil)
+		if runErr != nil {
+			return nil, runErr
+		}
+		_, consumeErr := result.Consume(ctx)
+		return nil, consumeErr
+	})
+	require.Error(t, err)
+
+	count := databaseScopedNodeCount(t, databaseScopedExecutor(t, store), "driver-rollback")
+	require.Equal(t, int64(0), count)
+}
+
+func TestDatabaseManagerBoltNeo4jDriverExecuteWritePrefixesGeneratedNodeIDs(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	mgr, err := multidb.NewDatabaseManager(base, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Close()
+	})
+
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+	go func() {
+		_ = server.ListenAndServe()
+	}()
+	port := waitForBoltTestPort(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = session.Close(ctx)
+	}()
+
+	_, err = session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, runErr := tx.Run(ctx, "MERGE (d:Directory {path: $path}) SET d.name = $name", map[string]any{
+			"path": "/repo/internal/runtime",
+			"name": "runtime",
+		})
+		if runErr != nil {
+			return nil, runErr
+		}
+		_, consumeErr := result.Consume(ctx)
+		return nil, consumeErr
+	})
+	require.NoError(t, err)
+
+	store, err := mgr.GetStorage("nornic")
+	require.NoError(t, err)
+	exec := cypher.NewStorageExecutor(store)
+	res, err := exec.Execute(ctx,
+		"MATCH (d:Directory {path: $path}) RETURN count(d) AS c",
+		map[string]any{"path": "/repo/internal/runtime"},
+	)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.EqualValues(t, 1, res.Rows[0][0])
+}
+
+func TestDatabaseManagerBoltNeo4jDriverExecuteWritePrefixesCanonicalUnwindIDs(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	mgr, err := multidb.NewDatabaseManager(base, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Close()
+	})
+
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+	go func() {
+		_ = server.ListenAndServe()
+	}()
+	port := waitForBoltTestPort(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = session.Close(ctx)
+	}()
+
+	_, err = session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		statements := []struct {
+			query  string
+			params map[string]any
+		}{
+			{
+				query: "MERGE (r:Repository {id: $repo_id}) SET r.name = $name, r.path = $path",
+				params: map[string]any{
+					"repo_id": "pcg-nornicdb-canonical",
+					"name":    "pcg-nornicdb-canonical",
+					"path":    "/tmp/pcg-nornicdb-canonical",
+				},
+			},
+			{
+				query: `UNWIND $rows AS row
+MATCH (r:Repository {id: row.repo_id})
+MERGE (d:Directory {path: row.path})
+SET d.name = row.name, d.repo_id = row.repo_id,
+    d.scope_id = row.scope_id, d.generation_id = row.generation_id
+MERGE (r)-[:CONTAINS]->(d)`,
+				params: map[string]any{
+					"rows": []map[string]any{{
+						"repo_id":       "pcg-nornicdb-canonical",
+						"path":          "/tmp/pcg-nornicdb-canonical/src",
+						"name":          "src",
+						"scope_id":      "scope:pcg-nornicdb-canonical",
+						"generation_id": "generation:pcg-nornicdb-canonical",
+					}},
+				},
+			},
+		}
+		for _, stmt := range statements {
+			result, runErr := tx.Run(ctx, stmt.query, stmt.params)
+			if runErr != nil {
+				return nil, runErr
+			}
+			if _, consumeErr := result.Consume(ctx); consumeErr != nil {
+				return nil, consumeErr
+			}
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	store, err := mgr.GetStorage("nornic")
+	require.NoError(t, err)
+	exec := cypher.NewStorageExecutor(store)
+	res, err := exec.Execute(ctx,
+		"MATCH (:Repository {id: $repo_id})-[:CONTAINS]->(:Directory {path: $path}) RETURN count(*) AS c",
+		map[string]any{
+			"repo_id": "pcg-nornicdb-canonical",
+			"path":    "/tmp/pcg-nornicdb-canonical/src",
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.EqualValues(t, 1, res.Rows[0][0])
+}
+
+func databaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {
+	t.Helper()
+
+	mgr := &mockDBManager{
+		stores: map[string]storage.Engine{
+			"nornic": store,
+		},
+		defaultDB: "nornic",
+	}
+	s := &Session{
+		server: &Server{
+			dbManager: mgr,
+		},
+	}
+	exec, err := s.getExecutorForDatabase("nornic")
+	require.NoError(t, err)
+	return exec
+}
+
+func waitForBoltTestPort(t *testing.T, server *Server) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if server.listener != nil {
+			addr, ok := server.listener.Addr().(*net.TCPAddr)
+			require.True(t, ok)
+			return addr.Port
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for Bolt test listener")
+	return 0
+}
+
+func transactionalDatabaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {
+	t.Helper()
+
+	mgr := &mockDBManager{
+		stores: map[string]storage.Engine{
+			"nornic": store,
+		},
+		defaultDB: "nornic",
+	}
+	s := &Session{
+		server: &Server{
+			dbManager: mgr,
+		},
+	}
+	exec, err := s.getTransactionalExecutorForDatabase("nornic")
+	require.NoError(t, err)
+	return exec
+}
+
+func databaseScopedNodeCount(t *testing.T, exec QueryExecutor, id string) int64 {
+	t.Helper()
+
+	res, err := exec.Execute(context.Background(),
+		"MATCH (n:TxProbe {id: $id}) RETURN count(n) AS c",
+		map[string]any{"id": id},
+	)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.Len(t, res.Rows[0], 1)
+	switch count := res.Rows[0][0].(type) {
+	case int:
+		return int64(count)
+	case int64:
+		return count
+	case float64:
+		return int64(count)
+	default:
+		t.Fatalf("count type = %T, want numeric", count)
+	}
+	return -1
 }
 
 type fixedEmbedder struct {

--- a/pkg/bolt/server_dbmanager_integration_test.go
+++ b/pkg/bolt/server_dbmanager_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/orneryd/nornicdb/pkg/cypher"
@@ -302,63 +301,32 @@ func databaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {
 	return exec
 }
 
-// startBoltTestServer binds a deterministic loopback port for the test server,
-// starts ListenAndServe in the background, and fails fast if startup returns an
-// unexpected error before the driver can connect.
+// startBoltTestServer pre-binds a loopback listener for the test server and
+// runs the accept loop directly, avoiding racy reads of server.listener and the
+// reserve-then-rebind TOCTOU window.
 func startBoltTestServer(t *testing.T, server *Server) int {
-	t.Helper()
-
-	port := reserveBoltTestPort(t)
-	server.config.Port = port
-
-	listenErrCh := make(chan error, 1)
-	go func() {
-		listenErrCh <- server.ListenAndServe()
-	}()
-
-	address := fmt.Sprintf("127.0.0.1:%d", port)
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case err := <-listenErrCh:
-			require.NoError(t, err)
-		default:
-		}
-
-		conn, err := net.DialTimeout("tcp", address, 50*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return port
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	select {
-	case err := <-listenErrCh:
-		require.NoError(t, err)
-	default:
-	}
-	t.Fatalf("timed out waiting for Bolt test listener on %s", address)
-	return -1
-}
-
-// reserveBoltTestPort grabs an ephemeral loopback port up front so tests avoid
-// racy reads of server.listener while ListenAndServe initializes.
-func reserveBoltTestPort(t *testing.T) int {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = listener.Close()
-	})
-
 	addr, ok := listener.Addr().(*net.TCPAddr)
 	require.True(t, ok)
 	require.Greater(t, addr.Port, 0)
-	port := addr.Port
-	require.NoError(t, listener.Close())
-	return port
+	server.listener = listener
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.serve()
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		default:
+		}
+	})
+	return addr.Port
 }
 
 func transactionalDatabaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {

--- a/pkg/bolt/server_dbmanager_integration_test.go
+++ b/pkg/bolt/server_dbmanager_integration_test.go
@@ -302,6 +302,9 @@ func databaseScopedExecutor(t *testing.T, store storage.Engine) QueryExecutor {
 	return exec
 }
 
+// startBoltTestServer binds a deterministic loopback port for the test server,
+// starts ListenAndServe in the background, and fails fast if startup returns an
+// unexpected error before the driver can connect.
 func startBoltTestServer(t *testing.T, server *Server) int {
 	t.Helper()
 
@@ -339,6 +342,8 @@ func startBoltTestServer(t *testing.T, server *Server) int {
 	return -1
 }
 
+// reserveBoltTestPort grabs an ephemeral loopback port up front so tests avoid
+// racy reads of server.listener while ListenAndServe initializes.
 func reserveBoltTestPort(t *testing.T) int {
 	t.Helper()
 

--- a/pkg/cypher/transaction.go
+++ b/pkg/cypher/transaction.go
@@ -279,6 +279,24 @@ func (e *StorageExecutor) executeInTransaction(ctx context.Context, cypher strin
 		return nil, fmt.Errorf("unknown transaction type")
 	}
 
+	// Recursive execution paths, such as UNWIND ... MATCH ... MERGE fallback
+	// routing, can re-enter Execute while the transaction wrapper is already in
+	// context. Reuse it so database namespace metadata is not lost by wrapping
+	// the same Badger transaction a second time.
+	if txWrapper, ok := ctx.Value(ctxKeyTxStorage).(*transactionStorageWrapper); ok && txWrapper != nil {
+		txExec := e.cloneWithStorage(txWrapper)
+		result, err := txExec.executeQueryAgainstStorage(ctx, cypher, upperQuery)
+		if err != nil {
+			return nil, err
+		}
+		if inlineEmbeddingEnabled {
+			if err := txExec.applyInlineEmbeddingMutations(ctx, txWrapper.snapshotMutatedNodeIDs()); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	}
+
 	// Create a transactional wrapper that routes writes through the transaction.
 	// IMPORTANT: carry namespace info so writes remain correctly prefixed in multi-db.
 	engines := e.resolveImplicitTxEngines()

--- a/pkg/cypher/transaction.go
+++ b/pkg/cypher/transaction.go
@@ -282,8 +282,12 @@ func (e *StorageExecutor) executeInTransaction(ctx context.Context, cypher strin
 	// Recursive execution paths, such as UNWIND ... MATCH ... MERGE fallback
 	// routing, can re-enter Execute while the transaction wrapper is already in
 	// context. Reuse it so database namespace metadata is not lost by wrapping
-	// the same Badger transaction a second time.
-	if txWrapper, ok := ctx.Value(ctxKeyTxStorage).(*transactionStorageWrapper); ok && txWrapper != nil {
+	// the same Badger transaction a second time. Only reuse the wrapper that
+	// belongs to the active explicit transaction; stale wrappers from reused
+	// contexts must fall back to a fresh wrapper for the current tx.
+	if txWrapper, ok := ctx.Value(ctxKeyTxStorage).(*transactionStorageWrapper); ok &&
+		txWrapper != nil &&
+		txWrapper.tx == tx {
 		txExec := e.cloneWithStorage(txWrapper)
 		result, err := txExec.executeQueryAgainstStorage(ctx, cypher, upperQuery)
 		if err != nil {

--- a/pkg/cypher/transaction_wrapper_reuse_test.go
+++ b/pkg/cypher/transaction_wrapper_reuse_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestExecuteInTransaction_ReusesExistingTransactionWrapper proves that
+// recursive execution paths reuse the transaction wrapper already stored in
+// context instead of re-wrapping the same Badger transaction and dropping the
+// active namespace metadata.
 func TestExecuteInTransaction_ReusesExistingTransactionWrapper(t *testing.T) {
 	baseStore := newTestMemoryEngine(t)
 	store := storage.NewNamespacedEngine(baseStore, "tenant")

--- a/pkg/cypher/transaction_wrapper_reuse_test.go
+++ b/pkg/cypher/transaction_wrapper_reuse_test.go
@@ -1,0 +1,49 @@
+package cypher
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteInTransaction_ReusesExistingTransactionWrapper(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "tenant")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, "BEGIN", nil)
+	require.NoError(t, err)
+	require.NotNil(t, exec.txContext)
+
+	tx, ok := exec.txContext.tx.(*storage.BadgerTransaction)
+	require.True(t, ok, "expected explicit transaction to use BadgerTransaction")
+
+	txWrapper := &transactionStorageWrapper{
+		tx:             tx,
+		underlying:     exec.storage,
+		namespace:      "tenant",
+		separator:      ":",
+		mutatedNodeIDs: make(map[string]struct{}),
+	}
+	txExec := exec.cloneWithStorage(txWrapper)
+	txCtx := context.WithValue(ctx, ctxKeyTxStorage, txWrapper)
+
+	_, err = txExec.executeInTransaction(
+		txCtx,
+		"CREATE (:TxReuse {name: 'ctx-wrapper'})",
+		strings.ToUpper("CREATE (:TxReuse {name: 'ctx-wrapper'})"),
+	)
+	require.NoError(t, err)
+	require.Len(t, txWrapper.snapshotMutatedNodeIDs(), 1, "existing tx wrapper should record mutations")
+
+	_, err = exec.Execute(ctx, "COMMIT", nil)
+	require.NoError(t, err)
+
+	result, err := exec.Execute(ctx, "MATCH (n:TxReuse {name: 'ctx-wrapper'}) RETURN count(n) AS c", nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, countFromResult(t, result))
+}

--- a/pkg/cypher/transaction_wrapper_reuse_test.go
+++ b/pkg/cypher/transaction_wrapper_reuse_test.go
@@ -51,3 +51,55 @@ func TestExecuteInTransaction_ReusesExistingTransactionWrapper(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, countFromResult(t, result))
 }
+
+func TestExecuteInTransaction_IgnoresStaleTransactionWrapper(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "tenant")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, "BEGIN", nil)
+	require.NoError(t, err)
+	require.NotNil(t, exec.txContext)
+
+	currentTx, ok := exec.txContext.tx.(*storage.BadgerTransaction)
+	require.True(t, ok, "expected explicit transaction to use BadgerTransaction")
+
+	otherExec := NewStorageExecutor(storage.NewNamespacedEngine(baseStore, "tenant"))
+	_, err = otherExec.Execute(ctx, "BEGIN", nil)
+	require.NoError(t, err)
+	require.NotNil(t, otherExec.txContext)
+	t.Cleanup(func() {
+		if otherExec.txContext != nil && otherExec.txContext.active {
+			_, _ = otherExec.Execute(ctx, "ROLLBACK", nil)
+		}
+	})
+
+	staleTx, ok := otherExec.txContext.tx.(*storage.BadgerTransaction)
+	require.True(t, ok, "expected stale transaction to use BadgerTransaction")
+	require.NotEqual(t, staleTx, currentTx, "test requires distinct explicit transactions")
+
+	staleWrapper := &transactionStorageWrapper{
+		tx:             staleTx,
+		underlying:     otherExec.storage,
+		namespace:      "tenant",
+		separator:      ":",
+		mutatedNodeIDs: make(map[string]struct{}),
+	}
+	txCtx := context.WithValue(ctx, ctxKeyTxStorage, staleWrapper)
+
+	_, err = exec.executeInTransaction(
+		txCtx,
+		"CREATE (:TxReuse {name: 'fresh-wrapper'})",
+		strings.ToUpper("CREATE (:TxReuse {name: 'fresh-wrapper'})"),
+	)
+	require.NoError(t, err)
+	require.Nil(t, staleWrapper.snapshotMutatedNodeIDs(), "stale wrapper should not be reused")
+
+	_, err = exec.Execute(ctx, "COMMIT", nil)
+	require.NoError(t, err)
+
+	result, err := exec.Execute(ctx, "MATCH (n:TxReuse {name: 'fresh-wrapper'}) RETURN count(n) AS c", nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, countFromResult(t, result))
+}


### PR DESCRIPTION
## Summary
Fix database-scoped Bolt explicit transactions so Neo4j-driver managed transactions use real Cypher `BEGIN`, `COMMIT`, and `ROLLBACK` semantics instead of cached autocommit execution.

Closes #106.

## Why This Change Was Needed
The database-scoped Bolt path could fall back into cached/autocommit-style execution, which meant:
- rollback-sensitive managed writes could leak partial state after a later statement failed,
- recursive `UNWIND ... MATCH ... MERGE` execution could lose namespace metadata if the same active transaction was wrapped twice,
- and the regression harness could hide startup failures or race on `server.listener` while waiting for the test server to bind.

## Changes
- route Bolt `BEGIN` through a non-cached transactional database-scoped executor
- reuse the active transaction storage wrapper during recursive execution so namespace metadata is preserved across re-entrant query paths
- harden the Bolt integration harness so startup failures fail loudly and test port discovery no longer races on `server.listener`
- add direct regression coverage for the transaction-wrapper reuse path, alongside rollback and canonical `UNWIND/MATCH/MERGE` write coverage

## Why The New Tests Matter
- `pkg/bolt/server_dbmanager_integration_test.go` now proves the external Neo4j-driver path sees correct rollback behavior without relying on racy listener polling.
- `pkg/cypher/transaction_wrapper_reuse_test.go` proves the internal `transaction.go` recursion path reuses the existing wrapper from context, which is the invariant that keeps multi-database namespace prefixes intact during fallback execution.

## Testing
- `go test -tags 'noui nolocalllm' ./pkg/bolt -run 'TestSessionGetExecutorForDatabase_Rollback|TestDatabaseManagerBoltNeo4jDriverExecuteWrite' -count=1 -v`
- `go test -tags 'noui nolocalllm' ./pkg/cypher -run 'TestExecuteInTransaction_ReusesExistingTransactionWrapper' -count=1 -v`
- `go test -tags 'noui nolocalllm' ./pkg/bolt ./pkg/cypher ./pkg/txsession -count=1`
- `git diff --check`
