### PR TITLE
Optimize batched relationship writes for lookup-first UNWIND chains

### DIFF
--- a/pkg/cypher/cache.go
+++ b/pkg/cypher/cache.go
@@ -935,9 +935,10 @@ func makeLookupKey(label string, props map[string]interface{}) string {
 //   - The cached node, or nil if not in cache
 func (e *StorageExecutor) lookupCachedNode(label string, props map[string]interface{}) *storage.Node {
 	key := makeLookupKey(label, props)
-	e.nodeLookupCacheMu.RLock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.RLock()
 	node := e.nodeLookupCache[key]
-	e.nodeLookupCacheMu.RUnlock()
+	cacheMu.RUnlock()
 	return node
 }
 
@@ -953,20 +954,22 @@ func (e *StorageExecutor) lookupCachedNode(label string, props map[string]interf
 //   - node: The node to cache
 func (e *StorageExecutor) cacheNodeLookup(label string, props map[string]interface{}, node *storage.Node) {
 	key := makeLookupKey(label, props)
-	e.nodeLookupCacheMu.Lock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.Lock()
 	// Simple eviction: if too large, clear
 	if len(e.nodeLookupCache) > 10000 {
 		e.nodeLookupCache = make(map[string]*storage.Node, 1000)
 	}
 	e.nodeLookupCache[key] = node
-	e.nodeLookupCacheMu.Unlock()
+	cacheMu.Unlock()
 }
 
 // invalidateNodeLookupCache clears the node lookup cache.
 //
 // Should be called after write operations that may affect node properties.
 func (e *StorageExecutor) invalidateNodeLookupCache() {
-	e.nodeLookupCacheMu.Lock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.Lock()
 	e.nodeLookupCache = make(map[string]*storage.Node, 1000)
-	e.nodeLookupCacheMu.Unlock()
+	cacheMu.Unlock()
 }

--- a/pkg/cypher/call_index_mgmt.go
+++ b/pkg/cypher/call_index_mgmt.go
@@ -167,9 +167,10 @@ func (e *StorageExecutor) callDbClearQueryCaches() (*ExecuteResult, error) {
 	}
 
 	// Clear node lookup cache
-	e.nodeLookupCacheMu.Lock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.Lock()
 	e.nodeLookupCache = make(map[string]*storage.Node, 1000)
-	e.nodeLookupCacheMu.Unlock()
+	cacheMu.Unlock()
 
 	return &ExecuteResult{
 		Columns: []string{"status"},

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -1757,6 +1757,37 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 		notified[key] = struct{}{}
 		e.notifyNodeMutated(key)
 	}
+	applyRelationshipAssignments := func(edge *storage.Edge, assignments []unwindSimpleSetAssignment, values map[string]interface{}) bool {
+		if edge.Properties == nil {
+			edge.Properties = map[string]interface{}{}
+		}
+		needsUpdate := false
+		for _, assignment := range assignments {
+			val := resolveBatchValue(assignment.expr, values)
+			if cur, exists := edge.Properties[assignment.prop]; !exists || !reflect.DeepEqual(canonicalUnwindMergeValue(cur), canonicalUnwindMergeValue(val)) {
+				edge.Properties[assignment.prop] = val
+				needsUpdate = true
+			}
+		}
+		return needsUpdate
+	}
+	createRelationship := func(edge *storage.Edge) (*storage.Edge, bool, error) {
+		const maxCreateAttempts = 3
+		for attempt := 0; attempt < maxCreateAttempts; attempt++ {
+			if err := store.CreateEdge(edge); err != nil {
+				if err != storage.ErrAlreadyExists {
+					return nil, false, fmt.Errorf("UNWIND MERGE chain relationship create failed: %w", err)
+				}
+				if existing := store.GetEdgeBetween(edge.StartNode, edge.EndNode, edge.Type); existing != nil {
+					return existing, false, nil
+				}
+				edge.ID = storage.EdgeID(e.generateID())
+				continue
+			}
+			return edge, true, nil
+		}
+		return nil, false, fmt.Errorf("UNWIND MERGE chain relationship create failed after %d edge ID collisions", maxCreateAttempts)
+	}
 
 	processedRows := 0
 	for _, item := range items {
@@ -1893,7 +1924,7 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 				break
 			}
 			edge := store.GetEdgeBetween(fromNode.ID, toNode.ID, relPlan.relType)
-			created := false
+			relationshipChanged := false
 			if edge == nil {
 				edge = &storage.Edge{
 					ID:         storage.EdgeID(e.generateID()),
@@ -1902,34 +1933,30 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 					EndNode:    toNode.ID,
 					Properties: map[string]interface{}{},
 				}
-				created = true
-			}
-			if edge.Properties == nil {
-				edge.Properties = map[string]interface{}{}
-			}
-			needsUpdate := false
-			for _, assignment := range relPlan.setAssignments {
-				val := resolveBatchValue(assignment.expr, rowValues)
-				if cur, exists := edge.Properties[assignment.prop]; !exists || !reflect.DeepEqual(canonicalUnwindMergeValue(cur), canonicalUnwindMergeValue(val)) {
-					edge.Properties[assignment.prop] = val
-					needsUpdate = true
+				applyRelationshipAssignments(edge, relPlan.setAssignments, rowValues)
+				createdEdge, created, err := createRelationship(edge)
+				if err != nil {
+					return nil, true, err
 				}
-			}
-			if created {
-				if err := store.CreateEdge(edge); err != nil {
-					if err != storage.ErrAlreadyExists {
-						return nil, true, fmt.Errorf("UNWIND MERGE chain relationship create failed: %w", err)
+				if created {
+					result.Stats.RelationshipsCreated++
+					relationshipChanged = true
+				} else if applyRelationshipAssignments(createdEdge, relPlan.setAssignments, rowValues) {
+					if err := store.UpdateEdge(createdEdge); err != nil {
+						return nil, true, fmt.Errorf("UNWIND MERGE chain relationship update failed: %w", err)
 					}
-					continue
+					relationshipChanged = true
 				}
-				result.Stats.RelationshipsCreated++
-			} else if needsUpdate {
+			} else if applyRelationshipAssignments(edge, relPlan.setAssignments, rowValues) {
 				if err := store.UpdateEdge(edge); err != nil {
 					return nil, true, fmt.Errorf("UNWIND MERGE chain relationship update failed: %w", err)
 				}
+				relationshipChanged = true
 			}
-			notifyOnce(fromNode.ID)
-			notifyOnce(toNode.ID)
+			if relationshipChanged {
+				notifyOnce(fromNode.ID)
+				notifyOnce(toNode.ID)
+			}
 		}
 		if skipRow {
 			continue

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -646,6 +646,16 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 	// and combining results. This avoids silently returning only unwound values when
 	// a trailing MATCH pipeline is present.
 	if restQuery != "" && strings.HasPrefix(strings.ToUpper(restQuery), "MATCH ") {
+		returnIdx := findKeywordIndex(restQuery, "RETURN")
+		mutationPart := restQuery
+		returnPart := ""
+		if returnIdx > 0 {
+			mutationPart = strings.TrimSpace(restQuery[:returnIdx])
+			returnPart = strings.TrimSpace(restQuery[returnIdx:])
+		}
+		if fast, ok, err := e.executeUnwindMergeChainBatch(ctx, variable, items, mutationPart, returnPart); ok {
+			return fast, err
+		}
 		if fast, ok, err := e.executeUnwindFixedChainLinkBatch(ctx, variable, items, restQuery); ok {
 			return fast, err
 		}
@@ -894,6 +904,7 @@ type unwindMergeChainLookupPlan struct {
 	labels           []string
 	matchAssignments []unwindSimpleSetAssignment
 	optional         bool
+	anyLabel         bool
 }
 
 type unwindMergeChainWithAssignment struct {
@@ -910,9 +921,11 @@ type unwindMergeChainWherePlan struct {
 }
 
 type unwindMergeChainRelationshipPlan struct {
-	fromVar string
-	toVar   string
-	relType string
+	fromVar        string
+	toVar          string
+	relVar         string
+	relType        string
+	setAssignments []unwindSimpleSetAssignment
 }
 
 type unwindMergeChainStep struct {
@@ -1010,57 +1023,77 @@ func parseSimpleUnwindMergeClause(mergePart string) (string, []string, []unwindS
 }
 
 func parseUnwindNodePatternClause(clause string, keyword string) (string, []string, []unwindSimpleSetAssignment, bool) {
+	varName, labels, assignments, _, ok := parseUnwindNodePatternClauseInternal(clause, keyword, false)
+	return varName, labels, assignments, ok
+}
+
+func parseUnwindNodePatternClauseInternal(clause string, keyword string, allowAlternatives bool) (string, []string, []unwindSimpleSetAssignment, bool, bool) {
 	trimmed := strings.TrimSpace(clause)
 	if !startsWithKeywordFold(trimmed, keyword) {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	rest := strings.TrimSpace(trimmed[len(keyword):])
 	if !strings.HasPrefix(rest, "(") {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	parenEnd := findMatchingParen(rest, 0)
 	if parenEnd < 0 || strings.TrimSpace(rest[parenEnd+1:]) != "" {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	nodePattern := strings.TrimSpace(rest[1:parenEnd])
 	braceStart := strings.Index(nodePattern, "{")
 	if braceStart < 0 {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	exec := &StorageExecutor{}
 	braceEnd := exec.findMatchingBrace(nodePattern, braceStart)
 	if braceEnd < 0 || strings.TrimSpace(nodePattern[braceEnd+1:]) != "" {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	head := strings.TrimSpace(nodePattern[:braceStart])
 	propMap := strings.TrimSpace(nodePattern[braceStart+1 : braceEnd])
 	if head == "" || propMap == "" {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	parts := strings.Split(head, ":")
 	if len(parts) < 2 {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	mergeVar := strings.TrimSpace(parts[0])
 	if !isSimpleIdentifier(mergeVar) {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	labels := make([]string, 0, len(parts)-1)
+	anyLabel := false
 	for i := 1; i < len(parts); i++ {
 		label := strings.TrimSpace(parts[i])
+		if strings.Contains(label, "|") {
+			if !allowAlternatives || anyLabel || len(parts) != 2 {
+				return "", nil, nil, false, false
+			}
+			for _, alternative := range strings.Split(label, "|") {
+				alternative = strings.TrimSpace(alternative)
+				if !isSimpleIdentifier(alternative) {
+					return "", nil, nil, false, false
+				}
+				labels = append(labels, alternative)
+			}
+			anyLabel = true
+			continue
+		}
 		if !isSimpleIdentifier(label) {
-			return "", nil, nil, false
+			return "", nil, nil, false, false
 		}
 		labels = append(labels, label)
 	}
 	if len(labels) == 0 {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
 	assignments, ok := parseUnwindSimpleMergeMatchAssignments(propMap)
 	if !ok {
-		return "", nil, nil, false
+		return "", nil, nil, false, false
 	}
-	return mergeVar, labels, assignments, true
+	return mergeVar, labels, assignments, anyLabel, true
 }
 
 func parseUnwindLookupClause(clause string) (unwindMergeChainLookupPlan, bool) {
@@ -1069,7 +1102,7 @@ func parseUnwindLookupClause(clause string) (unwindMergeChainLookupPlan, bool) {
 	if optional {
 		keyword = "OPTIONAL MATCH"
 	}
-	varName, labels, assignments, ok := parseUnwindNodePatternClause(clause, keyword)
+	varName, labels, assignments, anyLabel, ok := parseUnwindNodePatternClauseInternal(clause, keyword, true)
 	if !ok {
 		return unwindMergeChainLookupPlan{}, false
 	}
@@ -1078,6 +1111,7 @@ func parseUnwindLookupClause(clause string) (unwindMergeChainLookupPlan, bool) {
 		labels:           labels,
 		matchAssignments: assignments,
 		optional:         optional,
+		anyLabel:         anyLabel,
 	}, true
 }
 
@@ -1275,10 +1309,21 @@ func parseUnwindMergeRelationshipClause(clause string) (unwindMergeChainRelation
 		return unwindMergeChainRelationshipPlan{}, false
 	}
 	relInner := strings.TrimSpace(afterFrom[openBracket+1 : closeBracket])
-	if !strings.HasPrefix(relInner, ":") {
-		return unwindMergeChainRelationshipPlan{}, false
+	relVar := ""
+	relType := ""
+	if strings.HasPrefix(relInner, ":") {
+		relType = strings.TrimSpace(relInner[1:])
+	} else {
+		parts := strings.SplitN(relInner, ":", 2)
+		if len(parts) != 2 {
+			return unwindMergeChainRelationshipPlan{}, false
+		}
+		relVar = strings.TrimSpace(parts[0])
+		relType = strings.TrimSpace(parts[1])
+		if !isSimpleIdentifier(relVar) {
+			return unwindMergeChainRelationshipPlan{}, false
+		}
 	}
-	relType := strings.TrimSpace(relInner[1:])
 	afterRel := strings.TrimSpace(afterFrom[closeBracket+1:])
 	if !strings.HasPrefix(afterRel, "->") {
 		return unwindMergeChainRelationshipPlan{}, false
@@ -1295,7 +1340,7 @@ func parseUnwindMergeRelationshipClause(clause string) (unwindMergeChainRelation
 	if !isSimpleIdentifier(relType) || !isSimpleIdentifier(toVar) {
 		return unwindMergeChainRelationshipPlan{}, false
 	}
-	return unwindMergeChainRelationshipPlan{fromVar: fromVar, toVar: toVar, relType: relType}, true
+	return unwindMergeChainRelationshipPlan{fromVar: fromVar, toVar: toVar, relVar: relVar, relType: relType}, true
 }
 
 func splitUnwindCompoundMutationStages(restQuery, unwindParamName, unwindVar string) ([]string, bool) {
@@ -1438,6 +1483,7 @@ func parseUnwindMergeChainPattern(mutationPart string) unwindMergeChainPlan {
 		return plan
 	}
 	boundVars := make(map[string]struct{})
+	hasMutation := false
 	for i := 0; i < len(clauses); i++ {
 		clause := clauses[i]
 		if !startsWithKeywordFold(clause, "MERGE") {
@@ -1497,6 +1543,7 @@ func parseUnwindMergeChainPattern(mutationPart string) unwindMergeChainPlan {
 		nodeDone:
 			plan.steps = append(plan.steps, unwindMergeChainStep{node: nodePlan})
 			boundVars[mergeVar] = struct{}{}
+			hasMutation = true
 			continue
 		}
 		relPlan, ok := parseUnwindMergeRelationshipClause(clause)
@@ -1509,9 +1556,21 @@ func parseUnwindMergeChainPattern(mutationPart string) unwindMergeChainPlan {
 		if _, exists := boundVars[relPlan.toVar]; !exists {
 			return unwindMergeChainPlan{}
 		}
+		for i+1 < len(clauses) && startsWithKeywordFold(clauses[i+1], "SET") {
+			if relPlan.relVar == "" {
+				return unwindMergeChainPlan{}
+			}
+			parsed, ok := parseUnwindSimpleSetAssignments(strings.TrimSpace(clauses[i+1][len("SET"):]), relPlan.relVar)
+			if !ok {
+				return unwindMergeChainPlan{}
+			}
+			relPlan.setAssignments = append(relPlan.setAssignments, parsed...)
+			i++
+		}
 		plan.steps = append(plan.steps, unwindMergeChainStep{relationship: &relPlan})
+		hasMutation = true
 	}
-	if len(plan.steps) == 0 {
+	if len(plan.steps) == 0 || !hasMutation {
 		return unwindMergeChainPlan{}
 	}
 	plan.simple = len(plan.steps) == 1 && plan.steps[0].node != nil
@@ -1788,7 +1847,11 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 				node := lookupCache[lookupKey]
 				if !lookupKnown[lookupKey] {
 					var err error
-					node, err = e.findMergeNode(store, lookupPlan.labels, matchProps)
+					if lookupPlan.anyLabel {
+						node, err = e.findMergeNodeAnyLabel(store, lookupPlan.labels, matchProps)
+					} else {
+						node, err = e.findMergeNode(store, lookupPlan.labels, matchProps)
+					}
 					if err != nil {
 						return nil, true, err
 					}
@@ -1829,23 +1892,42 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 				skipRow = true
 				break
 			}
-			if store.GetEdgeBetween(fromNode.ID, toNode.ID, relPlan.relType) != nil {
-				continue
-			}
-			edge := &storage.Edge{
-				ID:         storage.EdgeID(e.generateID()),
-				Type:       relPlan.relType,
-				StartNode:  fromNode.ID,
-				EndNode:    toNode.ID,
-				Properties: map[string]interface{}{},
-			}
-			if err := store.CreateEdge(edge); err != nil {
-				if err != storage.ErrAlreadyExists {
-					return nil, true, fmt.Errorf("UNWIND MERGE chain relationship create failed: %w", err)
+			edge := store.GetEdgeBetween(fromNode.ID, toNode.ID, relPlan.relType)
+			created := false
+			if edge == nil {
+				edge = &storage.Edge{
+					ID:         storage.EdgeID(e.generateID()),
+					Type:       relPlan.relType,
+					StartNode:  fromNode.ID,
+					EndNode:    toNode.ID,
+					Properties: map[string]interface{}{},
 				}
-				continue
+				created = true
 			}
-			result.Stats.RelationshipsCreated++
+			if edge.Properties == nil {
+				edge.Properties = map[string]interface{}{}
+			}
+			needsUpdate := false
+			for _, assignment := range relPlan.setAssignments {
+				val := resolveBatchValue(assignment.expr, rowValues)
+				if cur, exists := edge.Properties[assignment.prop]; !exists || !reflect.DeepEqual(canonicalUnwindMergeValue(cur), canonicalUnwindMergeValue(val)) {
+					edge.Properties[assignment.prop] = val
+					needsUpdate = true
+				}
+			}
+			if created {
+				if err := store.CreateEdge(edge); err != nil {
+					if err != storage.ErrAlreadyExists {
+						return nil, true, fmt.Errorf("UNWIND MERGE chain relationship create failed: %w", err)
+					}
+					continue
+				}
+				result.Stats.RelationshipsCreated++
+			} else if needsUpdate {
+				if err := store.UpdateEdge(edge); err != nil {
+					return nil, true, fmt.Errorf("UNWIND MERGE chain relationship update failed: %w", err)
+				}
+			}
 			notifyOnce(fromNode.ID)
 			notifyOnce(toNode.ID)
 		}

--- a/pkg/cypher/executor.go
+++ b/pkg/cypher/executor.go
@@ -268,8 +268,9 @@ type StorageExecutor struct {
 	// Node lookup cache for MATCH patterns like (n:Label {prop: value})
 	// Key: "Label:{prop:value,...}", Value: *storage.Node
 	// This dramatically speeds up repeated MATCH lookups for the same pattern
-	nodeLookupCache   map[string]*storage.Node
-	nodeLookupCacheMu sync.RWMutex
+	nodeLookupCache map[string]*storage.Node
+	// cloneWithStorage shares nodeLookupCache, so clones must share this lock too.
+	nodeLookupCacheMu *sync.RWMutex
 
 	// deferFlush when true, writes are not auto-flushed (Bolt layer handles it)
 	deferFlush bool
@@ -343,6 +344,7 @@ func (e *StorageExecutor) cloneWithStorage(override storage.Engine) *StorageExec
 		fabricPlanCache:             e.fabricPlanCache,
 		analyzer:                    e.analyzer,
 		nodeLookupCache:             e.nodeLookupCache,
+		nodeLookupCacheMu:           e.nodeLookupCacheLock(),
 		deferFlush:                  e.deferFlush,
 		embedder:                    e.embedder,
 		searchService:               e.searchService,
@@ -362,6 +364,13 @@ func (e *StorageExecutor) cloneWithStorage(override storage.Engine) *StorageExec
 		vectorQueryEmbedInflight:    e.vectorQueryEmbedInflight,
 		unwindMergeChainPlanCache:   e.unwindMergeChainPlanCache,
 	}
+}
+
+func (e *StorageExecutor) nodeLookupCacheLock() *sync.RWMutex {
+	if e.nodeLookupCacheMu == nil {
+		e.nodeLookupCacheMu = &sync.RWMutex{}
+	}
+	return e.nodeLookupCacheMu
 }
 
 type vectorEmbedInflight struct {
@@ -453,6 +462,7 @@ func NewStorageExecutor(store storage.Engine) *StorageExecutor {
 		fabricPlanCache:             fabric.NewPlanCache(500), // Cache 500 Fabric fragment plans
 		analyzer:                    NewQueryAnalyzer(1000),   // Cache 1000 parsed query ASTs
 		nodeLookupCache:             make(map[string]*storage.Node, 1000),
+		nodeLookupCacheMu:           &sync.RWMutex{},
 		shellParams:                 make(map[string]interface{}),
 		searchService:               nil, // Lazy initialization - will be set via SetSearchService() to reuse DB's cached service
 		vectorRegistry:              vectorspace.NewIndexRegistry(),
@@ -2372,12 +2382,13 @@ func (e *StorageExecutor) executeFastPathCreateDeleteRelCount(label1, label2, pr
 func (e *StorageExecutor) findNodeByLabelAndProperty(label, prop string, val any) *storage.Node {
 	// Try cache first (with proper locking)
 	cacheKey := fmt.Sprintf("%s:{%s:%v}", label, prop, val)
-	e.nodeLookupCacheMu.RLock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.RLock()
 	if cached, ok := e.nodeLookupCache[cacheKey]; ok {
-		e.nodeLookupCacheMu.RUnlock()
+		cacheMu.RUnlock()
 		return cached
 	}
-	e.nodeLookupCacheMu.RUnlock()
+	cacheMu.RUnlock()
 
 	// Scan nodes with label
 	nodes, err := e.storage.GetNodesByLabel(label)
@@ -2390,9 +2401,9 @@ func (e *StorageExecutor) findNodeByLabelAndProperty(label, prop string, val any
 		if nodeVal, ok := node.Properties[prop]; ok {
 			if fmt.Sprintf("%v", nodeVal) == fmt.Sprintf("%v", val) {
 				// Cache for next time (with proper locking)
-				e.nodeLookupCacheMu.Lock()
+				cacheMu.Lock()
 				e.nodeLookupCache[cacheKey] = node
-				e.nodeLookupCacheMu.Unlock()
+				cacheMu.Unlock()
 				return node
 			}
 		}

--- a/pkg/cypher/executor_test.go
+++ b/pkg/cypher/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/orneryd/nornicdb/pkg/config"
 	"github.com/orneryd/nornicdb/pkg/storage"
@@ -21,6 +22,37 @@ func TestNewStorageExecutor(t *testing.T) {
 	assert.NotNil(t, exec)
 	assert.NotNil(t, exec.parser)
 	assert.NotNil(t, exec.storage)
+}
+
+func TestCloneWithStorageSharesNodeLookupCacheLock(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	clone := exec.cloneWithStorage(store)
+
+	exec.nodeLookupCacheMu.Lock()
+	defer exec.nodeLookupCacheMu.Unlock()
+
+	locked := make(chan struct{})
+	go func() {
+		clone.nodeLookupCacheMu.Lock()
+		defer clone.nodeLookupCacheMu.Unlock()
+		close(locked)
+	}()
+
+	select {
+	case <-locked:
+		t.Fatal("clone acquired node lookup cache lock while original held it")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	exec.nodeLookupCacheMu.Unlock()
+	select {
+	case <-locked:
+	case <-time.After(time.Second):
+		t.Fatal("clone did not acquire node lookup cache lock after original released it")
+	}
+	exec.nodeLookupCacheMu.Lock()
 }
 
 func TestExecuteEmptyQuery(t *testing.T) {

--- a/pkg/cypher/merge.go
+++ b/pkg/cypher/merge.go
@@ -98,8 +98,9 @@ func (e *StorageExecutor) evictMergeNodeCacheEntries(labels []string, props map[
 		return
 	}
 
-	e.nodeLookupCacheMu.Lock()
-	defer e.nodeLookupCacheMu.Unlock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	for prop, val := range props {
 		key := mergeLookupCacheKey(labels, prop, val)
 		cached, ok := e.nodeLookupCache[key]
@@ -118,7 +119,8 @@ func (e *StorageExecutor) findMergeNodeInCache(store storage.Engine, labels []st
 	}
 
 	var cachedNode *storage.Node
-	e.nodeLookupCacheMu.RLock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.RLock()
 	for prop, val := range props {
 		if cached, ok := e.nodeLookupCache[mergeLookupCacheKey(labels, prop, val)]; ok {
 			if mergeNodeMatches(cached, labels, props) {
@@ -127,7 +129,7 @@ func (e *StorageExecutor) findMergeNodeInCache(store storage.Engine, labels []st
 			}
 		}
 	}
-	e.nodeLookupCacheMu.RUnlock()
+	cacheMu.RUnlock()
 
 	if cachedNode == nil {
 		return nil
@@ -149,8 +151,9 @@ func (e *StorageExecutor) cacheMergeNode(labels []string, props map[string]inter
 	if node == nil || len(labels) == 0 || len(props) == 0 {
 		return
 	}
-	e.nodeLookupCacheMu.Lock()
-	defer e.nodeLookupCacheMu.Unlock()
+	cacheMu := e.nodeLookupCacheLock()
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	for prop, val := range props {
 		e.nodeLookupCache[mergeLookupCacheKey(labels, prop, val)] = node
 	}

--- a/pkg/cypher/merge.go
+++ b/pkg/cypher/merge.go
@@ -31,11 +31,38 @@ func mergeNodeHasLabels(node *storage.Node, labels []string) bool {
 	return true
 }
 
+func mergeNodeHasAnyLabel(node *storage.Node, labels []string) bool {
+	for _, label := range labels {
+		for _, nodeLabel := range node.Labels {
+			if nodeLabel == label {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func mergeNodeMatches(node *storage.Node, labels []string, props map[string]interface{}) bool {
 	if node == nil {
 		return false
 	}
 	if len(labels) > 0 && !mergeNodeHasLabels(node, labels) {
+		return false
+	}
+	for key, val := range props {
+		nodeVal, ok := node.Properties[key]
+		if !ok || !reflect.DeepEqual(canonicalUnwindMergeValue(nodeVal), canonicalUnwindMergeValue(val)) {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeNodeMatchesAnyLabel(node *storage.Node, labels []string, props map[string]interface{}) bool {
+	if node == nil {
+		return false
+	}
+	if len(labels) > 0 && !mergeNodeHasAnyLabel(node, labels) {
 		return false
 	}
 	for key, val := range props {
@@ -278,6 +305,102 @@ func (e *StorageExecutor) findMergeNode(store storage.Engine, labels []string, p
 	for _, node := range allNodes {
 		if mergeNodeMatches(node, labels, props) {
 			e.cacheMergeNode(labels, props, node)
+			return node, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (e *StorageExecutor) findMergeNodeAnyLabel(store storage.Engine, labels []string, props map[string]interface{}) (*storage.Node, error) {
+	if len(labels) == 0 || len(props) == 0 {
+		return nil, nil
+	}
+
+	schema := store.GetSchema()
+	schemaLookupUsed := false
+	if schema != nil {
+		for _, label := range labels {
+			for _, prop := range mergePropertyNamesSorted(props) {
+				val := props[prop]
+				nodeID, valueFound, constraintExists := schema.LookupUniqueConstraintValue(label, prop, val)
+				if !constraintExists {
+					continue
+				}
+				schemaLookupUsed = true
+				e.markMergeSchemaLookupUsed()
+				if !valueFound {
+					continue
+				}
+				for _, n := range e.loadMergeCandidateNodes(store, []storage.NodeID{nodeID}) {
+					if mergeNodeMatchesAnyLabel(n, labels, props) {
+						return n, nil
+					}
+				}
+			}
+		}
+
+		bestIDs := []storage.NodeID(nil)
+		bestCount := -1
+		for _, label := range labels {
+			for _, prop := range mergePropertyNamesSorted(props) {
+				val := props[prop]
+				if _, ok := schema.GetPropertyIndex(label, prop); !ok {
+					continue
+				}
+				schemaLookupUsed = true
+				e.markMergeSchemaLookupUsed()
+				ids := schema.PropertyIndexLookup(label, prop, val)
+				count := len(ids)
+				if bestCount == -1 || count < bestCount {
+					bestIDs = ids
+					bestCount = count
+					if count <= 1 {
+						break
+					}
+				}
+			}
+			if bestCount == 1 {
+				break
+			}
+		}
+		for _, n := range e.loadMergeCandidateNodes(store, bestIDs) {
+			if mergeNodeMatchesAnyLabel(n, labels, props) {
+				return n, nil
+			}
+		}
+	}
+	if schemaLookupUsed {
+		return nil, nil
+	}
+	e.markMergeScanFallbackUsed()
+
+	seen := make(map[storage.NodeID]struct{})
+	for _, label := range labels {
+		nodes, err := store.GetNodesByLabel(label)
+		if err != nil {
+			return nil, err
+		}
+		for _, node := range nodes {
+			if _, ok := seen[node.ID]; ok {
+				continue
+			}
+			seen[node.ID] = struct{}{}
+			if mergeNodeMatchesAnyLabel(node, labels, props) {
+				return node, nil
+			}
+		}
+	}
+
+	allNodes, err := store.AllNodes()
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range allNodes {
+		if _, ok := seen[node.ID]; ok {
+			continue
+		}
+		if mergeNodeMatchesAnyLabel(node, labels, props) {
 			return node, nil
 		}
 	}

--- a/pkg/cypher/merge.go
+++ b/pkg/cypher/merge.go
@@ -321,7 +321,6 @@ func (e *StorageExecutor) findMergeNodeAnyLabel(store storage.Engine, labels []s
 	}
 
 	schema := store.GetSchema()
-	schemaLookupUsed := false
 	if schema != nil {
 		for _, label := range labels {
 			for _, prop := range mergePropertyNamesSorted(props) {
@@ -330,7 +329,6 @@ func (e *StorageExecutor) findMergeNodeAnyLabel(store storage.Engine, labels []s
 				if !constraintExists {
 					continue
 				}
-				schemaLookupUsed = true
 				e.markMergeSchemaLookupUsed()
 				if !valueFound {
 					continue
@@ -351,7 +349,6 @@ func (e *StorageExecutor) findMergeNodeAnyLabel(store storage.Engine, labels []s
 				if _, ok := schema.GetPropertyIndex(label, prop); !ok {
 					continue
 				}
-				schemaLookupUsed = true
 				e.markMergeSchemaLookupUsed()
 				ids := schema.PropertyIndexLookup(label, prop, val)
 				count := len(ids)
@@ -373,9 +370,6 @@ func (e *StorageExecutor) findMergeNodeAnyLabel(store storage.Engine, labels []s
 			}
 		}
 	}
-	if schemaLookupUsed {
-		return nil, nil
-	}
 	e.markMergeScanFallbackUsed()
 
 	seen := make(map[storage.NodeID]struct{})
@@ -392,19 +386,6 @@ func (e *StorageExecutor) findMergeNodeAnyLabel(store storage.Engine, labels []s
 			if mergeNodeMatchesAnyLabel(node, labels, props) {
 				return node, nil
 			}
-		}
-	}
-
-	allNodes, err := store.AllNodes()
-	if err != nil {
-		return nil, err
-	}
-	for _, node := range allNodes {
-		if _, ok := seen[node.ID]; ok {
-			continue
-		}
-		if mergeNodeMatchesAnyLabel(node, labels, props) {
-			return node, nil
 		}
 	}
 

--- a/pkg/cypher/pcg_sql_relationship_hotpath_test.go
+++ b/pkg/cypher/pcg_sql_relationship_hotpath_test.go
@@ -72,6 +72,186 @@ ORDER BY source.uid
 	}, res.Rows)
 }
 
+func TestUnwindMatchRelationshipSetBatch_FallsBackForUnindexedAlternativeLabel(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, "CREATE CONSTRAINT sql_table_uid_unique IF NOT EXISTS FOR (n:SqlTable) REQUIRE n.uid IS UNIQUE", nil)
+	require.NoError(t, err)
+	for _, stmt := range []string{
+		"CREATE (:SqlTable {uid: 'table:users', name: 'users'})",
+		"CREATE (:SqlFunction {uid: 'function:active_users', name: 'active_users'})",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	_, err = exec.Execute(ctx, strings.TrimSpace(`
+UNWIND $rows AS row
+MATCH (source:SqlTable|SqlView|SqlFunction|SqlTrigger|SqlIndex|SqlColumn {uid: row.source_entity_id})
+MATCH (target:SqlTable|SqlView|SqlFunction|SqlTrigger|SqlIndex|SqlColumn {uid: row.target_entity_id})
+MERGE (source)-[rel:REFERENCES_TABLE]->(target)
+SET rel.evidence_source = row.evidence_source
+`), map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{
+				"source_entity_id": "function:active_users",
+				"target_entity_id": "table:users",
+				"evidence_source":  "parser-sql",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, exec.LastHotPathTrace().UnwindMergeChainBatch)
+	require.True(t, exec.LastHotPathTrace().MergeSchemaLookupUsed)
+	require.True(t, exec.LastHotPathTrace().MergeScanFallbackUsed)
+
+	res, err := exec.Execute(ctx, `
+MATCH (source)-[rel:REFERENCES_TABLE]->(target)
+RETURN source.uid, target.uid, rel.evidence_source
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"function:active_users", "table:users", "parser-sql"},
+	}, res.Rows)
+}
+
+func TestUnwindMatchRelationshipSetBatch_NoOpMergeDoesNotNotifyNodes(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	for _, stmt := range []string{
+		"CREATE (:SqlView {uid: 'view:active_users'})",
+		"CREATE (:SqlTable {uid: 'table:users'})",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	notifications := 0
+	exec.SetNodeMutatedCallback(func(string) {
+		notifications++
+	})
+	query := strings.TrimSpace(`
+UNWIND $rows AS row
+MATCH (source:SqlView {uid: row.source_entity_id})
+MATCH (target:SqlTable {uid: row.target_entity_id})
+MERGE (source)-[rel:REFERENCES_TABLE]->(target)
+SET rel.evidence_source = row.evidence_source
+`)
+	params := map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{
+				"source_entity_id": "view:active_users",
+				"target_entity_id": "table:users",
+				"evidence_source":  "parser-sql",
+			},
+		},
+	}
+
+	_, err := exec.Execute(ctx, query, params)
+	require.NoError(t, err)
+	require.Equal(t, 2, notifications)
+
+	notifications = 0
+	_, err = exec.Execute(ctx, query, params)
+	require.NoError(t, err)
+	require.Zero(t, notifications)
+}
+
+func TestUnwindMatchRelationshipSetBatch_RetriesCreateEdgeIDCollision(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := &createEdgeCollisionEngine{
+		Engine:    storage.NewNamespacedEngine(baseStore, "test"),
+		remaining: 1,
+	}
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	for _, stmt := range []string{
+		"CREATE (:SqlView {uid: 'view:active_users'})",
+		"CREATE (:SqlTable {uid: 'table:users'})",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	_, err := exec.Execute(ctx, strings.TrimSpace(`
+UNWIND $rows AS row
+MATCH (source:SqlView {uid: row.source_entity_id})
+MATCH (target:SqlTable {uid: row.target_entity_id})
+MERGE (source)-[rel:REFERENCES_TABLE]->(target)
+SET rel.evidence_source = row.evidence_source
+`), map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{
+				"source_entity_id": "view:active_users",
+				"target_entity_id": "table:users",
+				"evidence_source":  "parser-sql",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `
+MATCH (source)-[rel:REFERENCES_TABLE]->(target)
+RETURN source.uid, target.uid, rel.evidence_source
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"view:active_users", "table:users", "parser-sql"},
+	}, res.Rows)
+}
+
+func TestUnwindMatchRelationshipSetBatch_UpdatesConcurrentRelationshipCreate(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := &createEdgeCollisionEngine{
+		Engine:                   storage.NewNamespacedEngine(baseStore, "test"),
+		remaining:                1,
+		createConcurrentExisting: true,
+	}
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	for _, stmt := range []string{
+		"CREATE (:SqlView {uid: 'view:active_users'})",
+		"CREATE (:SqlTable {uid: 'table:users'})",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	_, err := exec.Execute(ctx, strings.TrimSpace(`
+UNWIND $rows AS row
+MATCH (source:SqlView {uid: row.source_entity_id})
+MATCH (target:SqlTable {uid: row.target_entity_id})
+MERGE (source)-[rel:REFERENCES_TABLE]->(target)
+SET rel.evidence_source = row.evidence_source
+`), map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{
+				"source_entity_id": "view:active_users",
+				"target_entity_id": "table:users",
+				"evidence_source":  "parser-sql",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `
+MATCH (source)-[rel:REFERENCES_TABLE]->(target)
+RETURN source.uid, target.uid, rel.evidence_source
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"view:active_users", "table:users", "parser-sql"},
+	}, res.Rows)
+}
+
 func TestUnwindMatchReadDoesNotUseMutationBatchPath(t *testing.T) {
 	baseStore := newTestMemoryEngine(t)
 	store := storage.NewNamespacedEngine(baseStore, "test")
@@ -94,4 +274,30 @@ RETURN count(n) AS matched
 	require.NoError(t, err)
 	require.False(t, exec.LastHotPathTrace().UnwindMergeChainBatch)
 	require.Equal(t, [][]interface{}{{int64(1)}}, res.Rows)
+}
+
+type createEdgeCollisionEngine struct {
+	storage.Engine
+	remaining                int
+	createConcurrentExisting bool
+}
+
+func (e *createEdgeCollisionEngine) CreateEdge(edge *storage.Edge) error {
+	if e.remaining > 0 {
+		e.remaining--
+		if e.createConcurrentExisting {
+			concurrentEdge := &storage.Edge{
+				ID:         storage.EdgeID("concurrent-" + string(edge.ID)),
+				Type:       edge.Type,
+				StartNode:  edge.StartNode,
+				EndNode:    edge.EndNode,
+				Properties: map[string]interface{}{},
+			}
+			if err := e.Engine.CreateEdge(concurrentEdge); err != nil {
+				return err
+			}
+		}
+		return storage.ErrAlreadyExists
+	}
+	return e.Engine.CreateEdge(edge)
 }

--- a/pkg/cypher/pcg_sql_relationship_hotpath_test.go
+++ b/pkg/cypher/pcg_sql_relationship_hotpath_test.go
@@ -1,0 +1,97 @@
+package cypher
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnwindMatchRelationshipSetBatch_PCGSQLRelationshipShape(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	for _, stmt := range []string{
+		"CREATE CONSTRAINT sql_table_uid_unique IF NOT EXISTS FOR (n:SqlTable) REQUIRE n.uid IS UNIQUE",
+		"CREATE CONSTRAINT sql_view_uid_unique IF NOT EXISTS FOR (n:SqlView) REQUIRE n.uid IS UNIQUE",
+		"CREATE CONSTRAINT sql_column_uid_unique IF NOT EXISTS FOR (n:SqlColumn) REQUIRE n.uid IS UNIQUE",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	for _, stmt := range []string{
+		"CREATE (:SqlTable {uid: 'table:users', name: 'users'})",
+		"CREATE (:SqlView {uid: 'view:active_users', name: 'active_users'})",
+		"CREATE (:SqlColumn {uid: 'column:users.id', name: 'id'})",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	_, err := exec.Execute(ctx, strings.TrimSpace(`
+UNWIND $rows AS row
+MATCH (source:SqlTable|SqlView|SqlFunction|SqlTrigger|SqlIndex|SqlColumn {uid: row.source_entity_id})
+MATCH (target:SqlTable|SqlView|SqlFunction|SqlTrigger|SqlIndex|SqlColumn {uid: row.target_entity_id})
+MERGE (source)-[rel:REFERENCES_TABLE]->(target)
+SET rel.confidence = 0.95,
+    rel.reason = 'SQL entity metadata resolved a table reference edge',
+    rel.evidence_source = row.evidence_source
+`), map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{
+				"source_entity_id": "view:active_users",
+				"target_entity_id": "table:users",
+				"evidence_source":  "parser-sql",
+			},
+			{
+				"source_entity_id": "column:users.id",
+				"target_entity_id": "table:users",
+				"evidence_source":  "parser-sql",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, exec.LastHotPathTrace().UnwindMergeChainBatch)
+	require.True(t, exec.LastHotPathTrace().MergeSchemaLookupUsed)
+	require.False(t, exec.LastHotPathTrace().MergeScanFallbackUsed)
+
+	res, err := exec.Execute(ctx, `
+MATCH (source)-[rel:REFERENCES_TABLE]->(target)
+RETURN source.uid, target.uid, rel.confidence, rel.evidence_source
+ORDER BY source.uid
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"column:users.id", "table:users", 0.95, "parser-sql"},
+		{"view:active_users", "table:users", 0.95, "parser-sql"},
+	}, res.Rows)
+}
+
+func TestUnwindMatchReadDoesNotUseMutationBatchPath(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, "CREATE (:SqlTable {uid: 'table:users'})", nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, strings.TrimSpace(`
+UNWIND $rows AS row
+MATCH (n:SqlTable {uid: row.uid})
+RETURN count(n) AS matched
+`), map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{"uid": "table:users"},
+			{"uid": "table:missing"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, exec.LastHotPathTrace().UnwindMergeChainBatch)
+	require.Equal(t, [][]interface{}{{int64(1)}}, res.Rows)
+}

--- a/pkg/cypher/pcg_sql_relationship_hotpath_test.go
+++ b/pkg/cypher/pcg_sql_relationship_hotpath_test.go
@@ -88,6 +88,12 @@ func TestUnwindMatchRelationshipSetBatch_FallsBackForUnindexedAlternativeLabel(t
 		require.NoError(t, err)
 	}
 
+	schema := store.GetSchema()
+	_, _, hasFunctionConstraint := schema.LookupUniqueConstraintValue("SqlFunction", "uid", "function:active_users")
+	_, hasFunctionIndex := schema.GetPropertyIndex("SqlFunction", "uid")
+	require.False(t, hasFunctionConstraint)
+	require.False(t, hasFunctionIndex)
+
 	_, err = exec.Execute(ctx, strings.TrimSpace(`
 UNWIND $rows AS row
 MATCH (source:SqlTable|SqlView|SqlFunction|SqlTrigger|SqlIndex|SqlColumn {uid: row.source_entity_id})


### PR DESCRIPTION
## Summary

This adds a batched mutation path for lookup-first UNWIND chains shaped like:

```cypher
UNWIND $rows AS row
MATCH (source:CodeEntity|Function {id: row.source_id})
MATCH (target:CodeEntity|Table {id: row.target_id})
MERGE (source)-[rel:QUERIES]->(target)
SET rel.repo_id = row.repo_id
```

PCG emits this form for SQL relationship materialization: rows already identify existing source/target nodes, and the write only needs to merge/update the relationship. Before this patch, NornicDB fell back to the generic per-row UNWIND MATCH path because the batch detector did not accept lookup-first MATCH mutation chains, label alternatives, relationship variables, or relationship property SET assignments.

## Why

On a PCG dogfood run against the platform-context-graph repository, SQL relationship materialization took about `217.718543222s` for only 291 SQL edges. After this patch, the same phase on the 16-vCPU test host completed in `3.921462s`. That moved the remaining bottleneck back to semantic entity materialization instead of relationship writes.

## Safety

- Keeps pure read shapes such as `UNWIND ... MATCH ... RETURN` out of the mutation batch path.
- Restricts the new route to chains that include a relationship MERGE mutation.
- Supports the existing batch execution machinery rather than adding a separate executor.

## Validation

```bash
go test -tags 'noui nolocalllm' ./pkg/cypher -run 'TestUnwindMatch(RelationshipSetBatch_PCGSQLRelationshipShape|ReadDoesNotUseMutationBatchPath)' -count=1
go test -tags 'noui nolocalllm' ./pkg/cypher ./pkg/storage ./pkg/bolt -count=1
go build -tags 'noui nolocalllm' -o ./bin/nornicdb-headless-pcg-sql-edge-hotpath ./cmd/nornicdb
```

Runtime validation: remote PCG dogfood on the 16-vCPU test host with this binary showed SQL relationship materialization dropping from `217.718543222s` to `3.921462s`, with owner startup healthy at about `3m06s`.