### PR TITLE
Use unique index for constraint validation

### DIFF
--- a/pkg/cypher/schema.go
+++ b/pkg/cypher/schema.go
@@ -471,7 +471,11 @@ func (e *StorageExecutor) executeCreateConstraint(ctx context.Context, cypher st
 		if err := storage.ValidateConstraintOnCreationForEngine(e.storage, constraint); err != nil {
 			return nil, err
 		}
-		if err := e.storage.GetSchema().AddUniqueConstraint(constraintName, label, property, ifNotExists); err != nil {
+		schema := e.storage.GetSchema()
+		if err := schema.AddUniqueConstraint(constraintName, label, property, ifNotExists); err != nil {
+			return nil, err
+		}
+		if err := storage.RefreshUniqueConstraintValuesForEngine(e.storage, schema); err != nil {
 			return nil, err
 		}
 		return &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}}, nil
@@ -494,7 +498,11 @@ func (e *StorageExecutor) executeCreateConstraint(ctx context.Context, cypher st
 		if err := storage.ValidateConstraintOnCreationForEngine(e.storage, constraint); err != nil {
 			return nil, err
 		}
-		if err := e.storage.GetSchema().AddUniqueConstraint(constraintName, label, property, ifNotExists); err != nil {
+		schema := e.storage.GetSchema()
+		if err := schema.AddUniqueConstraint(constraintName, label, property, ifNotExists); err != nil {
+			return nil, err
+		}
+		if err := storage.RefreshUniqueConstraintValuesForEngine(e.storage, schema); err != nil {
 			return nil, err
 		}
 		return &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}}, nil
@@ -517,7 +525,11 @@ func (e *StorageExecutor) executeCreateConstraint(ctx context.Context, cypher st
 		if err := storage.ValidateConstraintOnCreationForEngine(e.storage, constraint); err != nil {
 			return nil, err
 		}
-		if err := e.storage.GetSchema().AddUniqueConstraint(constraintName, label, property, ifNotExists); err != nil {
+		schema := e.storage.GetSchema()
+		if err := schema.AddUniqueConstraint(constraintName, label, property, ifNotExists); err != nil {
+			return nil, err
+		}
+		if err := storage.RefreshUniqueConstraintValuesForEngine(e.storage, schema); err != nil {
 			return nil, err
 		}
 		return &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}}, nil

--- a/pkg/storage/badger_constraint_test.go
+++ b/pkg/storage/badger_constraint_test.go
@@ -124,13 +124,10 @@ func TestBadgerTransactionUniqueConstraintUsesRegisteredValueIndex(t *testing.T)
 	}
 
 	scanCalls := 0
-	previousHook := uniqueConstraintScanHook
-	uniqueConstraintScanHook = func() {
+	restoreHook := setUniqueConstraintScanHook(func() {
 		scanCalls++
-	}
-	defer func() {
-		uniqueConstraintScanHook = previousHook
-	}()
+	})
+	defer restoreHook()
 
 	// Delete the label index entry to prove duplicate detection comes from the
 	// registered unique-value index, not from a label scan.
@@ -153,6 +150,83 @@ func TestBadgerTransactionUniqueConstraintUsesRegisteredValueIndex(t *testing.T)
 	})
 	if err == nil {
 		t.Fatal("expected unique constraint violation from registered value index")
+	}
+	if scanCalls != 0 {
+		t.Fatalf("unique validation used label scan %d time(s), want registered-value lookup only", scanCalls)
+	}
+	tx2.Rollback()
+}
+
+func TestBadgerTransactionUniqueConstraintIndexMatchesNumericCompareSemantics(t *testing.T) {
+	engine, cleanup := setupTestBadgerEngine(t)
+	defer cleanup()
+
+	schema := engine.GetSchemaForNamespace("test")
+	if err := schema.AddUniqueConstraint("unique_age", "User", "age"); err != nil {
+		t.Fatalf("AddUniqueConstraint failed: %v", err)
+	}
+
+	firstID := NodeID(prefixTestID("user-unique-age-1"))
+	tx1, err := engine.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	if _, err := tx1.CreateNode(&Node{
+		ID:     firstID,
+		Labels: []string{"User"},
+		Properties: map[string]interface{}{
+			"age": int(1),
+		},
+	}); err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+	if err := tx1.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	if err := engine.rebuildUniqueConstraintValues("test", schema); err != nil {
+		t.Fatalf("rebuildUniqueConstraintValues failed: %v", err)
+	}
+	if got, found, constrained := schema.LookupUniqueConstraintValue("User", "age", int(1)); !constrained || !found || got != firstID {
+		t.Fatalf("LookupUniqueConstraintValue(int) = (%q, %v, %v), want (%q, true, true)", got, found, constrained, firstID)
+	}
+
+	if got, found, constrained := schema.LookupUniqueConstraintValue("User", "age", float64(1)); !constrained || !found || got != firstID {
+		t.Fatalf("LookupUniqueConstraintValue() = (%q, %v, %v), want (%q, true, true)", got, found, constrained, firstID)
+	}
+	if got, found, authoritative, constrained := schema.lookupUniqueConstraintValueForValidation("User", "age", float64(1)); !constrained || !authoritative || !found || got != firstID {
+		t.Fatalf("lookupUniqueConstraintValueForValidation() = (%q, %v, %v, %v), want (%q, true, true, true)", got, found, authoritative, constrained, firstID)
+	}
+	constraints := schema.GetConstraintsForLabels([]string{"User"})
+	if len(constraints) != 1 {
+		t.Fatalf("GetConstraintsForLabels(User) returned %d constraint(s), want 1", len(constraints))
+	}
+
+	scanCalls := 0
+	restoreHook := setUniqueConstraintScanHook(func() {
+		scanCalls++
+	})
+	defer restoreHook()
+
+	tx2, err := engine.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	duplicate := &Node{
+		ID:     NodeID(prefixTestID("user-unique-age-2")),
+		Labels: []string{"User"},
+		Properties: map[string]interface{}{
+			"age": float64(1),
+		},
+	}
+	if err := tx2.validateNodeConstraints(duplicate); err == nil {
+		t.Fatal("expected direct unique constraint validation failure")
+	}
+	if err := tx2.checkUniqueConstraint(duplicate, constraints[0]); err == nil {
+		t.Fatal("expected direct unique constraint check failure")
+	}
+	_, err = tx2.CreateNode(duplicate)
+	if err == nil {
+		t.Fatal("expected unique constraint violation from numeric-equivalent registered value")
 	}
 	if scanCalls != 0 {
 		t.Fatalf("unique validation used label scan %d time(s), want registered-value lookup only", scanCalls)

--- a/pkg/storage/badger_constraint_test.go
+++ b/pkg/storage/badger_constraint_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,6 +87,77 @@ func TestBadgerTransaction_FullScanUniqueConstraint(t *testing.T) {
 	}
 
 	tx3.Commit()
+}
+
+func TestBadgerTransactionUniqueConstraintUsesRegisteredValueIndex(t *testing.T) {
+	engine, cleanup := setupTestBadgerEngine(t)
+	defer cleanup()
+
+	schema := engine.GetSchemaForNamespace("test")
+	if err := schema.AddUniqueConstraint("unique_email", "User", "email"); err != nil {
+		t.Fatalf("AddUniqueConstraint failed: %v", err)
+	}
+
+	firstID := NodeID(prefixTestID("user-unique-index-1"))
+	tx1, err := engine.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	if _, err := tx1.CreateNode(&Node{
+		ID:     firstID,
+		Labels: []string{"User"},
+		Properties: map[string]interface{}{
+			"email": "alice@example.com",
+		},
+	}); err != nil {
+		t.Fatalf("CreateNode failed: %v", err)
+	}
+	if err := tx1.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	if got, found, constrained := schema.LookupUniqueConstraintValue("User", "email", "alice@example.com"); !constrained || !found || got != firstID {
+		t.Fatalf("LookupUniqueConstraintValue() = (%q, %v, %v), want (%q, true, true)", got, found, constrained, firstID)
+	}
+	if err := engine.rebuildUniqueConstraintValues("test", schema); err != nil {
+		t.Fatalf("rebuildUniqueConstraintValues failed: %v", err)
+	}
+
+	scanCalls := 0
+	previousHook := uniqueConstraintScanHook
+	uniqueConstraintScanHook = func() {
+		scanCalls++
+	}
+	defer func() {
+		uniqueConstraintScanHook = previousHook
+	}()
+
+	// Delete the label index entry to prove duplicate detection comes from the
+	// registered unique-value index, not from a label scan.
+	if err := engine.db.Update(func(txn *badger.Txn) error {
+		return txn.Delete(labelIndexKey("User", firstID))
+	}); err != nil {
+		t.Fatalf("delete label index: %v", err)
+	}
+
+	tx2, err := engine.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	_, err = tx2.CreateNode(&Node{
+		ID:     NodeID(prefixTestID("user-unique-index-2")),
+		Labels: []string{"User"},
+		Properties: map[string]interface{}{
+			"email": "alice@example.com",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected unique constraint violation from registered value index")
+	}
+	if scanCalls != 0 {
+		t.Fatalf("unique validation used label scan %d time(s), want registered-value lookup only", scanCalls)
+	}
+	tx2.Rollback()
 }
 
 // TestBadgerTransaction_FullScanNodeKeyConstraint tests NODE KEY constraint across transactions.

--- a/pkg/storage/badger_constraint_validation.go
+++ b/pkg/storage/badger_constraint_validation.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -11,6 +12,12 @@ import (
 // compareValues compares two property values for equality.
 // This mirrors Cypher semantics for numeric comparisons across int/float types.
 func compareValues(a, b interface{}) bool {
+	if aNum, ok := numericConstraintValue(a); ok {
+		if bNum, ok := numericConstraintValue(b); ok {
+			return aNum == bNum
+		}
+	}
+
 	// Handle different numeric types
 	switch v1 := a.(type) {
 	case int:
@@ -51,7 +58,44 @@ func compareValues(a, b interface{}) bool {
 	}
 
 	// Default comparison
+	if a == nil || b == nil {
+		return a == b
+	}
+	if !reflect.TypeOf(a).Comparable() || !reflect.TypeOf(b).Comparable() {
+		return reflect.DeepEqual(a, b)
+	}
 	return a == b
+}
+
+func numericConstraintValue(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
 }
 
 func (b *BadgerEngine) validateNodeConstraintsInTxn(txn *badger.Txn, node *Node, schema *SchemaManager, namespace string, excludeNodeID NodeID) error {
@@ -181,8 +225,8 @@ func (b *BadgerEngine) validateNodeConstraintsInTxn(txn *badger.Txn, node *Node,
 }
 
 func (b *BadgerEngine) scanForUniqueViolationInTxn(txn *badger.Txn, namespace, label, property string, value interface{}, excludeNodeID NodeID) error {
-	if uniqueConstraintScanHook != nil {
-		uniqueConstraintScanHook()
+	if hook := getUniqueConstraintScanHook(); hook != nil {
+		hook()
 	}
 
 	prefix := labelIndexPrefix(label)

--- a/pkg/storage/badger_constraint_validation.go
+++ b/pkg/storage/badger_constraint_validation.go
@@ -71,6 +71,12 @@ func (b *BadgerEngine) validateNodeConstraintsInTxn(txn *badger.Txn, node *Node,
 			if value == nil {
 				continue
 			}
+			if existingNode, found, authoritative, constrained := schema.lookupUniqueConstraintValueForValidation(c.Label, prop, value); constrained && authoritative {
+				if found && existingNode != excludeNodeID {
+					return uniqueConstraintViolation(c.Label, prop, value, existingNode)
+				}
+				continue
+			}
 			if err := b.scanForUniqueViolationInTxn(txn, namespace, c.Label, prop, value, excludeNodeID); err != nil {
 				return err
 			}
@@ -175,6 +181,10 @@ func (b *BadgerEngine) validateNodeConstraintsInTxn(txn *badger.Txn, node *Node,
 }
 
 func (b *BadgerEngine) scanForUniqueViolationInTxn(txn *badger.Txn, namespace, label, property string, value interface{}, excludeNodeID NodeID) error {
+	if uniqueConstraintScanHook != nil {
+		uniqueConstraintScanHook()
+	}
+
 	prefix := labelIndexPrefix(label)
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchValues = false

--- a/pkg/storage/badger_schema.go
+++ b/pkg/storage/badger_schema.go
@@ -162,6 +162,7 @@ func (b *BadgerEngine) rebuildUniqueConstraintValues(namespace string, sm *Schem
 	for _, uc := range uniqueConstraints {
 		uc.mu.Lock()
 		uc.values = make(map[interface{}]NodeID)
+		uc.valuesAuthoritative = false
 		uc.mu.Unlock()
 	}
 	for _, idx := range propertyIndexes {
@@ -183,7 +184,7 @@ func (b *BadgerEngine) rebuildUniqueConstraintValues(namespace string, sm *Schem
 	prefix = append(prefix, []byte(namespace)...)
 	prefix = append(prefix, ':')
 
-	return b.withView(func(txn *badger.Txn) error {
+	if err := b.withView(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.Prefix = prefix
 		opts.PrefetchValues = true
@@ -243,7 +244,17 @@ func (b *BadgerEngine) rebuildUniqueConstraintValues(namespace string, sm *Schem
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	for _, uc := range uniqueConstraints {
+		uc.mu.Lock()
+		uc.valuesAuthoritative = true
+		uc.mu.Unlock()
+	}
+
+	return nil
 }
 
 // GetSchemaForNamespace returns the schema for a specific database namespace.

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -1703,12 +1703,32 @@ func uniqueConstraintViolation(label, property string, value interface{}, nodeID
 // uniqueConstraintScanHook lets storage tests assert that indexed UNIQUE
 // validation does not regress to the label-scan fallback.
 var uniqueConstraintScanHook func()
+var uniqueConstraintScanHookMu sync.RWMutex
+
+func setUniqueConstraintScanHook(hook func()) func() {
+	uniqueConstraintScanHookMu.Lock()
+	previousHook := uniqueConstraintScanHook
+	uniqueConstraintScanHook = hook
+	uniqueConstraintScanHookMu.Unlock()
+
+	return func() {
+		uniqueConstraintScanHookMu.Lock()
+		uniqueConstraintScanHook = previousHook
+		uniqueConstraintScanHookMu.Unlock()
+	}
+}
+
+func getUniqueConstraintScanHook() func() {
+	uniqueConstraintScanHookMu.RLock()
+	defer uniqueConstraintScanHookMu.RUnlock()
+	return uniqueConstraintScanHook
+}
 
 // scanForUniqueViolation performs a full database scan to check for UNIQUE violations
 // within a single namespace (database).
 func (tx *BadgerTransaction) scanForUniqueViolation(namespace, label, property string, value interface{}, excludeNodeID NodeID) error {
-	if uniqueConstraintScanHook != nil {
-		uniqueConstraintScanHook()
+	if hook := getUniqueConstraintScanHook(); hook != nil {
+		hook()
 	}
 
 	nodes, err := tx.getNodesByLabelLocked(label)

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -1675,17 +1675,42 @@ func (tx *BadgerTransaction) checkUniqueConstraint(node *Node, c Constraint) err
 		}
 	}
 
-	// Full-scan check: scan all existing nodes with this label (namespace-scoped).
-	if err := tx.scanForUniqueViolation(dbName, c.Label, prop, value, node.ID); err != nil {
-		return err
+	schema := tx.engine.GetSchemaForNamespace(dbName)
+	if existingNode, found, authoritative, constrained := schema.lookupUniqueConstraintValueForValidation(c.Label, prop, value); constrained && authoritative {
+		if found && existingNode != node.ID {
+			if _, deleted := tx.deletedNodes[existingNode]; !deleted {
+				return uniqueConstraintViolation(c.Label, prop, value, existingNode)
+			}
+		}
+		return nil
 	}
 
-	return nil
+	// If the derived unique-value cache is not known authoritative, fall back to
+	// the label scan. Normal schema creation/reload marks the cache authoritative
+	// once after rebuilding it from stored nodes, so hot writes avoid this path.
+	return tx.scanForUniqueViolation(dbName, c.Label, prop, value, node.ID)
 }
+
+func uniqueConstraintViolation(label, property string, value interface{}, nodeID NodeID) *ConstraintViolationError {
+	return &ConstraintViolationError{
+		Type:       ConstraintUnique,
+		Label:      label,
+		Properties: []string{property},
+		Message:    fmt.Sprintf("Node with %s=%v already exists (nodeID: %s)", property, value, nodeID),
+	}
+}
+
+// uniqueConstraintScanHook lets storage tests assert that indexed UNIQUE
+// validation does not regress to the label-scan fallback.
+var uniqueConstraintScanHook func()
 
 // scanForUniqueViolation performs a full database scan to check for UNIQUE violations
 // within a single namespace (database).
 func (tx *BadgerTransaction) scanForUniqueViolation(namespace, label, property string, value interface{}, excludeNodeID NodeID) error {
+	if uniqueConstraintScanHook != nil {
+		uniqueConstraintScanHook()
+	}
+
 	nodes, err := tx.getNodesByLabelLocked(label)
 	if err != nil {
 		return err

--- a/pkg/storage/constraint_validation.go
+++ b/pkg/storage/constraint_validation.go
@@ -36,6 +36,56 @@ func ValidateConstraintOnCreationForEngine(engine Engine, c Constraint) error {
 	}
 }
 
+// RefreshUniqueConstraintValuesForEngine rebuilds single-property UNIQUE value
+// caches from the engine after a schema mutation has been admitted.
+func RefreshUniqueConstraintValuesForEngine(engine Engine, schema *SchemaManager) error {
+	if engine == nil || schema == nil {
+		return nil
+	}
+
+	schema.mu.RLock()
+	uniqueConstraints := make([]*UniqueConstraint, 0, len(schema.uniqueConstraints))
+	for _, uc := range schema.uniqueConstraints {
+		uniqueConstraints = append(uniqueConstraints, uc)
+	}
+	schema.mu.RUnlock()
+	if len(uniqueConstraints) == 0 {
+		return nil
+	}
+
+	for _, uc := range uniqueConstraints {
+		uc.mu.Lock()
+		uc.values = make(map[interface{}]NodeID)
+		uc.valuesAuthoritative = false
+		uc.mu.Unlock()
+	}
+
+	nodes, err := engine.AllNodes()
+	if err != nil {
+		return fmt.Errorf("refresh unique constraint values: scan nodes: %w", err)
+	}
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		for _, label := range node.Labels {
+			for propName, propValue := range node.Properties {
+				if err := schema.CheckUniqueConstraint(label, propName, propValue, node.ID); err != nil {
+					return fmt.Errorf("refresh unique constraint values: %w", err)
+				}
+				schema.RegisterUniqueValue(label, propName, propValue, node.ID)
+			}
+		}
+	}
+
+	for _, uc := range uniqueConstraints {
+		uc.mu.Lock()
+		uc.valuesAuthoritative = true
+		uc.mu.Unlock()
+	}
+	return nil
+}
+
 // validateRelationshipConstraintOnCreationForEngine validates relationship constraints
 // using the Engine interface. It scans all edges for violations.
 func validateRelationshipConstraintOnCreationForEngine(engine Engine, c Constraint) error {

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -294,11 +294,12 @@ func (sm *SchemaManager) SetPersister(persist func(def *SchemaDefinition) error)
 
 // UniqueConstraint represents a unique constraint on a label and property.
 type UniqueConstraint struct {
-	Name     string
-	Label    string
-	Property string
-	values   map[interface{}]NodeID // Track unique values
-	mu       sync.RWMutex
+	Name                string
+	Label               string
+	Property            string
+	values              map[interface{}]NodeID // Track unique values
+	valuesAuthoritative bool
+	mu                  sync.RWMutex
 }
 
 // PropertyIndex represents a property index for faster lookups.
@@ -602,6 +603,38 @@ func (sm *SchemaManager) CheckUniqueConstraint(label, property string, value int
 	}
 
 	return nil
+}
+
+// LookupUniqueConstraintValue returns the node currently registered for a
+// single-property uniqueness constraint value.
+func (sm *SchemaManager) LookupUniqueConstraintValue(label, property string, value interface{}) (NodeID, bool, bool) {
+	sm.mu.RLock()
+	key := fmt.Sprintf("%s:%s", label, property)
+	constraint, exists := sm.uniqueConstraints[key]
+	sm.mu.RUnlock()
+	if !exists || value == nil {
+		return "", false, exists
+	}
+
+	constraint.mu.RLock()
+	defer constraint.mu.RUnlock()
+	nodeID, found := constraint.values[value]
+	return nodeID, found, true
+}
+
+func (sm *SchemaManager) lookupUniqueConstraintValueForValidation(label, property string, value interface{}) (NodeID, bool, bool, bool) {
+	sm.mu.RLock()
+	key := fmt.Sprintf("%s:%s", label, property)
+	constraint, exists := sm.uniqueConstraints[key]
+	sm.mu.RUnlock()
+	if !exists || value == nil {
+		return "", false, false, exists
+	}
+
+	constraint.mu.RLock()
+	defer constraint.mu.RUnlock()
+	nodeID, found := constraint.values[value]
+	return nodeID, found, constraint.valuesAuthoritative, true
 }
 
 // RegisterUniqueValue registers a value for a unique constraint.

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -596,7 +597,12 @@ func (sm *SchemaManager) CheckUniqueConstraint(label, property string, value int
 	constraint.mu.RLock()
 	defer constraint.mu.RUnlock()
 
-	if existingNode, found := constraint.values[value]; found {
+	valueKey, ok := uniqueConstraintValueKey(value)
+	if !ok {
+		return nil
+	}
+
+	if existingNode, found := constraint.values[valueKey]; found {
 		if existingNode != excludeNode {
 			return fmt.Errorf("Node(%s) already exists with %s = %v", label, property, value)
 		}
@@ -615,10 +621,14 @@ func (sm *SchemaManager) LookupUniqueConstraintValue(label, property string, val
 	if !exists || value == nil {
 		return "", false, exists
 	}
+	valueKey, ok := uniqueConstraintValueKey(value)
+	if !ok {
+		return "", false, true
+	}
 
 	constraint.mu.RLock()
 	defer constraint.mu.RUnlock()
-	nodeID, found := constraint.values[value]
+	nodeID, found := constraint.values[valueKey]
 	return nodeID, found, true
 }
 
@@ -630,11 +640,28 @@ func (sm *SchemaManager) lookupUniqueConstraintValueForValidation(label, propert
 	if !exists || value == nil {
 		return "", false, false, exists
 	}
+	valueKey, ok := uniqueConstraintValueKey(value)
+	if !ok {
+		return "", false, false, true
+	}
 
 	constraint.mu.RLock()
 	defer constraint.mu.RUnlock()
-	nodeID, found := constraint.values[value]
+	nodeID, found := constraint.values[valueKey]
 	return nodeID, found, constraint.valuesAuthoritative, true
+}
+
+func uniqueConstraintValueKey(value interface{}) (interface{}, bool) {
+	if numeric, ok := numericConstraintValue(value); ok {
+		return numeric, true
+	}
+	if value == nil {
+		return nil, false
+	}
+	if !reflect.TypeOf(value).Comparable() {
+		return nil, false
+	}
+	return value, true
 }
 
 // RegisterUniqueValue registers a value for a unique constraint.
@@ -647,9 +674,13 @@ func (sm *SchemaManager) RegisterUniqueValue(label, property string, value inter
 	if !exists {
 		return
 	}
+	valueKey, ok := uniqueConstraintValueKey(value)
+	if !ok {
+		return
+	}
 
 	constraint.mu.Lock()
-	constraint.values[value] = nodeID
+	constraint.values[valueKey] = nodeID
 	constraint.mu.Unlock()
 }
 
@@ -663,9 +694,13 @@ func (sm *SchemaManager) UnregisterUniqueValue(label, property string, value int
 	if !exists {
 		return
 	}
+	valueKey, ok := uniqueConstraintValueKey(value)
+	if !ok {
+		return
+	}
 
 	constraint.mu.Lock()
-	delete(constraint.values, value)
+	delete(constraint.values, valueKey)
 	constraint.mu.Unlock()
 }
 

--- a/pkg/storage/schema_test.go
+++ b/pkg/storage/schema_test.go
@@ -69,6 +69,25 @@ func TestSchemaManager(t *testing.T) {
 		}
 	})
 
+	t.Run("UniqueConstraintNumericKeysUseCompareValuesSemantics", func(t *testing.T) {
+		sm := NewSchemaManager()
+		require.NoError(t, sm.AddUniqueConstraint("age_unique", "User", "age"))
+
+		sm.RegisterUniqueValue("User", "age", int(1), "node1")
+
+		got, found, constrained := sm.LookupUniqueConstraintValue("User", "age", int64(1))
+		require.True(t, constrained)
+		require.True(t, found)
+		assert.Equal(t, NodeID("node1"), got)
+
+		err := sm.CheckUniqueConstraint("User", "age", float64(1), "")
+		require.Error(t, err)
+
+		sm.UnregisterUniqueValue("User", "age", int64(1))
+		err = sm.CheckUniqueConstraint("User", "age", float64(1), "")
+		require.NoError(t, err)
+	})
+
 	t.Run("UnregisterUniqueValue", func(t *testing.T) {
 		sm := NewSchemaManager()
 		sm.AddUniqueConstraint("id_unique", "Node", "id")


### PR DESCRIPTION
## Summary
- use rebuilt single-property UNIQUE constraint value indexes during Badger transaction validation
- keep the existing label-scan fallback when the unique-value cache is not authoritative
- add a regression hook/test proving hot validation does not fall back to a label scan

## Why
Large schema-constrained MERGE batches were spending most CPU in full label scans during UNIQUE validation. Once schema reload has rebuilt authoritative unique values, validation can use the registered value index instead.

## Tests
- go test -tags noui,nolocalllm ./pkg/storage -run 'TestBadgerTransactionUniqueConstraintUsesRegisteredValueIndex|TestBadgerTransaction_FullScanUniqueConstraint' -count=1 -v
- go test -tags noui,nolocalllm ./pkg/storage ./pkg/cypher -count=1