### PR TITLE
Route UNWIND MATCH map merges through hot path

### DIFF
--- a/docs/performance/hot-path-query-cookbook.md
+++ b/docs/performance/hot-path-query-cookbook.md
@@ -559,7 +559,24 @@ MERGE (event)-[:BELONGS_TO]->(key)
 
 Use this for qVersions-style write families where one input row materializes multiple node upserts and multiple idempotent relationship upserts in a deterministic order.
 
-### 7.3e.1 Staged Compound `UNWIND` Version Pipeline
+### 7.3e.1 Lookup-Then-Upsert With Map-Merge Properties
+
+```cypher
+UNWIND $rows AS row
+MATCH (parent:EntityA {primaryKey: row.parentKey})
+MERGE (child:EntityB {primaryKey: row.childKey})
+SET child += row.props
+MERGE (parent)-[:KEY_REL]->(child)
+RETURN count(child) AS prepared;
+```
+
+Use this when each row first resolves an existing parent, upserts a child by a
+schema-backed key, merges a row-provided property map, and links the two
+idempotently. This shape is optimized by `UnwindMergeChainBatch`; it avoids the
+generic per-row fallback for `UNWIND ... MATCH ... MERGE ... SET += row.props
+... MERGE relationship` ingestion pipelines.
+
+### 7.3e.2 Staged Compound `UNWIND` Version Pipeline
 
 ```cypher
 UNWIND $rows AS row

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -517,7 +517,8 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 			}
 		}
 		if strings.HasPrefix(upperRest, "CREATE") ||
-			strings.HasPrefix(upperRest, "MERGE") {
+			strings.HasPrefix(upperRest, "MERGE") ||
+			(strings.HasPrefix(upperRest, "OPTIONAL MATCH") && matchStartedMutation) {
 			if fast, ok, err := e.executeUnwindCompoundMutationBatch(ctx, variable, unwindParamName, items, restQuery); ok {
 				return fast, err
 			}
@@ -560,7 +561,8 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 				// in WITH pipelines, execute with per-item parameters instead of literal substitution.
 				// This preserves complex map/string payloads and avoids corrupting clauses like
 				// `WITH cc, row, csByID` when `row` is a map.
-				useParamExecution := strings.Contains(mutationPart, "+=")
+				useParamExecution := strings.Contains(mutationPart, "+=") ||
+					strings.HasPrefix(strings.ToUpper(strings.TrimSpace(mutationPart)), "OPTIONAL MATCH")
 
 				var mutationResult *ExecuteResult
 				var err error
@@ -570,7 +572,17 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 						callParams[k] = v
 					}
 					callParams[variable] = item
-					mutationResult, err = e.executeInternal(ctx, fullQuery, callParams)
+					if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(mutationPart)), "OPTIONAL MATCH") &&
+						findKeywordIndexInContext(mutationPart, "MERGE") > 0 {
+						substitutedMutation := e.replaceVariableInMutationQuery(mutationPart, variable, item)
+						substitutedFull := substitutedMutation
+						if returnPart != "" {
+							substitutedFull += " " + returnPart
+						}
+						mutationResult, err = e.executeCompoundMatchMerge(context.WithValue(ctx, paramsKey, params), substitutedFull)
+					} else {
+						mutationResult, err = e.executeInternal(ctx, fullQuery, callParams)
+					}
 				} else {
 					// Replace variable references ONLY in the mutation clause
 					mutationQuerySubstituted := e.replaceVariableInMutationQuery(mutationPart, variable, item)
@@ -1687,6 +1699,7 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 		e.notifyNodeMutated(key)
 	}
 
+	processedRows := 0
 	for _, item := range items {
 		rowValues := map[string]interface{}{unwindVar: item}
 		skipRow := false
@@ -1839,10 +1852,11 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 		if skipRow {
 			continue
 		}
+		processedRows++
 	}
 
 	if countAlias != "" {
-		result.Rows = [][]interface{}{{int64(len(items))}}
+		result.Rows = [][]interface{}{{int64(processedRows)}}
 	}
 	return result, true, nil
 }

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -483,10 +483,41 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 		}
 	}
 
-	// Handle UNWIND ... CREATE/MERGE ... pattern
+	// Handle UNWIND ... CREATE/MERGE/MATCH ... mutation patterns.
 	if restQuery != "" {
-		upperRest := strings.ToUpper(strings.TrimSpace(restQuery))
-		if strings.HasPrefix(upperRest, "CREATE") || strings.HasPrefix(upperRest, "MERGE") {
+		trimmedRest := strings.TrimSpace(restQuery)
+		upperRest := strings.ToUpper(trimmedRest)
+		matchStartedMutation := (strings.HasPrefix(upperRest, "MATCH") || strings.HasPrefix(upperRest, "OPTIONAL MATCH")) &&
+			(findKeywordIndexInContext(trimmedRest, "MERGE") >= 0 ||
+				findKeywordIndexInContext(trimmedRest, "CREATE") >= 0 ||
+				findKeywordIndexInContext(trimmedRest, "SET") >= 0)
+		if matchStartedMutation {
+			if strings.HasPrefix(upperRest, "MATCH") {
+				if fast, ok, err := e.executeUnwindFixedChainLinkBatch(ctx, variable, items, restQuery); ok {
+					return fast, err
+				}
+			}
+			if fast, ok, err := e.executeUnwindCompoundMutationBatch(ctx, variable, unwindParamName, items, restQuery); ok {
+				return fast, err
+			}
+			returnIdx := findKeywordIndex(restQuery, "RETURN")
+			var mutationPart, returnPart string
+			if returnIdx > 0 {
+				mutationPart = strings.TrimSpace(restQuery[:returnIdx])
+				returnPart = strings.TrimSpace(restQuery[returnIdx:])
+			} else {
+				mutationPart = restQuery
+				returnPart = ""
+			}
+			if startsWithKeywordFold(strings.TrimSpace(mutationPart), "MATCH") ||
+				startsWithKeywordFold(strings.TrimSpace(mutationPart), "OPTIONAL MATCH") {
+				if fast, ok, err := e.executeUnwindMergeChainBatch(ctx, variable, items, mutationPart, returnPart); ok {
+					return fast, err
+				}
+			}
+		}
+		if strings.HasPrefix(upperRest, "CREATE") ||
+			strings.HasPrefix(upperRest, "MERGE") {
 			if fast, ok, err := e.executeUnwindCompoundMutationBatch(ctx, variable, unwindParamName, items, restQuery); ok {
 				return fast, err
 			}
@@ -508,7 +539,8 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 				returnPart = ""
 			}
 
-			// Hot path: UNWIND row MERGE (n:Label {k: row.x}) [SET n.p = row.y] RETURN count(n)
+			// Hot path: UNWIND row [MATCH ...] MERGE (n:Label {k: row.x})
+			// [SET n.p = row.y | SET n += row.props] [MERGE relationship] RETURN count(n).
 			// Execute as a single batched pass to avoid per-item MERGE query re-parsing/scans.
 			if startsWithKeywordFold(strings.TrimSpace(mutationPart), "MERGE") {
 				if fast, ok, err := e.executeUnwindMergeChainBatch(ctx, variable, items, mutationPart, returnPart); ok {
@@ -831,8 +863,9 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 }
 
 type unwindSimpleSetAssignment struct {
-	prop string
-	expr string
+	prop     string
+	expr     string
+	mergeMap bool
 }
 
 type unwindMergeChainNodePlan struct {
@@ -923,6 +956,18 @@ func parseUnwindSimpleSetAssignments(raw, mergeVar string) ([]unwindSimpleSetAss
 	for _, assignment := range assignments {
 		a := strings.TrimSpace(assignment)
 		if a == "" {
+			continue
+		}
+		if plusEqIdx := strings.Index(a, "+="); plusEqIdx > 0 {
+			left := strings.TrimSpace(a[:plusEqIdx])
+			right := strings.TrimSpace(a[plusEqIdx+2:])
+			if left != mergeVar || right == "" {
+				return nil, false
+			}
+			out = append(out, unwindSimpleSetAssignment{
+				expr:     right,
+				mergeMap: true,
+			})
 			continue
 		}
 		eqIdx := strings.Index(a, "=")
@@ -1540,6 +1585,38 @@ func unwindMergeKey(label string, props map[string]interface{}) string {
 	return string(encoded)
 }
 
+func applyUnwindMergeChainSetAssignment(
+	node *storage.Node,
+	assignment unwindSimpleSetAssignment,
+	rowValues map[string]interface{},
+	resolveValue func(string, map[string]interface{}) interface{},
+) (bool, error) {
+	if node.Properties == nil {
+		node.Properties = make(map[string]interface{})
+	}
+	if assignment.mergeMap {
+		value := resolveValue(assignment.expr, rowValues)
+		props, err := normalizePropsMap(value, fmt.Sprintf("variable %s", assignment.expr))
+		if err != nil {
+			return false, err
+		}
+		changed := false
+		for prop, val := range props {
+			if cur, exists := node.Properties[prop]; !exists || !reflect.DeepEqual(cur, val) {
+				node.Properties[prop] = val
+				changed = true
+			}
+		}
+		return changed, nil
+	}
+	val := resolveValue(assignment.expr, rowValues)
+	if cur, exists := node.Properties[assignment.prop]; !exists || !reflect.DeepEqual(cur, val) {
+		node.Properties[assignment.prop] = val
+		return true, nil
+	}
+	return false, nil
+}
+
 func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwindVar string, items []interface{}, mutationPart, returnPart string) (*ExecuteResult, bool, error) {
 	plan := e.cachedUnwindMergeChainPlan(mutationPart)
 	if !plan.supported {
@@ -1638,10 +1715,14 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 						Properties: cloneNodePropertiesMap(matchProps),
 					}
 					for _, assignment := range nodePlan.setAssignments {
-						node.Properties[assignment.prop] = resolveBatchValue(assignment.expr, rowValues)
+						if _, err := applyUnwindMergeChainSetAssignment(node, assignment, rowValues, resolveBatchValue); err != nil {
+							return nil, true, err
+						}
 					}
 					for _, assignment := range nodePlan.onCreateAssignments {
-						node.Properties[assignment.prop] = resolveBatchValue(assignment.expr, rowValues)
+						if _, err := applyUnwindMergeChainSetAssignment(node, assignment, rowValues, resolveBatchValue); err != nil {
+							return nil, true, err
+						}
 					}
 					actualID, err := store.CreateNode(node)
 					if err != nil {
@@ -1655,16 +1736,20 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 				} else {
 					needsUpdate := false
 					for _, assignment := range nodePlan.setAssignments {
-						val := resolveBatchValue(assignment.expr, rowValues)
-						if cur, exists := node.Properties[assignment.prop]; !exists || cur != val {
-							node.Properties[assignment.prop] = val
+						changed, err := applyUnwindMergeChainSetAssignment(node, assignment, rowValues, resolveBatchValue)
+						if err != nil {
+							return nil, true, err
+						}
+						if changed {
 							needsUpdate = true
 						}
 					}
 					for _, assignment := range nodePlan.onMatchAssignments {
-						val := resolveBatchValue(assignment.expr, rowValues)
-						if cur, exists := node.Properties[assignment.prop]; !exists || cur != val {
-							node.Properties[assignment.prop] = val
+						changed, err := applyUnwindMergeChainSetAssignment(node, assignment, rowValues, resolveBatchValue)
+						if err != nil {
+							return nil, true, err
+						}
+						if changed {
 							needsUpdate = true
 						}
 					}

--- a/pkg/cypher/unwind_merge_batch_test.go
+++ b/pkg/cypher/unwind_merge_batch_test.go
@@ -166,6 +166,82 @@ ORDER BY n.uid
 	}, contains.Rows)
 }
 
+func TestUnwindMergeBatch_MatchMergeCountReflectsFilteredRows(t *testing.T) {
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+CREATE CONSTRAINT file_path_unique IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE
+`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MERGE (f:File {path: $path})
+`, map[string]interface{}{"path": "src/handler.go"})
+	require.NoError(t, err)
+
+	rows := []map[string]interface{}{
+		{"file_path": "src/handler.go", "entity_id": "annotation-1"},
+		{"file_path": "missing.go", "entity_id": "annotation-2"},
+	}
+
+	res, err := exec.Execute(ctx, `
+UNWIND $rows AS row
+MATCH (f:File {path: row.file_path})
+MERGE (n:Annotation {uid: row.entity_id})
+MERGE (f)-[:CONTAINS]->(n)
+RETURN count(n) AS prepared
+`, map[string]interface{}{"rows": rows})
+	require.NoError(t, err)
+	require.Equal(t, []string{"prepared"}, res.Columns)
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, int64(1), toInt64ForTest(t, res.Rows[0][0]))
+	require.True(t, exec.LastHotPathTrace().UnwindMergeChainBatch, "expected generalized unwind merge chain hot path")
+
+	nodes, err := store.GetNodesByLabel("Annotation")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, "annotation-1", nodes[0].Properties["uid"])
+}
+
+func TestUnwindOptionalMatchMutationFallsBackPerRow(t *testing.T) {
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+MERGE (f:File {path: $path})
+`, map[string]interface{}{"path": "src/handler.go"})
+	require.NoError(t, err)
+
+	rows := []map[string]interface{}{
+		{"file_path": "src/handler.go", "entity_id": "annotation-1"},
+		{"file_path": "missing.go", "entity_id": "annotation-2"},
+	}
+
+	res, err := exec.Execute(ctx, `
+UNWIND $rows AS row
+OPTIONAL MATCH (f:File {path: row.file_path})-[:CONTAINS]->(old)
+MERGE (n:Annotation {uid: row.entity_id})
+RETURN count(n) AS prepared
+`, map[string]interface{}{"rows": rows})
+	require.NoError(t, err)
+	require.Equal(t, []string{"prepared"}, res.Columns)
+	require.Len(t, res.Rows, 2)
+
+	nodes, err := store.GetNodesByLabel("Annotation")
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+	seen := make(map[interface{}]bool, len(nodes))
+	for _, node := range nodes {
+		seen[node.Properties["uid"]] = true
+	}
+	require.True(t, seen["annotation-1"])
+	require.True(t, seen["annotation-2"])
+}
+
 func TestUnwindMergeBatch_HopUpsertUpdatesExisting(t *testing.T) {
 	base := newTestMemoryEngine(t)
 	store := storage.NewNamespacedEngine(base, "test")

--- a/pkg/cypher/unwind_merge_batch_test.go
+++ b/pkg/cypher/unwind_merge_batch_test.go
@@ -85,6 +85,87 @@ RETURN count(h) AS prepared
 	}
 }
 
+func TestUnwindMergeBatch_MatchMergeSetMapPropertiesUsesHotPath(t *testing.T) {
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+CREATE CONSTRAINT file_path_unique IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE
+`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+CREATE CONSTRAINT annotation_uid_unique IF NOT EXISTS FOR (n:Annotation) REQUIRE n.uid IS UNIQUE
+`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MERGE (f:File {path: $path})
+SET f.repo_id = $repo_id
+`, map[string]interface{}{"path": "src/handler.go", "repo_id": "repo-1"})
+	require.NoError(t, err)
+
+	rows := []map[string]interface{}{
+		{
+			"file_path": "src/handler.go",
+			"entity_id": "annotation-1",
+			"properties": map[string]interface{}{
+				"id":              "annotation-1",
+				"name":            "Route",
+				"path":            "src/handler.go",
+				"line_number":     int64(12),
+				"semantic_kind":   "Annotation",
+				"evidence_source": "parser/semantic-entities",
+			},
+		},
+		{
+			"file_path": "src/handler.go",
+			"entity_id": "annotation-2",
+			"properties": map[string]interface{}{
+				"id":              "annotation-2",
+				"name":            "Auth",
+				"path":            "src/handler.go",
+				"line_number":     int64(18),
+				"semantic_kind":   "Annotation",
+				"evidence_source": "parser/semantic-entities",
+			},
+		},
+	}
+
+	res, err := exec.Execute(ctx, `
+UNWIND $rows AS row
+MATCH (f:File {path: row.file_path})
+MERGE (n:Annotation {uid: row.entity_id})
+SET n += row.properties
+MERGE (f)-[:CONTAINS]->(n)
+RETURN count(n) AS prepared
+`, map[string]interface{}{"rows": rows})
+	require.NoError(t, err)
+	require.Equal(t, []string{"prepared"}, res.Columns)
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, int64(2), toInt64ForTest(t, res.Rows[0][0]))
+	require.True(t, exec.LastHotPathTrace().UnwindMergeChainBatch, "expected generalized unwind merge chain hot path")
+
+	nodes, err := store.GetNodesByLabel("Annotation")
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+	for _, node := range nodes {
+		require.Equal(t, "parser/semantic-entities", node.Properties["evidence_source"])
+		require.NotEmpty(t, node.Properties["semantic_kind"])
+	}
+
+	contains, err := exec.Execute(ctx, `
+MATCH (f:File)-[:CONTAINS]->(n:Annotation)
+RETURN f.path, n.uid
+ORDER BY n.uid
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"src/handler.go", "annotation-1"},
+		{"src/handler.go", "annotation-2"},
+	}, contains.Rows)
+}
+
 func TestUnwindMergeBatch_HopUpsertUpdatesExisting(t *testing.T) {
 	base := newTestMemoryEngine(t)
 	store := storage.NewNamespacedEngine(base, "test")


### PR DESCRIPTION
## Summary
- route supported UNWIND MATCH/OPTIONAL MATCH mutation tails through the generalized merge-chain hot path only when the plan proves supported
- add SET n += row.props map-merge handling inside the chain executor
- preserve existing fixed-chain and generic MATCH routing for unsupported shapes
- document the lookup-then-upsert map-merge write shape in the hot-path cookbook

## Why
Bounded ingestion pipelines often resolve a parent with MATCH, upsert a child with MERGE, merge a row property map, and create an idempotent relationship. Without this route, those statements can fall back to per-row execution or miss the specialized hot path.

## Tests
- go test -tags noui,nolocalllm ./pkg/cypher -run TestUnwindMergeBatch_MatchMergeSetMapPropertiesUsesHotPath -count=1 -v
- go test -tags noui,nolocalllm ./pkg/cypher -run 'TestUnwindMergeBatch|TestE2E_UnwindMergeChainBatch|TestUnwindBenchHopLinkBatch' -count=1
- go test -tags noui,nolocalllm ./pkg/cypher -run 'TestUnwindMergeBatch_MatchMergeSetMapPropertiesUsesHotPath|TestBatchRelationshipMergeWithUnwindKeys|TestMigrationShape_UnwindMatchMergeSetMap_ComplexRowsAndClauses|TestBug_UnwindMatchCreate_CorrelatedJoinKeepsCardinality|TestUnwindTopLevelMergeSetMergeUsesNestedMapPropertyAccess' -count=1
- go test -tags noui,nolocalllm ./pkg/storage ./pkg/cypher -count=1
- git diff --check