### PR TITLE
Optimize UNWIND merge relationship probes

### DIFF
--- a/docs/performance/hot-path-query-cookbook.md
+++ b/docs/performance/hot-path-query-cookbook.md
@@ -576,6 +576,13 @@ idempotently. This shape is optimized by `UnwindMergeChainBatch`; it avoids the
 generic per-row fallback for `UNWIND ... MATCH ... MERGE ... SET += row.props
 ... MERGE relationship` ingestion pipelines.
 
+When the batch creates the relationship target and immediately links an existing
+parent to it, `UnwindMergeChainBatch` skips committed relationship existence
+probes for that batch-created endpoint and uses a batch-local relationship cache
+for duplicate rows. That keeps duplicate input idempotent while avoiding
+repeated scans across an already-large source-node fanout for relationships that
+could not have existed before the target node was created.
+
 ### 7.3e.2 Staged Compound `UNWIND` Version Pipeline
 
 ```cypher

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -1714,6 +1714,9 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 
 	lookupCache := make(map[string]*storage.Node)
 	lookupKnown := make(map[string]bool)
+	batchCreatedNodes := make(map[storage.NodeID]struct{})
+	relationshipCache := make(map[string]*storage.Edge)
+	relationshipKnown := make(map[string]bool)
 	notified := make(map[string]struct{})
 	params := getParamsFromContext(ctx)
 	resolveBatchValue := func(expr string, values map[string]interface{}) interface{} {
@@ -1788,6 +1791,25 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 		}
 		return nil, false, fmt.Errorf("UNWIND MERGE chain relationship create failed after %d edge ID collisions", maxCreateAttempts)
 	}
+	relationshipKey := func(startID, endID storage.NodeID, edgeType string) string {
+		return string(startID) + "\x00" + edgeType + "\x00" + string(endID)
+	}
+	findRelationship := func(fromNode, toNode *storage.Node, edgeType string) (*storage.Edge, string) {
+		key := relationshipKey(fromNode.ID, toNode.ID, edgeType)
+		if relationshipKnown[key] {
+			return relationshipCache[key], key
+		}
+		_, fromCreated := batchCreatedNodes[fromNode.ID]
+		_, toCreated := batchCreatedNodes[toNode.ID]
+		if fromCreated || toCreated {
+			relationshipKnown[key] = true
+			return nil, key
+		}
+		edge := store.GetEdgeBetween(fromNode.ID, toNode.ID, edgeType)
+		relationshipCache[key] = edge
+		relationshipKnown[key] = true
+		return edge, key
+	}
 
 	processedRows := 0
 	for _, item := range items {
@@ -1832,6 +1854,7 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 						return nil, true, fmt.Errorf("UNWIND MERGE chain create failed: %w", err)
 					}
 					node.ID = actualID
+					batchCreatedNodes[node.ID] = struct{}{}
 					lookupCache[lookupKey] = node
 					e.cacheMergeNode(nodePlan.labels, matchProps, node)
 					result.Stats.NodesCreated++
@@ -1923,7 +1946,7 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 				skipRow = true
 				break
 			}
-			edge := store.GetEdgeBetween(fromNode.ID, toNode.ID, relPlan.relType)
+			edge, relKey := findRelationship(fromNode, toNode, relPlan.relType)
 			relationshipChanged := false
 			if edge == nil {
 				edge = &storage.Edge{
@@ -1938,6 +1961,9 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 				if err != nil {
 					return nil, true, err
 				}
+				edge = createdEdge
+				relationshipCache[relKey] = edge
+				relationshipKnown[relKey] = true
 				if created {
 					result.Stats.RelationshipsCreated++
 					relationshipChanged = true
@@ -1945,17 +1971,22 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 					if err := store.UpdateEdge(createdEdge); err != nil {
 						return nil, true, fmt.Errorf("UNWIND MERGE chain relationship update failed: %w", err)
 					}
+					relationshipCache[relKey] = createdEdge
 					relationshipChanged = true
 				}
 			} else if applyRelationshipAssignments(edge, relPlan.setAssignments, rowValues) {
 				if err := store.UpdateEdge(edge); err != nil {
 					return nil, true, fmt.Errorf("UNWIND MERGE chain relationship update failed: %w", err)
 				}
+				relationshipCache[relKey] = edge
 				relationshipChanged = true
 			}
 			if relationshipChanged {
 				notifyOnce(fromNode.ID)
 				notifyOnce(toNode.ID)
+			}
+			if relPlan.relVar != "" {
+				rowValues[relPlan.relVar] = edge
 			}
 		}
 		if skipRow {

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -1714,6 +1714,9 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 
 	lookupCache := make(map[string]*storage.Node)
 	lookupKnown := make(map[string]bool)
+	// Relationships touching nodes created inside this batch cannot exist in
+	// committed storage yet, but duplicate input rows must still reuse any edge
+	// created earlier in the same batch.
 	batchCreatedNodes := make(map[storage.NodeID]struct{})
 	relationshipCache := make(map[string]*storage.Edge)
 	relationshipKnown := make(map[string]bool)
@@ -1794,6 +1797,8 @@ func (e *StorageExecutor) executeUnwindMergeChainBatch(ctx context.Context, unwi
 	relationshipKey := func(startID, endID storage.NodeID, edgeType string) string {
 		return string(startID) + "\x00" + edgeType + "\x00" + string(endID)
 	}
+	// findRelationship prefers the batch-local relationship cache and only
+	// falls back to committed storage when both endpoints predate this batch.
 	findRelationship := func(fromNode, toNode *storage.Node, edgeType string) (*storage.Edge, string) {
 		key := relationshipKey(fromNode.ID, toNode.ID, edgeType)
 		if relationshipKnown[key] {

--- a/pkg/cypher/unwind_merge_batch_test.go
+++ b/pkg/cypher/unwind_merge_batch_test.go
@@ -3,11 +3,22 @@ package cypher
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/orneryd/nornicdb/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
+
+type countingEdgeLookupEngine struct {
+	storage.Engine
+	edgeBetweenCalls int64
+}
+
+func (e *countingEdgeLookupEngine) GetEdgeBetween(startID, endID storage.NodeID, edgeType string) *storage.Edge {
+	atomic.AddInt64(&e.edgeBetweenCalls, 1)
+	return e.Engine.GetEdgeBetween(startID, endID, edgeType)
+}
 
 func TestUnwindCollectDistinctProjection_UsesHelperRoute(t *testing.T) {
 	base := newTestMemoryEngine(t)
@@ -164,6 +175,63 @@ ORDER BY n.uid
 		{"src/handler.go", "annotation-1"},
 		{"src/handler.go", "annotation-2"},
 	}, contains.Rows)
+}
+
+func TestUnwindMergeBatch_SkipsRelationshipExistenceLookupForBatchCreatedEndpoint(t *testing.T) {
+	base := newTestMemoryEngine(t)
+	namespaced := storage.NewNamespacedEngine(base, "test")
+	store := &countingEdgeLookupEngine{Engine: namespaced}
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	for _, query := range []string{
+		`CREATE CONSTRAINT repo_id_unique IF NOT EXISTS FOR (r:Repository) REQUIRE r.id IS UNIQUE`,
+		`CREATE CONSTRAINT dir_path_unique IF NOT EXISTS FOR (d:Directory) REQUIRE d.path IS UNIQUE`,
+		`CREATE CONSTRAINT file_path_unique IF NOT EXISTS FOR (f:File) REQUIRE f.path IS UNIQUE`,
+	} {
+		_, err := exec.Execute(ctx, query, nil)
+		require.NoError(t, err)
+	}
+	_, err := exec.Execute(ctx, `
+MERGE (r:Repository {id: $repo_id})
+MERGE (d:Directory {path: $dir_path})
+`, map[string]interface{}{"repo_id": "repo-1", "dir_path": "src"})
+	require.NoError(t, err)
+
+	rows := []map[string]interface{}{
+		{"path": "src/a.go", "name": "a.go", "relative_path": "src/a.go", "language": "go", "repo_id": "repo-1", "scope_id": "scope-1", "generation_id": "gen-1", "dir_path": "src"},
+		{"path": "src/b.go", "name": "b.go", "relative_path": "src/b.go", "language": "go", "repo_id": "repo-1", "scope_id": "scope-1", "generation_id": "gen-1", "dir_path": "src"},
+		{"path": "src/a.go", "name": "a.go", "relative_path": "src/a.go", "language": "go", "repo_id": "repo-1", "scope_id": "scope-1", "generation_id": "gen-1", "dir_path": "src"},
+	}
+
+	res, err := exec.Execute(ctx, `
+UNWIND $rows AS row
+MERGE (f:File {path: row.path})
+SET f.name = row.name, f.relative_path = row.relative_path,
+    f.language = row.language, f.lang = row.language,
+    f.repo_id = row.repo_id,
+    f.scope_id = row.scope_id, f.generation_id = row.generation_id,
+    f.evidence_source = 'projector/canonical'
+WITH f, row
+MATCH (r:Repository {id: row.repo_id})
+MERGE (r)-[repoRel:REPO_CONTAINS]->(f)
+SET repoRel.evidence_source = 'projector/canonical',
+    repoRel.generation_id = row.generation_id
+WITH f, row
+MATCH (d:Directory {path: row.dir_path})
+MERGE (d)-[dirRel:CONTAINS]->(f)
+SET dirRel.evidence_source = 'projector/canonical',
+    dirRel.generation_id = row.generation_id
+RETURN count(f) AS prepared
+`, map[string]interface{}{"rows": rows})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), toInt64ForTest(t, res.Rows[0][0]))
+	require.True(t, exec.LastHotPathTrace().UnwindMergeChainBatch, "expected generalized unwind merge chain hot path")
+	require.Zero(t, store.edgeBetweenCalls, "batch-created File endpoints should not scan existing relationship fanout")
+
+	edges, err := store.AllEdges()
+	require.NoError(t, err)
+	require.Len(t, edges, 4, "duplicate file row must reuse batch-created relationships")
 }
 
 func TestUnwindMergeBatch_MatchMergeCountReflectsFilteredRows(t *testing.T) {

--- a/pkg/cypher/unwind_merge_batch_test.go
+++ b/pkg/cypher/unwind_merge_batch_test.go
@@ -10,11 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// countingEdgeLookupEngine records relationship existence probes while
+// delegating all storage behavior to the wrapped engine.
 type countingEdgeLookupEngine struct {
 	storage.Engine
 	edgeBetweenCalls int64
 }
 
+// GetEdgeBetween counts committed relationship lookups so hot-path tests can
+// distinguish true batch-local reuse from storage-level fanout scans.
 func (e *countingEdgeLookupEngine) GetEdgeBetween(startID, endID storage.NodeID, edgeType string) *storage.Edge {
 	atomic.AddInt64(&e.edgeBetweenCalls, 1)
 	return e.Engine.GetEdgeBetween(startID, endID, edgeType)
@@ -177,6 +181,9 @@ ORDER BY n.uid
 	}, contains.Rows)
 }
 
+// TestUnwindMergeBatch_SkipsRelationshipExistenceLookupForBatchCreatedEndpoint
+// verifies that a batch-created relationship target avoids committed-store
+// existence probes while duplicate rows still reuse the batch-created edges.
 func TestUnwindMergeBatch_SkipsRelationshipExistenceLookupForBatchCreatedEndpoint(t *testing.T) {
 	base := newTestMemoryEngine(t)
 	namespaced := storage.NewNamespacedEngine(base, "test")
@@ -227,7 +234,7 @@ RETURN count(f) AS prepared
 	require.NoError(t, err)
 	require.Equal(t, int64(3), toInt64ForTest(t, res.Rows[0][0]))
 	require.True(t, exec.LastHotPathTrace().UnwindMergeChainBatch, "expected generalized unwind merge chain hot path")
-	require.Zero(t, store.edgeBetweenCalls, "batch-created File endpoints should not scan existing relationship fanout")
+	require.Zero(t, atomic.LoadInt64(&store.edgeBetweenCalls), "batch-created File endpoints should not scan existing relationship fanout")
 
 	edges, err := store.AllEdges()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

This PR optimizes the `UnwindMergeChainBatch` hot path for ingestion workloads
that create a target node in the current batch and then immediately `MERGE`
relationships from existing parent nodes to that target.

PCG's canonical file write shape does exactly that:

```cypher
UNWIND $rows AS row
MERGE (f:File {path: row.path})
SET f += row.props
WITH f, row
MATCH (r:Repository {id: row.repo_id})
MERGE (r)-[:REPO_CONTAINS]->(f)
WITH f, row
MATCH (d:Directory {path: row.dir_path})
MERGE (d)-[:CONTAINS]->(f)
RETURN count(f)
```

Before this change, every relationship `MERGE` still called
`GetEdgeBetween(start, end, type)`. For a batch of file rows this meant two
relationship-existence probes per row, even when the `File` endpoint was just
created inside the same batch. On large repositories, those probes are costly
because they walk source-node relationship fanout that cannot contain an edge to
a node that did not exist before the current batch.

## Why this is safe

The optimization is scoped to one executor invocation and one batch-local fact:
if either endpoint was created earlier in this batch, no committed relationship
can already point to that endpoint. In that case the hot path can skip the
committed-store existence probe and create the relationship directly.

Duplicate input rows remain idempotent because the executor now keeps a
batch-local relationship cache keyed by `(startID, type, endID)`. Once a
relationship is created or found, later rows in the same batch reuse that cached
edge instead of creating duplicates.

## Changes

- Track node IDs created by `UnwindMergeChainBatch`.
- Cache relationship lookups and created relationships within the batch.
- Skip committed `GetEdgeBetween` probes when either relationship endpoint was
  created in the same batch.
- Document the batch-created endpoint behavior in the hot-path query cookbook.
- Add a regression test for the PCG file write shape, including duplicate input
  rows.
- Read the regression test's probe counter with `atomic.LoadInt64` so the test
  remains race-safe if the helper is reused under concurrent execution.

## Verification

- `go test -tags 'noui nolocalllm' ./pkg/cypher -run TestUnwindMergeBatch_SkipsRelationshipExistenceLookupForBatchCreatedEndpoint -count=1`
- `go test -tags 'noui nolocalllm' ./pkg/cypher ./pkg/storage -count=1`
- `git diff --check`
