### PR TITLE
Use unique constraints for MERGE lookup

### DIFF
--- a/pkg/cypher/merge.go
+++ b/pkg/cypher/merge.go
@@ -210,6 +210,25 @@ func (e *StorageExecutor) findMergeNode(store storage.Engine, labels []string, p
 			}
 		}
 
+		for _, prop := range mergePropertyNamesSorted(props) {
+			val := props[prop]
+			nodeID, valueFound, constraintExists := schema.LookupUniqueConstraintValue(label, prop, val)
+			if !constraintExists {
+				continue
+			}
+			schemaLookupUsed = true
+			e.markMergeSchemaLookupUsed()
+			if !valueFound {
+				continue
+			}
+			for _, n := range e.loadMergeCandidateNodes(store, []storage.NodeID{nodeID}) {
+				if mergeNodeMatches(n, labels, props) {
+					e.cacheMergeNode(labels, props, n)
+					return n, nil
+				}
+			}
+		}
+
 		bestIDs := []storage.NodeID(nil)
 		bestCount := -1
 		for _, prop := range mergePropertyNamesSorted(props) {

--- a/pkg/cypher/merge_test.go
+++ b/pkg/cypher/merge_test.go
@@ -26,6 +26,18 @@ func (s *staleMergeLookupEngine) GetNodesByLabel(label string) ([]*storage.Node,
 	return s.Engine.GetNodesByLabel(label)
 }
 
+type noScanMergeLookupEngine struct {
+	storage.Engine
+}
+
+func (n *noScanMergeLookupEngine) GetNodesByLabel(label string) ([]*storage.Node, error) {
+	return nil, assert.AnError
+}
+
+func (n *noScanMergeLookupEngine) AllNodes() ([]*storage.Node, error) {
+	return nil, assert.AnError
+}
+
 // ========================================
 // Basic MERGE Node Tests
 // ========================================
@@ -427,6 +439,32 @@ func TestFindMergeNode_UsesPropertyIndexLookup(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, found)
 	require.Equal(t, storage.NodeID("orig-idx-1"), found.ID)
+}
+
+func TestFindMergeNode_UsesUniqueConstraintLookupWithoutScan(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+
+	schema := store.GetSchema()
+	require.NotNil(t, schema)
+	require.NoError(t, schema.AddUniqueConstraint("function_uid_unique", "Function", "uid"))
+	_, err := store.CreateNode(&storage.Node{
+		ID:     "function-1",
+		Labels: []string{"Function"},
+		Properties: map[string]interface{}{
+			"uid":  "content-entity:e_hot",
+			"name": "hotPath",
+		},
+	})
+	require.NoError(t, err)
+
+	noScanStore := &noScanMergeLookupEngine{Engine: store}
+	exec := NewStorageExecutor(noScanStore)
+
+	found, err := exec.findMergeNode(noScanStore, []string{"Function"}, map[string]interface{}{"uid": "content-entity:e_hot"})
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Equal(t, storage.NodeID("function-1"), found.ID)
 }
 
 func TestFindMergeNode_RequiresFullMultiLabelMatch(t *testing.T) {

--- a/pkg/cypher/merge_test.go
+++ b/pkg/cypher/merge_test.go
@@ -467,6 +467,22 @@ func TestFindMergeNode_UsesUniqueConstraintLookupWithoutScan(t *testing.T) {
 	require.Equal(t, storage.NodeID("function-1"), found.ID)
 }
 
+func TestFindMergeNode_IgnoresNonComparableUniqueLookupValue(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+
+	schema := store.GetSchema()
+	require.NotNil(t, schema)
+	require.NoError(t, schema.AddUniqueConstraint("function_uid_unique", "Function", "uid"))
+	exec := NewStorageExecutor(store)
+
+	require.NotPanics(t, func() {
+		found, err := exec.findMergeNode(store, []string{"Function"}, map[string]interface{}{"uid": []string{"bad"}})
+		require.NoError(t, err)
+		require.Nil(t, found)
+	})
+}
+
 func TestFindMergeNode_RequiresFullMultiLabelMatch(t *testing.T) {
 	baseStore := newTestMemoryEngine(t)
 	store := storage.NewNamespacedEngine(baseStore, "test")

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -627,6 +627,9 @@ func (sm *SchemaManager) LookupUniqueConstraintValue(label, property string, val
 	if !ok {
 		return "", false, true
 	}
+	if !isComparableConstraintValue(value) {
+		return "", true, false
+	}
 
 	constraint.mu.RLock()
 	defer constraint.mu.RUnlock()
@@ -664,6 +667,13 @@ func uniqueConstraintValueKey(value interface{}) (interface{}, bool) {
 		return nil, false
 	}
 	return value, true
+}
+
+func isComparableConstraintValue(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	return reflect.TypeOf(value).Comparable()
 }
 
 // RegisterUniqueValue registers a value for a unique constraint.

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -612,7 +612,9 @@ func (sm *SchemaManager) CheckUniqueConstraint(label, property string, value int
 }
 
 // LookupUniqueConstraintValue returns the node currently registered for a
-// single-property uniqueness constraint value.
+// single-property uniqueness constraint value. The second return value reports
+// whether the value is present, and the third reports whether the unique
+// constraint exists.
 func (sm *SchemaManager) LookupUniqueConstraintValue(label, property string, value interface{}) (NodeID, bool, bool) {
 	sm.mu.RLock()
 	key := fmt.Sprintf("%s:%s", label, property)

--- a/pkg/storage/schema_test.go
+++ b/pkg/storage/schema_test.go
@@ -88,6 +88,18 @@ func TestSchemaManager(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("LookupUniqueConstraintValue ignores non-comparable values", func(t *testing.T) {
+		sm := NewSchemaManager()
+		require.NoError(t, sm.AddUniqueConstraint("test_tags_unique", "User", "tags"))
+
+		require.NotPanics(t, func() {
+			nodeID, valueFound, constraintExists := sm.LookupUniqueConstraintValue("User", "tags", []string{"a"})
+			require.Empty(t, nodeID)
+			require.True(t, constraintExists)
+			require.False(t, valueFound)
+		})
+	})
+
 	t.Run("UnregisterUniqueValue", func(t *testing.T) {
 		sm := NewSchemaManager()
 		sm.AddUniqueConstraint("id_unique", "Node", "id")


### PR DESCRIPTION
## Summary
- add a schema lookup API for single-property unique constraint values
- route MERGE node lookup through unique constraint metadata before label-scan fallback
- add regression coverage that forbids label/full scans when a unique constraint can resolve the node

## Why
PCG dogfood runs create uid uniqueness constraints such as Function.uid and then issue batched MERGE writes on that uid. NornicDB was validating uniqueness through unique constraint metadata, but findMergeNode only consulted composite/property indexes before falling back to label scans. As a graph grows, this makes each MERGE slower even when a unique constraint already proves the key is indexed.

## Validation
- go test -tags noui,nolocalllm ./pkg/cypher -run 'TestFindMergeNode_UsesUniqueConstraintLookupWithoutScan|TestFindMergeNode_UsesPropertyIndexLookup|TestExecuteMerge_RecoversFromDuplicateCreateForParameterizedRepositoryMerge' -count=1 -v
- go test -tags noui,nolocalllm ./pkg/storage ./pkg/cypher -count=1
- git diff --check