### PR TITLE
Index exact relationship lookups

### DIFF
--- a/docs/performance/hot-path-query-cookbook.md
+++ b/docs/performance/hot-path-query-cookbook.md
@@ -412,6 +412,11 @@ MERGE (a)-[r:LINKS_TO]->(b)
 SET r.updatedAt = $now;
 ```
 
+NornicDB maintains a direct relationship-existence index for this shape, keyed
+by start node, end node, relationship type, and edge ID. That keeps idempotent
+relationship `MERGE` checks from degrading with the start node's total outgoing
+degree.
+
 ### 6.4 Relationship Attach By ID
 
 ```cypher

--- a/docs/performance/hot-path-query-cookbook.md
+++ b/docs/performance/hot-path-query-cookbook.md
@@ -417,7 +417,7 @@ by start node, end node, relationship type, and edge ID. That keeps idempotent
 relationship `MERGE` checks from degrading with the start node's total outgoing
 degree.
 
-### 6.4 Relationship Attach By ID
+### 6.2 Relationship Attach By ID
 
 ```cypher
 MATCH (a:EntityA) WHERE elementId(a) = $fromId
@@ -427,7 +427,7 @@ CREATE (a)-[:LINKS_TO {createdAt: $now}]->(b);
 
 Use stable ID lookups before relationship creation for predictable attach latency.
 
-### 6.2 Bounded Traversal
+### 6.3 Bounded Traversal
 
 ```cypher
 MATCH p = (start:EntityA {primaryKey: $startKey})-[:LINKS_TO*1..3]->(n)
@@ -437,7 +437,7 @@ LIMIT 100;
 
 Always bound traversal depth and result count.
 
-### 6.3 Traversal With Early Filters
+### 6.4 Traversal With Early Filters
 
 ```cypher
 MATCH p = (start:EntityA {primaryKey: $startKey})-[:LINKS_TO*1..3]->(n:EntityB)

--- a/docs/performance/hot-path-query-cookbook.md
+++ b/docs/performance/hot-path-query-cookbook.md
@@ -412,10 +412,13 @@ MERGE (a)-[r:LINKS_TO]->(b)
 SET r.updatedAt = $now;
 ```
 
-NornicDB maintains a direct relationship-existence index for this shape, keyed
-by start node, end node, relationship type, and edge ID. That keeps idempotent
-relationship `MERGE` checks from degrading with the start node's total outgoing
-degree.
+NornicDB maintains direct relationship-existence indexes for this shape. The
+typed head key maps `(start node, end node, relationship type)` to one edge ID
+for the common single-edge lookup, while the set key keeps
+`(start node, end node, relationship type, edge ID)` entries for
+`GetEdgesBetween` and valid multiple same-type edges. Reads fall back to the
+legacy outgoing-edge scan and self-heal the new keys when opening mixed-version
+stores, so correctness does not depend solely on the one-time backfill marker.
 
 ### 6.2 Relationship Attach By ID
 

--- a/pkg/storage/badger.go
+++ b/pkg/storage/badger.go
@@ -18,22 +18,23 @@ import (
 // Key prefixes for BadgerDB storage organization
 // Using single-byte prefixes for efficiency
 const (
-	prefixNode          = byte(0x01) // nodes:nodeID -> Node
-	prefixEdge          = byte(0x02) // edges:edgeID -> Edge
-	prefixLabelIndex    = byte(0x03) // label:labelName:nodeID -> []byte{}
-	prefixOutgoingIndex = byte(0x04) // outgoing:nodeID:edgeID -> []byte{}
-	prefixIncomingIndex = byte(0x05) // incoming:nodeID:edgeID -> []byte{}
-	prefixEdgeTypeIndex = byte(0x06) // edgetype:type:edgeID -> []byte{} (for fast type lookups)
-	prefixPendingEmbed  = byte(0x07) // pending_embed:nodeID -> []byte{} (nodes needing embedding)
-	prefixEmbedding     = byte(0x08) // embedding:nodeID:chunkIndex -> []float32 (separate storage for large embeddings)
-	prefixSchema        = byte(0x09) // schema:global -> JSON(SchemaDefinition)
-	prefixTemporalIndex = byte(0x0A) // temporal:namespace:label:keyprops:keyhash:valid_from:nodeID -> []byte{}
-	prefixTemporalHead  = byte(0x0B) // temporal_current:namespace:label:keyprops:keyhash -> nodeID
-	prefixMVCCNode      = byte(0x0C) // mvcc_node:nodeID:version -> Node version payload
-	prefixMVCCEdge      = byte(0x0D) // mvcc_edge:edgeID:version -> Edge version payload
-	prefixMVCCNodeHead  = byte(0x0E) // mvcc_node_head:nodeID -> MVCCHead
-	prefixMVCCEdgeHead  = byte(0x0F) // mvcc_edge_head:edgeID -> MVCCHead
-	prefixMVCCMeta      = byte(0x10) // mvcc_meta:* -> MVCC metadata (sequence, rebuild markers)
+	prefixNode             = byte(0x01) // nodes:nodeID -> Node
+	prefixEdge             = byte(0x02) // edges:edgeID -> Edge
+	prefixLabelIndex       = byte(0x03) // label:labelName:nodeID -> []byte{}
+	prefixOutgoingIndex    = byte(0x04) // outgoing:nodeID:edgeID -> []byte{}
+	prefixIncomingIndex    = byte(0x05) // incoming:nodeID:edgeID -> []byte{}
+	prefixEdgeTypeIndex    = byte(0x06) // edgetype:type:edgeID -> []byte{} (for fast type lookups)
+	prefixPendingEmbed     = byte(0x07) // pending_embed:nodeID -> []byte{} (nodes needing embedding)
+	prefixEmbedding        = byte(0x08) // embedding:nodeID:chunkIndex -> []float32 (separate storage for large embeddings)
+	prefixSchema           = byte(0x09) // schema:global -> JSON(SchemaDefinition)
+	prefixTemporalIndex    = byte(0x0A) // temporal:namespace:label:keyprops:keyhash:valid_from:nodeID -> []byte{}
+	prefixTemporalHead     = byte(0x0B) // temporal_current:namespace:label:keyprops:keyhash -> nodeID
+	prefixMVCCNode         = byte(0x0C) // mvcc_node:nodeID:version -> Node version payload
+	prefixMVCCEdge         = byte(0x0D) // mvcc_edge:edgeID:version -> Edge version payload
+	prefixMVCCNodeHead     = byte(0x0E) // mvcc_node_head:nodeID -> MVCCHead
+	prefixMVCCEdgeHead     = byte(0x0F) // mvcc_edge_head:edgeID -> MVCCHead
+	prefixMVCCMeta         = byte(0x10) // mvcc_meta:* -> MVCC metadata (sequence, rebuild markers)
+	prefixEdgeBetweenIndex = byte(0x11) // edgebetween:start:end:type:edgeID -> []byte{} (direct relationship lookup)
 )
 
 // maxNodeSize is the maximum size for a node to be stored inline (50KB to leave room for BadgerDB overhead)
@@ -61,6 +62,7 @@ const (
 //   - Label Index: 0x03 + label + 0x00 + nodeID -> empty
 //   - Outgoing Index: 0x04 + nodeID + 0x00 + edgeID -> empty
 //   - Incoming Index: 0x05 + nodeID + 0x00 + edgeID -> empty
+//   - Edge-Between Index: 0x11 + startID + 0x00 + endID + 0x00 + type + 0x00 + edgeID -> empty
 //
 // Example:
 //
@@ -582,6 +584,11 @@ func NewBadgerEngineWithOptions(opts BadgerOptions) (*BadgerEngine, error) {
 	if err := engine.initializeCounts(); err != nil {
 		db.Close() // Clean up on error
 		return nil, fmt.Errorf("failed to initialize counts: %w", err)
+	}
+
+	if err := engine.ensureEdgeBetweenIndex(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to initialize edge-between index: %w", err)
 	}
 
 	// Load persisted schema definitions (per namespace) and rebuild derived caches.

--- a/pkg/storage/badger.go
+++ b/pkg/storage/badger.go
@@ -34,7 +34,8 @@ const (
 	prefixMVCCNodeHead     = byte(0x0E) // mvcc_node_head:nodeID -> MVCCHead
 	prefixMVCCEdgeHead     = byte(0x0F) // mvcc_edge_head:edgeID -> MVCCHead
 	prefixMVCCMeta         = byte(0x10) // mvcc_meta:* -> MVCC metadata (sequence, rebuild markers)
-	prefixEdgeBetweenIndex = byte(0x11) // edgebetween:start:end:type:edgeID -> []byte{} (direct relationship lookup)
+	prefixEdgeBetweenIndex = byte(0x11) // edgebetween_set:start:end:type:edgeID -> []byte{} (all exact relationship lookups)
+	prefixEdgeBetweenHead  = byte(0x12) // edgebetween_head:start:end:type -> edgeID (fast single relationship lookup)
 )
 
 // maxNodeSize is the maximum size for a node to be stored inline (50KB to leave room for BadgerDB overhead)
@@ -62,7 +63,8 @@ const (
 //   - Label Index: 0x03 + label + 0x00 + nodeID -> empty
 //   - Outgoing Index: 0x04 + nodeID + 0x00 + edgeID -> empty
 //   - Incoming Index: 0x05 + nodeID + 0x00 + edgeID -> empty
-//   - Edge-Between Index: 0x11 + startID + 0x00 + endID + 0x00 + type + 0x00 + edgeID -> empty
+//   - Edge-Between Set: 0x11 + startID + 0x00 + endID + 0x00 + type + 0x00 + edgeID -> empty
+//   - Edge-Between Head: 0x12 + startID + 0x00 + endID + 0x00 + type -> edgeID
 //
 // Example:
 //

--- a/pkg/storage/badger.go
+++ b/pkg/storage/badger.go
@@ -5,7 +5,9 @@
 package storage
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -36,6 +38,11 @@ const (
 	prefixMVCCMeta         = byte(0x10) // mvcc_meta:* -> MVCC metadata (sequence, rebuild markers)
 	prefixEdgeBetweenIndex = byte(0x11) // edgebetween_set:start:end:type:edgeID -> []byte{} (all exact relationship lookups)
 	prefixEdgeBetweenHead  = byte(0x12) // edgebetween_head:start:end:type -> edgeID (fast single relationship lookup)
+)
+
+// prefixMVCCMeta subkeys reserved by storage metadata records.
+const (
+	prefixMVCCMetaEdgeBetweenIndexReady = byte(0x02)
 )
 
 // maxNodeSize is the maximum size for a node to be stored inline (50KB to leave room for BadgerDB overhead)
@@ -128,6 +135,10 @@ type BadgerEngine struct {
 	namespaceCountsMu   sync.RWMutex
 	namespaceNodeCounts map[string]int64
 	namespaceEdgeCounts map[string]int64
+
+	edgeBetweenIndexBackfillMu     sync.Mutex
+	edgeBetweenIndexBackfillCancel context.CancelFunc
+	edgeBetweenIndexBackfillDone   chan struct{}
 
 	// Event callbacks for external coordination (search indexes, caches, etc.)
 	// These are fired AFTER storage operations succeed
@@ -595,11 +606,13 @@ func NewBadgerEngineWithOptions(opts BadgerOptions) (*BadgerEngine, error) {
 
 	// Load persisted schema definitions (per namespace) and rebuild derived caches.
 	if err := engine.loadPersistedSchemas(); err != nil {
+		engine.stopEdgeBetweenIndexBackfill()
 		db.Close()
 		return nil, fmt.Errorf("failed to load persisted schema: %w", err)
 	}
 
 	if err := engine.initializeMVCCSequence(); err != nil {
+		engine.stopEdgeBetweenIndexBackfill()
 		db.Close()
 		return nil, fmt.Errorf("failed to initialize mvcc sequence: %w", err)
 	}
@@ -641,7 +654,7 @@ func (b *BadgerEngine) loadPersistedMVCCSequence() (uint64, error) {
 	var seq uint64
 	err := b.db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(mvccSequenceKey())
-		if err == badger.ErrKeyNotFound {
+		if errors.Is(err, badger.ErrKeyNotFound) {
 			return nil
 		}
 		if err != nil {

--- a/pkg/storage/badger_backup.go
+++ b/pkg/storage/badger_backup.go
@@ -104,6 +104,7 @@ func (b *BadgerEngine) DeleteByPrefix(prefix string) (nodesDeleted int64, edgesD
 		append([]byte{prefixOutgoingIndex}, prefixBytes...),
 		append([]byte{prefixIncomingIndex}, prefixBytes...),
 		append([]byte{prefixEdgeBetweenIndex}, prefixBytes...),
+		append([]byte{prefixEdgeBetweenHead}, prefixBytes...),
 		append([]byte{prefixPendingEmbed}, prefixBytes...),
 		append([]byte{prefixEmbedding}, prefixBytes...),
 	}

--- a/pkg/storage/badger_backup.go
+++ b/pkg/storage/badger_backup.go
@@ -103,6 +103,7 @@ func (b *BadgerEngine) DeleteByPrefix(prefix string) (nodesDeleted int64, edgesD
 		edgeKeyPrefix,
 		append([]byte{prefixOutgoingIndex}, prefixBytes...),
 		append([]byte{prefixIncomingIndex}, prefixBytes...),
+		append([]byte{prefixEdgeBetweenIndex}, prefixBytes...),
 		append([]byte{prefixPendingEmbed}, prefixBytes...),
 		append([]byte{prefixEmbedding}, prefixBytes...),
 	}

--- a/pkg/storage/badger_bulk.go
+++ b/pkg/storage/badger_bulk.go
@@ -279,7 +279,7 @@ func (b *BadgerEngine) BulkCreateEdges(edges []*Edge) error {
 			if err := txn.Set(edgeTypeIndexKey(edge.Type, edge.ID), []byte{}); err != nil {
 				return err
 			}
-			if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+			if err := writeEdgeBetweenIndexesInTxn(txn, edge); err != nil {
 				return err
 			}
 			if err := b.writeEdgeMVCCVersionInTxn(txn, edge, version); err != nil {

--- a/pkg/storage/badger_bulk.go
+++ b/pkg/storage/badger_bulk.go
@@ -279,6 +279,9 @@ func (b *BadgerEngine) BulkCreateEdges(edges []*Edge) error {
 			if err := txn.Set(edgeTypeIndexKey(edge.Type, edge.ID), []byte{}); err != nil {
 				return err
 			}
+			if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+				return err
+			}
 			if err := b.writeEdgeMVCCVersionInTxn(txn, edge, version); err != nil {
 				return err
 			}

--- a/pkg/storage/badger_edge_between_index.go
+++ b/pkg/storage/badger_edge_between_index.go
@@ -2,54 +2,147 @@
 package storage
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/dgraph-io/badger/v4"
 )
 
-var edgeBetweenIndexReadyKey = []byte{prefixMVCCMeta, 0x02}
+var edgeBetweenIndexReadyKey = []byte{prefixMVCCMeta, prefixMVCCMetaEdgeBetweenIndexReady}
 
-const edgeBetweenIndexRebuildBatchSize = 50_000
+const (
+	edgeBetweenIndexRebuildBatchSize = 50_000
+	edgeBetweenIndexRebuildLogEvery  = 100_000
+)
 
-// ensureEdgeBetweenIndex backfills the direct relationship lookup index once.
+// ensureEdgeBetweenIndex schedules direct relationship lookup backfill once.
 //
-// Older Badger stores predate the edge-between index. Rebuilding on first open
-// preserves correctness for existing databases while keeping future startup
-// costs bounded by a small metadata marker.
+// Older Badger stores predate the edge-between indexes. Existing latest-state
+// reads can fall back to the outgoing-edge index and self-heal opportunistically,
+// so non-empty stores rebuild in the background instead of blocking open.
 func (b *BadgerEngine) ensureEdgeBetweenIndex() error {
-	var ready bool
-	if err := b.db.View(func(txn *badger.Txn) error {
-		_, err := txn.Get(edgeBetweenIndexReadyKey)
-		if err == nil {
-			ready = true
-			return nil
-		}
-		if err == badger.ErrKeyNotFound {
-			return nil
-		}
-		return err
-	}); err != nil {
+	ready, err := b.edgeBetweenIndexReady()
+	if err != nil {
 		return err
 	}
 	if ready {
 		return nil
 	}
 
-	return b.rebuildEdgeBetweenIndex()
+	hasEdges, err := b.hasAnyStoredEdges()
+	if err != nil {
+		return err
+	}
+	if !hasEdges {
+		return b.markEdgeBetweenIndexReady()
+	}
+
+	b.startEdgeBetweenIndexBackfill()
+	return nil
+}
+
+// edgeBetweenIndexReady reports whether the compatibility backfill completed.
+func (b *BadgerEngine) edgeBetweenIndexReady() (bool, error) {
+	var ready bool
+	err := b.db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get(edgeBetweenIndexReadyKey)
+		if err == nil {
+			ready = true
+			return nil
+		}
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	})
+	return ready, err
+}
+
+// hasAnyStoredEdges detects whether a startup rebuild has work to do.
+func (b *BadgerEngine) hasAnyStoredEdges() (bool, error) {
+	var hasEdges bool
+	err := b.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badgerIterOptsKeyOnly([]byte{prefixEdge}))
+		defer it.Close()
+		it.Rewind()
+		hasEdges = it.ValidForPrefix([]byte{prefixEdge})
+		return nil
+	})
+	return hasEdges, err
+}
+
+// markEdgeBetweenIndexReady records that no compatibility rebuild remains.
+func (b *BadgerEngine) markEdgeBetweenIndexReady() error {
+	return b.withUpdate(func(txn *badger.Txn) error {
+		return txn.Set(edgeBetweenIndexReadyKey, []byte{1})
+	})
+}
+
+// startEdgeBetweenIndexBackfill launches one cancellable background rebuild.
+func (b *BadgerEngine) startEdgeBetweenIndexBackfill() {
+	b.edgeBetweenIndexBackfillMu.Lock()
+	if b.edgeBetweenIndexBackfillDone != nil {
+		b.edgeBetweenIndexBackfillMu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	b.edgeBetweenIndexBackfillCancel = cancel
+	b.edgeBetweenIndexBackfillDone = done
+	b.edgeBetweenIndexBackfillMu.Unlock()
+
+	go func() {
+		defer close(done)
+		start := time.Now()
+		log.Printf("edge-between index backfill started")
+		processed, err := b.rebuildEdgeBetweenIndex(ctx)
+		switch {
+		case err == nil:
+			log.Printf("edge-between index backfill completed: edges=%d duration=%s", processed, time.Since(start))
+		case errors.Is(err, context.Canceled), errors.Is(err, ErrStorageClosed):
+			log.Printf("edge-between index backfill canceled: edges=%d duration=%s", processed, time.Since(start))
+		default:
+			log.Printf("edge-between index backfill failed: edges=%d duration=%s err=%v", processed, time.Since(start), err)
+		}
+	}()
+}
+
+// stopEdgeBetweenIndexBackfill cancels and waits for a running rebuild.
+func (b *BadgerEngine) stopEdgeBetweenIndexBackfill() {
+	b.edgeBetweenIndexBackfillMu.Lock()
+	cancel := b.edgeBetweenIndexBackfillCancel
+	done := b.edgeBetweenIndexBackfillDone
+	b.edgeBetweenIndexBackfillCancel = nil
+	b.edgeBetweenIndexBackfillDone = nil
+	b.edgeBetweenIndexBackfillMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
 }
 
 // rebuildEdgeBetweenIndex scans stored edges and writes direct lookup entries.
-func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
+func (b *BadgerEngine) rebuildEdgeBetweenIndex(ctx context.Context) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := b.db.DropPrefix([]byte{prefixEdgeBetweenIndex}); err != nil {
-		return fmt.Errorf("clear edge-between set index before rebuild: %w", err)
+		return 0, fmt.Errorf("clear edge-between set index before rebuild: %w", err)
 	}
 	if err := b.db.DropPrefix([]byte{prefixEdgeBetweenHead}); err != nil {
-		return fmt.Errorf("clear edge-between head index before rebuild: %w", err)
+		return 0, fmt.Errorf("clear edge-between head index before rebuild: %w", err)
 	}
 
 	batch := b.db.NewWriteBatch()
 	defer batch.Cancel()
 	batchCount := 0
+	processed := 0
 
 	flushBatch := func() error {
 		if batchCount == 0 {
@@ -69,6 +162,9 @@ func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 		defer it.Close()
 
 		for it.Rewind(); it.ValidForPrefix([]byte{prefixEdge}); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			item := it.Item()
 			if err := item.Value(func(val []byte) error {
 				edge, err := decodeEdge(val)
@@ -82,6 +178,10 @@ func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 					return err
 				}
 				batchCount++
+				processed++
+				if processed%edgeBetweenIndexRebuildLogEvery == 0 {
+					log.Printf("edge-between index backfill progress: edges=%d", processed)
+				}
 				if batchCount >= edgeBetweenIndexRebuildBatchSize {
 					return flushBatch()
 				}
@@ -92,14 +192,17 @@ func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 		}
 		return nil
 	}); err != nil {
-		return err
+		return processed, err
 	}
 
 	if err := flushBatch(); err != nil {
-		return err
+		return processed, err
 	}
 
-	return b.withUpdate(func(txn *badger.Txn) error {
+	if err := ctx.Err(); err != nil {
+		return processed, err
+	}
+	return processed, b.withUpdate(func(txn *badger.Txn) error {
 		return txn.Set(edgeBetweenIndexReadyKey, []byte{1})
 	})
 }

--- a/pkg/storage/badger_edge_between_index.go
+++ b/pkg/storage/badger_edge_between_index.go
@@ -1,0 +1,72 @@
+// Package storage provides storage engine implementations for NornicDB.
+package storage
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+var edgeBetweenIndexReadyKey = []byte{prefixMVCCMeta, 0x02}
+
+// ensureEdgeBetweenIndex backfills the direct relationship lookup index once.
+//
+// Older Badger stores predate the edge-between index. Rebuilding on first open
+// preserves correctness for existing databases while keeping future startup
+// costs bounded by a small metadata marker.
+func (b *BadgerEngine) ensureEdgeBetweenIndex() error {
+	var ready bool
+	if err := b.db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get(edgeBetweenIndexReadyKey)
+		if err == nil {
+			ready = true
+			return nil
+		}
+		if err == badger.ErrKeyNotFound {
+			return nil
+		}
+		return err
+	}); err != nil {
+		return err
+	}
+	if ready {
+		return nil
+	}
+
+	return b.rebuildEdgeBetweenIndex()
+}
+
+// rebuildEdgeBetweenIndex scans stored edges and writes direct lookup entries.
+func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
+	var edges []*Edge
+	if err := b.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badgerIterOptsKeyOnly([]byte{prefixEdge}))
+		defer it.Close()
+
+		for it.Rewind(); it.ValidForPrefix([]byte{prefixEdge}); it.Next() {
+			item := it.Item()
+			if err := item.Value(func(val []byte) error {
+				edge, err := decodeEdge(val)
+				if err != nil {
+					return fmt.Errorf("decode edge for edge-between index: %w", err)
+				}
+				edges = append(edges, edge)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return b.withUpdate(func(txn *badger.Txn) error {
+		for _, edge := range edges {
+			if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+				return err
+			}
+		}
+		return txn.Set(edgeBetweenIndexReadyKey, []byte{1})
+	})
+}

--- a/pkg/storage/badger_edge_between_index.go
+++ b/pkg/storage/badger_edge_between_index.go
@@ -9,6 +9,8 @@ import (
 
 var edgeBetweenIndexReadyKey = []byte{prefixMVCCMeta, 0x02}
 
+const edgeBetweenIndexRebuildBatchSize = 50_000
+
 // ensureEdgeBetweenIndex backfills the direct relationship lookup index once.
 //
 // Older Badger stores predate the edge-between index. Rebuilding on first open
@@ -38,9 +40,29 @@ func (b *BadgerEngine) ensureEdgeBetweenIndex() error {
 
 // rebuildEdgeBetweenIndex scans stored edges and writes direct lookup entries.
 func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
-	var edges []*Edge
+	if err := b.db.DropPrefix([]byte{prefixEdgeBetweenIndex}); err != nil {
+		return fmt.Errorf("clear edge-between index before rebuild: %w", err)
+	}
+
+	batch := b.db.NewWriteBatch()
+	defer batch.Cancel()
+	batchCount := 0
+
+	flushBatch := func() error {
+		if batchCount == 0 {
+			return nil
+		}
+		if err := batch.Flush(); err != nil {
+			return err
+		}
+		batch.Cancel()
+		batch = b.db.NewWriteBatch()
+		batchCount = 0
+		return nil
+	}
+
 	if err := b.db.View(func(txn *badger.Txn) error {
-		it := txn.NewIterator(badgerIterOptsKeyOnly([]byte{prefixEdge}))
+		it := txn.NewIterator(badgerIterOptsPrefetchValues([]byte{prefixEdge}, 100))
 		defer it.Close()
 
 		for it.Rewind(); it.ValidForPrefix([]byte{prefixEdge}); it.Next() {
@@ -50,7 +72,13 @@ func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 				if err != nil {
 					return fmt.Errorf("decode edge for edge-between index: %w", err)
 				}
-				edges = append(edges, edge)
+				if err := batch.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+					return err
+				}
+				batchCount++
+				if batchCount >= edgeBetweenIndexRebuildBatchSize {
+					return flushBatch()
+				}
 				return nil
 			}); err != nil {
 				return err
@@ -61,12 +89,11 @@ func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 		return err
 	}
 
+	if err := flushBatch(); err != nil {
+		return err
+	}
+
 	return b.withUpdate(func(txn *badger.Txn) error {
-		for _, edge := range edges {
-			if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
-				return err
-			}
-		}
 		return txn.Set(edgeBetweenIndexReadyKey, []byte{1})
 	})
 }

--- a/pkg/storage/badger_edge_between_index.go
+++ b/pkg/storage/badger_edge_between_index.go
@@ -41,7 +41,10 @@ func (b *BadgerEngine) ensureEdgeBetweenIndex() error {
 // rebuildEdgeBetweenIndex scans stored edges and writes direct lookup entries.
 func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 	if err := b.db.DropPrefix([]byte{prefixEdgeBetweenIndex}); err != nil {
-		return fmt.Errorf("clear edge-between index before rebuild: %w", err)
+		return fmt.Errorf("clear edge-between set index before rebuild: %w", err)
+	}
+	if err := b.db.DropPrefix([]byte{prefixEdgeBetweenHead}); err != nil {
+		return fmt.Errorf("clear edge-between head index before rebuild: %w", err)
 	}
 
 	batch := b.db.NewWriteBatch()
@@ -73,6 +76,9 @@ func (b *BadgerEngine) rebuildEdgeBetweenIndex() error {
 					return fmt.Errorf("decode edge for edge-between index: %w", err)
 				}
 				if err := batch.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+					return err
+				}
+				if err := batch.Set(edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type), []byte(edge.ID)); err != nil {
 					return err
 				}
 				batchCount++

--- a/pkg/storage/badger_edges.go
+++ b/pkg/storage/badger_edges.go
@@ -98,7 +98,7 @@ func (b *BadgerEngine) CreateEdge(edge *Edge) error {
 		if err := txn.Set(edgeTypeIndexKey(edge.Type, edge.ID), []byte{}); err != nil {
 			return err
 		}
-		if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+		if err := writeEdgeBetweenIndexesInTxn(txn, edge); err != nil {
 			return err
 		}
 		if err := b.writeEdgeMVCCVersionInTxn(txn, edge, version); err != nil {
@@ -215,7 +215,7 @@ func (b *BadgerEngine) UpdateEdge(edge *Edge) error {
 			if err := txn.Delete(incomingIndexKey(existing.EndNode, edge.ID)); err != nil {
 				return err
 			}
-			if err := txn.Delete(edgeBetweenIndexKey(existing.StartNode, existing.EndNode, existing.Type, edge.ID)); err != nil {
+			if err := deleteEdgeBetweenIndexesInTxn(txn, existing); err != nil {
 				return err
 			}
 
@@ -226,7 +226,7 @@ func (b *BadgerEngine) UpdateEdge(edge *Edge) error {
 			if err := txn.Set(incomingIndexKey(edge.EndNode, edge.ID), []byte{}); err != nil {
 				return err
 			}
-			if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+			if err := writeEdgeBetweenIndexesInTxn(txn, edge); err != nil {
 				return err
 			}
 		}
@@ -239,7 +239,7 @@ func (b *BadgerEngine) UpdateEdge(edge *Edge) error {
 				}
 			}
 			if existing.StartNode == edge.StartNode && existing.EndNode == edge.EndNode {
-				if err := txn.Delete(edgeBetweenIndexKey(existing.StartNode, existing.EndNode, existing.Type, edge.ID)); err != nil {
+				if err := deleteEdgeBetweenIndexesInTxn(txn, existing); err != nil {
 					return err
 				}
 			}
@@ -249,7 +249,7 @@ func (b *BadgerEngine) UpdateEdge(edge *Edge) error {
 				}
 			}
 			if existing.StartNode == edge.StartNode && existing.EndNode == edge.EndNode {
-				if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+				if err := writeEdgeBetweenIndexesInTxn(txn, edge); err != nil {
 					return err
 				}
 			}
@@ -357,7 +357,7 @@ func (b *BadgerEngine) deleteEdgeInTxn(txn *badger.Txn, id EdgeID) error {
 	if err := txn.Delete(edgeTypeIndexKey(edge.Type, id)); err != nil {
 		return err
 	}
-	if err := txn.Delete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, id)); err != nil {
+	if err := deleteEdgeBetweenIndexesInTxn(txn, edge); err != nil {
 		return err
 	}
 

--- a/pkg/storage/badger_edges.go
+++ b/pkg/storage/badger_edges.go
@@ -98,6 +98,9 @@ func (b *BadgerEngine) CreateEdge(edge *Edge) error {
 		if err := txn.Set(edgeTypeIndexKey(edge.Type, edge.ID), []byte{}); err != nil {
 			return err
 		}
+		if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+			return err
+		}
 		if err := b.writeEdgeMVCCVersionInTxn(txn, edge, version); err != nil {
 			return err
 		}
@@ -212,12 +215,18 @@ func (b *BadgerEngine) UpdateEdge(edge *Edge) error {
 			if err := txn.Delete(incomingIndexKey(existing.EndNode, edge.ID)); err != nil {
 				return err
 			}
+			if err := txn.Delete(edgeBetweenIndexKey(existing.StartNode, existing.EndNode, existing.Type, edge.ID)); err != nil {
+				return err
+			}
 
 			// Add new indexes
 			if err := txn.Set(outgoingIndexKey(edge.StartNode, edge.ID), []byte{}); err != nil {
 				return err
 			}
 			if err := txn.Set(incomingIndexKey(edge.EndNode, edge.ID), []byte{}); err != nil {
+				return err
+			}
+			if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
 				return err
 			}
 		}
@@ -229,8 +238,18 @@ func (b *BadgerEngine) UpdateEdge(edge *Edge) error {
 					return err
 				}
 			}
+			if existing.StartNode == edge.StartNode && existing.EndNode == edge.EndNode {
+				if err := txn.Delete(edgeBetweenIndexKey(existing.StartNode, existing.EndNode, existing.Type, edge.ID)); err != nil {
+					return err
+				}
+			}
 			if edge.Type != "" {
 				if err := txn.Set(edgeTypeIndexKey(edge.Type, edge.ID), []byte{}); err != nil {
+					return err
+				}
+			}
+			if existing.StartNode == edge.StartNode && existing.EndNode == edge.EndNode {
+				if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
 					return err
 				}
 			}
@@ -336,6 +355,9 @@ func (b *BadgerEngine) deleteEdgeInTxn(txn *badger.Txn, id EdgeID) error {
 		return err
 	}
 	if err := txn.Delete(edgeTypeIndexKey(edge.Type, id)); err != nil {
+		return err
+	}
+	if err := txn.Delete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, id)); err != nil {
 		return err
 	}
 

--- a/pkg/storage/badger_helpers.go
+++ b/pkg/storage/badger_helpers.go
@@ -247,6 +247,66 @@ func edgeBetweenIndexKey(startID, endID NodeID, edgeType string, edgeID EdgeID) 
 	return key
 }
 
+// edgeBetweenHeadKey stores the fastest typed lookup for one edge between nodes.
+//
+// The set index remains the source for GetEdgesBetween and for multiple edges
+// of the same type. The head is a compatibility-friendly accelerator: if it is
+// absent or stale, reads can fall back to the set or legacy outgoing scan and
+// repopulate it.
+func edgeBetweenHeadKey(startID, endID NodeID, edgeType string) []byte {
+	normalizedType := strings.ToLower(edgeType)
+	key := make([]byte, 0, 1+len(startID)+1+len(endID)+1+len(normalizedType))
+	key = append(key, prefixEdgeBetweenHead)
+	key = append(key, []byte(startID)...)
+	key = append(key, 0x00)
+	key = append(key, []byte(endID)...)
+	key = append(key, 0x00)
+	key = append(key, []byte(normalizedType)...)
+	return key
+}
+
+// writeEdgeBetweenIndexesInTxn maintains both relationship lookup indexes.
+func writeEdgeBetweenIndexesInTxn(txn *badger.Txn, edge *Edge) error {
+	if err := txn.Set(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{}); err != nil {
+		return err
+	}
+	return txn.Set(edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type), []byte(edge.ID))
+}
+
+// deleteEdgeBetweenIndexesInTxn removes an edge from the set index and clears
+// the head only when it points at the same edge.
+func deleteEdgeBetweenIndexesInTxn(txn *badger.Txn, edge *Edge) error {
+	if err := txn.Delete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID)); err != nil {
+		return err
+	}
+	return deleteEdgeBetweenHeadIfMatchesInTxn(txn, edge)
+}
+
+// deleteEdgeBetweenHeadIfMatchesInTxn avoids removing a head already advanced
+// to another same-type edge.
+func deleteEdgeBetweenHeadIfMatchesInTxn(txn *badger.Txn, edge *Edge) error {
+	key := edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type)
+	item, err := txn.Get(key)
+	if err == badger.ErrKeyNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var matches bool
+	if err := item.Value(func(val []byte) error {
+		matches = EdgeID(val) == edge.ID
+		return nil
+	}); err != nil {
+		return err
+	}
+	if !matches {
+		return nil
+	}
+	return txn.Delete(key)
+}
+
 // edgeBetweenIndexPrefix returns the prefix for all edges between two nodes.
 func edgeBetweenIndexPrefix(startID, endID NodeID) []byte {
 	key := make([]byte, 0, 1+len(startID)+1+len(endID)+1)

--- a/pkg/storage/badger_helpers.go
+++ b/pkg/storage/badger_helpers.go
@@ -228,6 +228,45 @@ func edgeTypeIndexPrefix(edgeType string) []byte {
 	return key
 }
 
+// edgeBetweenIndexKey stores an exact relationship lookup entry.
+//
+// The key order lets GetEdgesBetween scan by start/end and lets GetEdgeBetween
+// narrow further by relationship type without scanning every outgoing edge from
+// the start node.
+func edgeBetweenIndexKey(startID, endID NodeID, edgeType string, edgeID EdgeID) []byte {
+	normalizedType := strings.ToLower(edgeType)
+	key := make([]byte, 0, 1+len(startID)+1+len(endID)+1+len(normalizedType)+1+len(edgeID))
+	key = append(key, prefixEdgeBetweenIndex)
+	key = append(key, []byte(startID)...)
+	key = append(key, 0x00)
+	key = append(key, []byte(endID)...)
+	key = append(key, 0x00)
+	key = append(key, []byte(normalizedType)...)
+	key = append(key, 0x00)
+	key = append(key, []byte(edgeID)...)
+	return key
+}
+
+// edgeBetweenIndexPrefix returns the prefix for all edges between two nodes.
+func edgeBetweenIndexPrefix(startID, endID NodeID) []byte {
+	key := make([]byte, 0, 1+len(startID)+1+len(endID)+1)
+	key = append(key, prefixEdgeBetweenIndex)
+	key = append(key, []byte(startID)...)
+	key = append(key, 0x00)
+	key = append(key, []byte(endID)...)
+	key = append(key, 0x00)
+	return key
+}
+
+// typedEdgeBetweenIndexPrefix returns the prefix for edges of one type between two nodes.
+func typedEdgeBetweenIndexPrefix(startID, endID NodeID, edgeType string) []byte {
+	normalizedType := strings.ToLower(edgeType)
+	key := edgeBetweenIndexPrefix(startID, endID)
+	key = append(key, []byte(normalizedType)...)
+	key = append(key, 0x00)
+	return key
+}
+
 // pendingEmbedKey creates a key for the pending embeddings index.
 // Format: prefix + nodeID
 func pendingEmbedKey(nodeID NodeID) []byte {
@@ -272,6 +311,23 @@ func extractEdgeIDFromIndexKey(key []byte) EdgeID {
 	// Find the separator (0x00) - reverse iteration (separator typically near end)
 	for i := len(key) - 1; i >= 1; i-- {
 		if key[i] == 0x00 {
+			return EdgeID(key[i+1:])
+		}
+	}
+	return ""
+}
+
+// extractEdgeIDFromEdgeBetweenIndexKey returns the edge ID suffix from an
+// edge-between index entry.
+func extractEdgeIDFromEdgeBetweenIndexKey(key []byte) EdgeID {
+	if len(key) < 2 || key[0] != prefixEdgeBetweenIndex {
+		return ""
+	}
+	for i := len(key) - 1; i >= 1; i-- {
+		if key[i] == 0x00 {
+			if i+1 >= len(key) {
+				return ""
+			}
 			return EdgeID(key[i+1:])
 		}
 	}

--- a/pkg/storage/badger_mvcc_behavior_test.go
+++ b/pkg/storage/badger_mvcc_behavior_test.go
@@ -535,6 +535,34 @@ func TestBadgerEngine_MVCCIndexedVisibilityAtSnapshot(t *testing.T) {
 	require.Equal(t, "PUBLISHED_LINK", betweenAtV2[0].Type)
 }
 
+func TestBadgerEngine_MVCCBetweenVisibleAtIgnoresLatestEdgeBetweenIndex(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	start := NodeID(prefixTestID("mvcc-between-index-start"))
+	end := NodeID(prefixTestID("mvcc-between-index-end"))
+	_, err := engine.CreateNode(&Node{ID: start, Labels: []string{"Doc"}})
+	require.NoError(t, err)
+	_, err = engine.CreateNode(&Node{ID: end, Labels: []string{"Doc"}})
+	require.NoError(t, err)
+
+	first := &Edge{ID: EdgeID(prefixTestID("mvcc-between-index-e1")), StartNode: start, EndNode: end, Type: "OLD_LINK"}
+	require.NoError(t, engine.CreateEdge(first))
+	firstHead, err := engine.GetEdgeCurrentHead(first.ID)
+	require.NoError(t, err)
+	require.NoError(t, engine.DeleteEdge(first.ID))
+	second := &Edge{ID: EdgeID(prefixTestID("mvcc-between-index-e2")), StartNode: start, EndNode: end, Type: "NEW_LINK"}
+	require.NoError(t, engine.CreateEdge(second))
+
+	require.NotNil(t, engine.GetEdgeBetween(start, end, "NEW_LINK"))
+	requireEdgeBetweenIndexEntry(t, engine, start, end, "NEW_LINK", second.ID, true)
+
+	betweenAtFirst, err := engine.GetEdgesBetweenVisibleAt(start, end, firstHead.Version)
+	require.NoError(t, err)
+	require.Len(t, betweenAtFirst, 1)
+	require.Equal(t, first.ID, betweenAtFirst[0].ID)
+	require.Equal(t, "OLD_LINK", betweenAtFirst[0].Type)
+}
+
 func TestMVCCWrappers_FallbackLatestButRejectSnapshotWhenUnsupported(t *testing.T) {
 	baseInner := NewMemoryEngine()
 	t.Cleanup(func() { _ = baseInner.Close() })

--- a/pkg/storage/badger_queries.go
+++ b/pkg/storage/badger_queries.go
@@ -3,10 +3,15 @@ package storage
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"log"
 	"strings"
 
 	"github.com/dgraph-io/badger/v4"
 )
+
+const edgeBetweenSelfHealMaxEdges = 64
 
 // Query Operations
 // ============================================================================
@@ -415,7 +420,7 @@ func (b *BadgerEngine) HasLabelBatch(ids []NodeID, label string) (map[NodeID]boo
 				result[id] = true
 				continue
 			}
-			if err == badger.ErrKeyNotFound {
+			if errors.Is(err, badger.ErrKeyNotFound) {
 				continue
 			}
 			return err
@@ -551,7 +556,11 @@ func (b *BadgerEngine) GetEdgeBetween(source, target NodeID, edgeType string) *E
 		return nil
 	}
 	if edgeType != "" {
-		if edge, err := b.edgeBetweenFromHeadIndex(source, target, edgeType); err == nil && edge != nil {
+		edge, err := b.edgeBetweenFromHeadIndex(source, target, edgeType)
+		if err != nil {
+			log.Printf("edge-between head lookup failed; falling back to set/legacy scan: start=%q end=%q type=%q err=%v", source, target, edgeType, err)
+		}
+		if edge != nil {
 			return edge
 		}
 	}
@@ -576,7 +585,7 @@ func (b *BadgerEngine) edgeBetweenFromHeadIndex(source, target NodeID, edgeType 
 	var result *Edge
 	err := b.withView(func(txn *badger.Txn) error {
 		item, err := txn.Get(edgeBetweenHeadKey(source, target, edgeType))
-		if err == badger.ErrKeyNotFound {
+		if errors.Is(err, badger.ErrKeyNotFound) {
 			return nil
 		}
 		if err != nil {
@@ -591,7 +600,7 @@ func (b *BadgerEngine) edgeBetweenFromHeadIndex(source, target NodeID, edgeType 
 		}
 		edge, err := edgeFromTxn(txn, edgeID)
 		if err != nil {
-			return nil
+			return fmt.Errorf("load edge-between head edge %q: %w", edgeID, err)
 		}
 		if edgeMatchesBetween(edge, source, target, edgeType) {
 			result = edge
@@ -656,7 +665,10 @@ func (b *BadgerEngine) edgesBetweenFromLegacyOutgoingIndex(startID, endID NodeID
 // selfHealEdgeBetweenIndexes repairs lookup indexes discovered through a
 // fallback read, preventing ready-marker drift from becoming a correctness bug.
 func (b *BadgerEngine) selfHealEdgeBetweenIndexes(edges []*Edge) error {
-	return b.withUpdate(func(txn *badger.Txn) error {
+	if len(edges) > edgeBetweenSelfHealMaxEdges {
+		edges = edges[:edgeBetweenSelfHealMaxEdges]
+	}
+	err := b.withUpdate(func(txn *badger.Txn) error {
 		for _, edge := range edges {
 			if edge == nil {
 				continue
@@ -667,6 +679,11 @@ func (b *BadgerEngine) selfHealEdgeBetweenIndexes(edges []*Edge) error {
 		}
 		return nil
 	})
+	if errors.Is(err, badger.ErrConflict) {
+		log.Printf("edge-between index self-heal skipped after Badger conflict")
+		return nil
+	}
+	return err
 }
 
 // edgeMatchesBetween rejects stale secondary-index entries before returning an

--- a/pkg/storage/badger_queries.go
+++ b/pkg/storage/badger_queries.go
@@ -526,34 +526,20 @@ func (b *BadgerEngine) GetEdgesBetween(startID, endID NodeID) ([]*Edge, error) {
 		return nil, ErrInvalidID
 	}
 
-	b.mu.RLock()
-	if b.closed {
-		b.mu.RUnlock()
-		return nil, ErrStorageClosed
-	}
-	b.mu.RUnlock()
-
-	var result []*Edge
-	err := b.withView(func(txn *badger.Txn) error {
-		prefix := edgeBetweenIndexPrefix(startID, endID)
-		it := txn.NewIterator(badgerIterOptsKeyOnly(prefix))
-		defer it.Close()
-
-		for it.Rewind(); it.ValidForPrefix(prefix); it.Next() {
-			edgeID := extractEdgeIDFromEdgeBetweenIndexKey(it.Item().Key())
-			if edgeID == "" {
-				continue
-			}
-			edge, err := edgeFromTxn(txn, edgeID)
-			if err != nil {
-				continue
-			}
-			result = append(result, edge)
-		}
-		return nil
-	})
+	result, err := b.edgesBetweenFromSetIndex(startID, endID, "")
 	if err != nil {
 		return nil, err
+	}
+	if len(result) > 0 {
+		return result, nil
+	}
+
+	result, err = b.edgesBetweenFromLegacyOutgoingIndex(startID, endID, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(result) > 0 {
+		_ = b.selfHealEdgeBetweenIndexes(result)
 	}
 
 	return result, nil
@@ -564,11 +550,64 @@ func (b *BadgerEngine) GetEdgeBetween(source, target NodeID, edgeType string) *E
 	if source == "" || target == "" {
 		return nil
 	}
+	if edgeType != "" {
+		if edge, err := b.edgeBetweenFromHeadIndex(source, target, edgeType); err == nil && edge != nil {
+			return edge
+		}
+	}
+
+	indexed, err := b.edgesBetweenFromSetIndex(source, target, edgeType)
+	if err == nil && len(indexed) > 0 {
+		_ = b.selfHealEdgeBetweenIndexes(indexed[:1])
+		return indexed[0]
+	}
+
+	legacy, err := b.edgesBetweenFromLegacyOutgoingIndex(source, target, edgeType)
+	if err == nil && len(legacy) > 0 {
+		_ = b.selfHealEdgeBetweenIndexes(legacy)
+		return legacy[0]
+	}
+
+	return nil
+}
+
+// edgeBetweenFromHeadIndex loads the typed common-case lookup without scanning.
+func (b *BadgerEngine) edgeBetweenFromHeadIndex(source, target NodeID, edgeType string) (*Edge, error) {
 	var result *Edge
-	_ = b.withView(func(txn *badger.Txn) error {
-		prefix := edgeBetweenIndexPrefix(source, target)
+	err := b.withView(func(txn *badger.Txn) error {
+		item, err := txn.Get(edgeBetweenHeadKey(source, target, edgeType))
+		if err == badger.ErrKeyNotFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		var edgeID EdgeID
+		if err := item.Value(func(val []byte) error {
+			edgeID = EdgeID(append([]byte(nil), val...))
+			return nil
+		}); err != nil {
+			return err
+		}
+		edge, err := edgeFromTxn(txn, edgeID)
+		if err != nil {
+			return nil
+		}
+		if edgeMatchesBetween(edge, source, target, edgeType) {
+			result = edge
+		}
+		return nil
+	})
+	return result, err
+}
+
+// edgesBetweenFromSetIndex scans the exact relationship set index.
+func (b *BadgerEngine) edgesBetweenFromSetIndex(startID, endID NodeID, edgeType string) ([]*Edge, error) {
+	var result []*Edge
+	err := b.withView(func(txn *badger.Txn) error {
+		prefix := edgeBetweenIndexPrefix(startID, endID)
 		if edgeType != "" {
-			prefix = typedEdgeBetweenIndexPrefix(source, target, edgeType)
+			prefix = typedEdgeBetweenIndexPrefix(startID, endID, edgeType)
 		}
 		it := txn.NewIterator(badgerIterOptsKeyOnly(prefix))
 		defer it.Close()
@@ -579,15 +618,64 @@ func (b *BadgerEngine) GetEdgeBetween(source, target NodeID, edgeType string) *E
 				continue
 			}
 			edge, err := edgeFromTxn(txn, edgeID)
-			if err != nil {
+			if err != nil || !edgeMatchesBetween(edge, startID, endID, edgeType) {
 				continue
 			}
-			result = edge
-			return nil
+			result = append(result, edge)
 		}
 		return nil
 	})
-	return result
+	return result, err
+}
+
+// edgesBetweenFromLegacyOutgoingIndex preserves compatibility with stores that
+// predate the edge-between indexes or missed a self-heal/backfill window.
+func (b *BadgerEngine) edgesBetweenFromLegacyOutgoingIndex(startID, endID NodeID, edgeType string) ([]*Edge, error) {
+	var result []*Edge
+	err := b.withView(func(txn *badger.Txn) error {
+		prefix := outgoingIndexPrefix(startID)
+		it := txn.NewIterator(badgerIterOptsKeyOnly(prefix))
+		defer it.Close()
+
+		for it.Rewind(); it.ValidForPrefix(prefix); it.Next() {
+			edgeID := extractEdgeIDFromIndexKey(it.Item().Key())
+			if edgeID == "" {
+				continue
+			}
+			edge, err := edgeFromTxn(txn, edgeID)
+			if err != nil || !edgeMatchesBetween(edge, startID, endID, edgeType) {
+				continue
+			}
+			result = append(result, edge)
+		}
+		return nil
+	})
+	return result, err
+}
+
+// selfHealEdgeBetweenIndexes repairs lookup indexes discovered through a
+// fallback read, preventing ready-marker drift from becoming a correctness bug.
+func (b *BadgerEngine) selfHealEdgeBetweenIndexes(edges []*Edge) error {
+	return b.withUpdate(func(txn *badger.Txn) error {
+		for _, edge := range edges {
+			if edge == nil {
+				continue
+			}
+			if err := writeEdgeBetweenIndexesInTxn(txn, edge); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// edgeMatchesBetween rejects stale secondary-index entries before returning an
+// edge from either the head, set, or legacy fallback path.
+func edgeMatchesBetween(edge *Edge, startID, endID NodeID, edgeType string) bool {
+	if edge == nil || edge.StartNode != startID || edge.EndNode != endID {
+		return false
+	}
+	return edgeType == "" || strings.EqualFold(edge.Type, edgeType)
 }
 
 // edgeFromTxn loads an edge record while callers iterate a secondary index.

--- a/pkg/storage/badger_queries.go
+++ b/pkg/storage/badger_queries.go
@@ -533,16 +533,27 @@ func (b *BadgerEngine) GetEdgesBetween(startID, endID NodeID) ([]*Edge, error) {
 	}
 	b.mu.RUnlock()
 
-	outgoing, err := b.GetOutgoingEdges(startID)
-	if err != nil {
-		return nil, err
-	}
-
 	var result []*Edge
-	for _, edge := range outgoing {
-		if edge.EndNode == endID {
+	err := b.withView(func(txn *badger.Txn) error {
+		prefix := edgeBetweenIndexPrefix(startID, endID)
+		it := txn.NewIterator(badgerIterOptsKeyOnly(prefix))
+		defer it.Close()
+
+		for it.Rewind(); it.ValidForPrefix(prefix); it.Next() {
+			edgeID := extractEdgeIDFromEdgeBetweenIndexKey(it.Item().Key())
+			if edgeID == "" {
+				continue
+			}
+			edge, err := edgeFromTxn(txn, edgeID)
+			if err != nil {
+				continue
+			}
 			result = append(result, edge)
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return result, nil
@@ -550,18 +561,50 @@ func (b *BadgerEngine) GetEdgesBetween(startID, endID NodeID) ([]*Edge, error) {
 
 // GetEdgeBetween returns an edge between two nodes with the given type.
 func (b *BadgerEngine) GetEdgeBetween(source, target NodeID, edgeType string) *Edge {
-	edges, err := b.GetEdgesBetween(source, target)
-	if err != nil {
+	if source == "" || target == "" {
 		return nil
 	}
-
-	for _, edge := range edges {
-		if edgeType == "" || edge.Type == edgeType {
-			return edge
+	var result *Edge
+	_ = b.withView(func(txn *badger.Txn) error {
+		prefix := edgeBetweenIndexPrefix(source, target)
+		if edgeType != "" {
+			prefix = typedEdgeBetweenIndexPrefix(source, target, edgeType)
 		}
-	}
+		it := txn.NewIterator(badgerIterOptsKeyOnly(prefix))
+		defer it.Close()
 
-	return nil
+		for it.Rewind(); it.ValidForPrefix(prefix); it.Next() {
+			edgeID := extractEdgeIDFromEdgeBetweenIndexKey(it.Item().Key())
+			if edgeID == "" {
+				continue
+			}
+			edge, err := edgeFromTxn(txn, edgeID)
+			if err != nil {
+				continue
+			}
+			result = edge
+			return nil
+		}
+		return nil
+	})
+	return result
+}
+
+// edgeFromTxn loads an edge record while callers iterate a secondary index.
+func edgeFromTxn(txn *badger.Txn, edgeID EdgeID) (*Edge, error) {
+	item, err := txn.Get(edgeKey(edgeID))
+	if err != nil {
+		return nil, err
+	}
+	var edge *Edge
+	if err := item.Value(func(val []byte) error {
+		var decodeErr error
+		edge, decodeErr = decodeEdge(val)
+		return decodeErr
+	}); err != nil {
+		return nil, err
+	}
+	return edge, nil
 }
 
 // ============================================================================

--- a/pkg/storage/badger_stats.go
+++ b/pkg/storage/badger_stats.go
@@ -175,6 +175,8 @@ func (b *BadgerEngine) GetSchema() *SchemaManager {
 
 // Close closes the BadgerDB database.
 func (b *BadgerEngine) Close() error {
+	b.stopEdgeBetweenIndexBackfill()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/pkg/storage/badger_test.go
+++ b/pkg/storage/badger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -740,6 +741,63 @@ func TestBadgerEngine_GetEdgeBetween(t *testing.T) {
 		edge := engine.GetEdgeBetween(NodeID(prefixTestID("n1")), NodeID(prefixTestID("n2")), "BLOCKS")
 		assert.Nil(t, edge)
 	})
+}
+
+func TestBadgerEngine_GetEdgeBetweenIndexMaintenance(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	n1 := testNode("edge-index-n1")
+	n2 := testNode("edge-index-n2")
+	n3 := testNode("edge-index-n3")
+	_, err := engine.CreateNode(n1)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n2)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n3)
+	require.NoError(t, err)
+
+	edge := testEdge("edge-index-e1", n1.ID, n2.ID, "KNOWS")
+	require.NoError(t, engine.CreateEdge(edge))
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
+
+	updated := copyEdge(edge)
+	updated.EndNode = n3.ID
+	updated.Type = "FOLLOWS"
+	require.NoError(t, engine.UpdateEdge(updated))
+
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "FOLLOWS", edge.ID, true)
+	assert.Nil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
+	require.NotNil(t, engine.GetEdgeBetween(n1.ID, n3.ID, "FOLLOWS"))
+
+	require.NoError(t, engine.DeleteEdge(edge.ID))
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "FOLLOWS", edge.ID, false)
+	assert.Nil(t, engine.GetEdgeBetween(n1.ID, n3.ID, "FOLLOWS"))
+}
+
+func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	n1 := testNode("edge-index-backfill-n1")
+	n2 := testNode("edge-index-backfill-n2")
+	_, err := engine.CreateNode(n1)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n2)
+	require.NoError(t, err)
+
+	edge := testEdge("edge-index-backfill-e1", n1.ID, n2.ID, "KNOWS")
+	require.NoError(t, engine.CreateEdge(edge))
+	require.NoError(t, engine.withUpdate(func(txn *badger.Txn) error {
+		if err := txn.Delete(edgeBetweenIndexKey(n1.ID, n2.ID, "KNOWS", edge.ID)); err != nil {
+			return err
+		}
+		return txn.Delete(edgeBetweenIndexReadyKey)
+	}))
+
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
+	require.NoError(t, engine.ensureEdgeBetweenIndex())
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
+	require.NotNil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
 }
 
 // ============================================================================
@@ -1501,10 +1559,70 @@ func TestKeyEncoding(t *testing.T) {
 		assert.Equal(t, EdgeID(prefixTestID("edge-1")), edgeID)
 	})
 
+	t.Run("edgeBetweenIndexKey and extraction", func(t *testing.T) {
+		key := edgeBetweenIndexKey(
+			NodeID(prefixTestID("node-1")),
+			NodeID(prefixTestID("node-2")),
+			"KNOWS",
+			EdgeID(prefixTestID("edge-1")),
+		)
+		assert.Equal(t, prefixEdgeBetweenIndex, key[0])
+		assert.Equal(t, EdgeID(prefixTestID("edge-1")), extractEdgeIDFromEdgeBetweenIndexKey(key))
+		assert.True(t, hasBytePrefix(key, edgeBetweenIndexPrefix(NodeID(prefixTestID("node-1")), NodeID(prefixTestID("node-2")))))
+		assert.True(t, hasBytePrefix(key, typedEdgeBetweenIndexPrefix(NodeID(prefixTestID("node-1")), NodeID(prefixTestID("node-2")), "knows")))
+	})
+
 	t.Run("extract helpers return empty on malformed keys", func(t *testing.T) {
 		assert.Equal(t, EdgeID(""), extractEdgeIDFromIndexKey([]byte{prefixOutgoingIndex, 'x', 'y'}))
+		assert.Equal(t, EdgeID(""), extractEdgeIDFromEdgeBetweenIndexKey([]byte{prefixEdgeBetweenIndex, 'x', 'y'}))
 		assert.Equal(t, NodeID(""), extractNodeIDFromLabelIndex([]byte{prefixLabelIndex, 'P', 'e'}, len("Person")))
 	})
+}
+
+// requireEdgeBetweenIndexEntry verifies the direct relationship-existence index
+// entry without using GetEdgeBetween, so the test catches accidental scan-only
+// regressions in the storage layer.
+func requireEdgeBetweenIndexEntry(
+	t *testing.T,
+	engine *BadgerEngine,
+	startID NodeID,
+	endID NodeID,
+	edgeType string,
+	edgeID EdgeID,
+	want bool,
+) {
+	t.Helper()
+
+	key := edgeBetweenIndexKey(startID, endID, edgeType, edgeID)
+	var exists bool
+	err := engine.withView(func(txn *badger.Txn) error {
+		_, err := txn.Get(key)
+		if err == nil {
+			exists = true
+			return nil
+		}
+		if err == badger.ErrKeyNotFound {
+			exists = false
+			return nil
+		}
+		return err
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want, exists)
+}
+
+// hasBytePrefix keeps key-encoding assertions local to storage tests without
+// pulling in bytes.HasPrefix just for one small invariant check.
+func hasBytePrefix(value, prefix []byte) bool {
+	if len(prefix) > len(value) {
+		return false
+	}
+	for i := range prefix {
+		if value[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // ============================================================================

--- a/pkg/storage/badger_test.go
+++ b/pkg/storage/badger_test.go
@@ -827,6 +827,39 @@ func TestBadgerEngine_GetEdgesBetweenKeepsSameTypeSetWithHead(t *testing.T) {
 	assert.NotNil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
 }
 
+func TestBadgerEngine_GetEdgesBetweenSelfHealIsBounded(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	n1 := testNode("edge-heal-bound-n1")
+	n2 := testNode("edge-heal-bound-n2")
+	_, err := engine.CreateNode(n1)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n2)
+	require.NoError(t, err)
+
+	edgeCount := edgeBetweenSelfHealMaxEdges + 5
+	for i := 0; i < edgeCount; i++ {
+		edge := testEdge(
+			fmt.Sprintf("edge-heal-bound-e-%03d", i),
+			n1.ID,
+			n2.ID,
+			fmt.Sprintf("REL_%03d", i),
+		)
+		require.NoError(t, engine.CreateEdge(edge))
+		require.NoError(t, engine.withUpdate(func(txn *badger.Txn) error {
+			if err := txn.Delete(edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type)); err != nil {
+				return err
+			}
+			return txn.Delete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID))
+		}))
+	}
+
+	edges, err := engine.GetEdgesBetween(n1.ID, n2.ID)
+	require.NoError(t, err)
+	require.Len(t, edges, edgeCount)
+	assert.Equal(t, edgeBetweenSelfHealMaxEdges, countEdgeBetweenSetEntries(t, engine, n1.ID, n2.ID))
+}
+
 func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
 	engine := createTestBadgerEngine(t)
 
@@ -860,10 +893,50 @@ func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "STALE", staleEdgeID, true)
 	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
 	require.NoError(t, engine.ensureEdgeBetweenIndex())
+	require.Eventually(t, func() bool {
+		return edgeBetweenIndexReady(t, engine) &&
+			hasEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID)
+	}, 2*time.Second, 20*time.Millisecond)
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "STALE", staleEdgeID, false)
-	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
 	require.NotNil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
+}
+
+func TestBadgerEngine_EdgeBetweenIndexBackfillRepairsStoreAsynchronously(t *testing.T) {
+	dir := t.TempDir()
+	engine, err := NewBadgerEngine(dir)
+	require.NoError(t, err)
+
+	n1 := testNode("edge-index-async-n1")
+	n2 := testNode("edge-index-async-n2")
+	_, err = engine.CreateNode(n1)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n2)
+	require.NoError(t, err)
+	edge := testEdge("edge-index-async-e1", n1.ID, n2.ID, "KNOWS")
+	require.NoError(t, engine.CreateEdge(edge))
+	require.NoError(t, engine.withUpdate(func(txn *badger.Txn) error {
+		if err := txn.Delete(edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type)); err != nil {
+			return err
+		}
+		if err := txn.Delete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID)); err != nil {
+			return err
+		}
+		return txn.Delete(edgeBetweenIndexReadyKey)
+	}))
+	require.NoError(t, engine.Close())
+
+	reopened, err := NewBadgerEngine(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	got := reopened.GetEdgeBetween(n1.ID, n2.ID, "KNOWS")
+	require.NotNil(t, got)
+	assert.Equal(t, edge.ID, got.ID)
+	require.Eventually(t, func() bool {
+		return edgeBetweenIndexReady(t, reopened) &&
+			hasEdgeBetweenHeadEntry(t, reopened, n1.ID, n2.ID, "KNOWS", edge.ID)
+	}, 2*time.Second, 20*time.Millisecond)
 }
 
 // ============================================================================
@@ -1683,6 +1756,74 @@ func requireEdgeBetweenHeadEntry(
 	})
 	require.NoError(t, err)
 	assert.Equal(t, want, exists)
+}
+
+// hasEdgeBetweenHeadEntry reports whether the typed head points at edgeID.
+func hasEdgeBetweenHeadEntry(
+	t *testing.T,
+	engine *BadgerEngine,
+	startID NodeID,
+	endID NodeID,
+	edgeType string,
+	edgeID EdgeID,
+) bool {
+	t.Helper()
+
+	key := edgeBetweenHeadKey(startID, endID, edgeType)
+	var exists bool
+	err := engine.withView(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if err == nil {
+			return item.Value(func(val []byte) error {
+				exists = EdgeID(val) == edgeID
+				return nil
+			})
+		}
+		if err == badger.ErrKeyNotFound {
+			return nil
+		}
+		return err
+	})
+	require.NoError(t, err)
+	return exists
+}
+
+// countEdgeBetweenSetEntries counts set-index entries for one node pair.
+func countEdgeBetweenSetEntries(t *testing.T, engine *BadgerEngine, startID, endID NodeID) int {
+	t.Helper()
+
+	count := 0
+	prefix := edgeBetweenIndexPrefix(startID, endID)
+	err := engine.withView(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badgerIterOptsKeyOnly(prefix))
+		defer it.Close()
+		for it.Rewind(); it.ValidForPrefix(prefix); it.Next() {
+			count++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return count
+}
+
+// edgeBetweenIndexReady reports whether the startup backfill marker is present.
+func edgeBetweenIndexReady(t *testing.T, engine *BadgerEngine) bool {
+	t.Helper()
+
+	var ready bool
+	err := engine.withView(func(txn *badger.Txn) error {
+		_, err := txn.Get(edgeBetweenIndexReadyKey)
+		if err == nil {
+			ready = true
+			return nil
+		}
+		if err == badger.ErrKeyNotFound {
+			return nil
+		}
+		return err
+	})
+	require.NoError(t, err)
+	return ready
 }
 
 // requireEdgeBetweenIndexEntry verifies the direct relationship-existence index

--- a/pkg/storage/badger_test.go
+++ b/pkg/storage/badger_test.go
@@ -780,23 +780,32 @@ func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
 
 	n1 := testNode("edge-index-backfill-n1")
 	n2 := testNode("edge-index-backfill-n2")
+	n3 := testNode("edge-index-backfill-n3")
 	_, err := engine.CreateNode(n1)
 	require.NoError(t, err)
 	_, err = engine.CreateNode(n2)
 	require.NoError(t, err)
+	_, err = engine.CreateNode(n3)
+	require.NoError(t, err)
 
 	edge := testEdge("edge-index-backfill-e1", n1.ID, n2.ID, "KNOWS")
+	staleEdgeID := EdgeID(prefixTestID("edge-index-backfill-stale"))
 	require.NoError(t, engine.CreateEdge(edge))
 	require.NoError(t, engine.withUpdate(func(txn *badger.Txn) error {
 		if err := txn.Delete(edgeBetweenIndexKey(n1.ID, n2.ID, "KNOWS", edge.ID)); err != nil {
+			return err
+		}
+		if err := txn.Set(edgeBetweenIndexKey(n1.ID, n3.ID, "STALE", staleEdgeID), []byte{}); err != nil {
 			return err
 		}
 		return txn.Delete(edgeBetweenIndexReadyKey)
 	}))
 
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "STALE", staleEdgeID, true)
 	require.NoError(t, engine.ensureEdgeBetweenIndex())
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "STALE", staleEdgeID, false)
 	require.NotNil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
 }
 

--- a/pkg/storage/badger_test.go
+++ b/pkg/storage/badger_test.go
@@ -775,6 +775,58 @@ func TestBadgerEngine_GetEdgeBetweenIndexMaintenance(t *testing.T) {
 	assert.Nil(t, engine.GetEdgeBetween(n1.ID, n3.ID, "FOLLOWS"))
 }
 
+func TestBadgerEngine_GetEdgeBetweenHeadIndexSelfHealsFromLegacyScan(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	n1 := testNode("edge-head-heal-n1")
+	n2 := testNode("edge-head-heal-n2")
+	_, err := engine.CreateNode(n1)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n2)
+	require.NoError(t, err)
+
+	edge := testEdge("edge-head-heal-e1", n1.ID, n2.ID, "KNOWS")
+	require.NoError(t, engine.CreateEdge(edge))
+	require.NoError(t, engine.withUpdate(func(txn *badger.Txn) error {
+		if err := txn.Delete(edgeBetweenHeadKey(n1.ID, n2.ID, "KNOWS")); err != nil {
+			return err
+		}
+		return txn.Delete(edgeBetweenIndexKey(n1.ID, n2.ID, "KNOWS", edge.ID))
+	}))
+
+	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
+	got := engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS")
+	require.NotNil(t, got)
+	assert.Equal(t, edge.ID, got.ID)
+	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
+}
+
+func TestBadgerEngine_GetEdgesBetweenKeepsSameTypeSetWithHead(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	n1 := testNode("edge-head-set-n1")
+	n2 := testNode("edge-head-set-n2")
+	_, err := engine.CreateNode(n1)
+	require.NoError(t, err)
+	_, err = engine.CreateNode(n2)
+	require.NoError(t, err)
+
+	first := testEdge("edge-head-set-e1", n1.ID, n2.ID, "KNOWS")
+	second := testEdge("edge-head-set-e2", n1.ID, n2.ID, "KNOWS")
+	require.NoError(t, engine.CreateEdge(first))
+	require.NoError(t, engine.CreateEdge(second))
+
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", first.ID, true)
+	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", second.ID, true)
+	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", second.ID, true)
+	edges, err := engine.GetEdgesBetween(n1.ID, n2.ID)
+	require.NoError(t, err)
+	require.Len(t, edges, 2)
+	assert.NotNil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
+}
+
 func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
 	engine := createTestBadgerEngine(t)
 
@@ -795,6 +847,9 @@ func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
 		if err := txn.Delete(edgeBetweenIndexKey(n1.ID, n2.ID, "KNOWS", edge.ID)); err != nil {
 			return err
 		}
+		if err := txn.Delete(edgeBetweenHeadKey(n1.ID, n2.ID, "KNOWS")); err != nil {
+			return err
+		}
 		if err := txn.Set(edgeBetweenIndexKey(n1.ID, n3.ID, "STALE", staleEdgeID), []byte{}); err != nil {
 			return err
 		}
@@ -803,9 +858,11 @@ func TestBadgerEngine_EdgeBetweenIndexBackfill(t *testing.T) {
 
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "STALE", staleEdgeID, true)
+	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, false)
 	require.NoError(t, engine.ensureEdgeBetweenIndex())
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
 	requireEdgeBetweenIndexEntry(t, engine, n1.ID, n3.ID, "STALE", staleEdgeID, false)
+	requireEdgeBetweenHeadEntry(t, engine, n1.ID, n2.ID, "KNOWS", edge.ID, true)
 	require.NotNil(t, engine.GetEdgeBetween(n1.ID, n2.ID, "KNOWS"))
 }
 
@@ -1579,6 +1636,13 @@ func TestKeyEncoding(t *testing.T) {
 		assert.Equal(t, EdgeID(prefixTestID("edge-1")), extractEdgeIDFromEdgeBetweenIndexKey(key))
 		assert.True(t, hasBytePrefix(key, edgeBetweenIndexPrefix(NodeID(prefixTestID("node-1")), NodeID(prefixTestID("node-2")))))
 		assert.True(t, hasBytePrefix(key, typedEdgeBetweenIndexPrefix(NodeID(prefixTestID("node-1")), NodeID(prefixTestID("node-2")), "knows")))
+
+		headKey := edgeBetweenHeadKey(
+			NodeID(prefixTestID("node-1")),
+			NodeID(prefixTestID("node-2")),
+			"KNOWS",
+		)
+		assert.Equal(t, prefixEdgeBetweenHead, headKey[0])
 	})
 
 	t.Run("extract helpers return empty on malformed keys", func(t *testing.T) {
@@ -1586,6 +1650,39 @@ func TestKeyEncoding(t *testing.T) {
 		assert.Equal(t, EdgeID(""), extractEdgeIDFromEdgeBetweenIndexKey([]byte{prefixEdgeBetweenIndex, 'x', 'y'}))
 		assert.Equal(t, NodeID(""), extractNodeIDFromLabelIndex([]byte{prefixLabelIndex, 'P', 'e'}, len("Person")))
 	})
+}
+
+// requireEdgeBetweenHeadEntry verifies the typed single-edge head index without
+// using GetEdgeBetween, so fallback/self-heal logic cannot hide a missing head.
+func requireEdgeBetweenHeadEntry(
+	t *testing.T,
+	engine *BadgerEngine,
+	startID NodeID,
+	endID NodeID,
+	edgeType string,
+	edgeID EdgeID,
+	want bool,
+) {
+	t.Helper()
+
+	key := edgeBetweenHeadKey(startID, endID, edgeType)
+	var exists bool
+	err := engine.withView(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if err == nil {
+			return item.Value(func(val []byte) error {
+				exists = EdgeID(val) == edgeID
+				return nil
+			})
+		}
+		if err == badger.ErrKeyNotFound {
+			exists = false
+			return nil
+		}
+		return err
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want, exists)
 }
 
 // requireEdgeBetweenIndexEntry verifies the direct relationship-existence index

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -572,6 +572,7 @@ func (tx *BadgerTransaction) deleteEdgesWithPrefixBuffered(prefix []byte) (int64
 		tx.bufferDelete(outgoingIndexKey(edge.StartNode, edgeID))
 		tx.bufferDelete(incomingIndexKey(edge.EndNode, edgeID))
 		tx.bufferDelete(edgeTypeIndexKey(edge.Type, edgeID))
+		tx.bufferDelete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edgeID))
 
 		deletedCount++
 		deletedIDs = append(deletedIDs, edgeID)
@@ -669,6 +670,7 @@ func (tx *BadgerTransaction) CreateEdge(edge *Edge) error {
 	// Without this, edges created inside implicit/explicit transactions are invisible
 	// to type-based scans and Cypher fast-paths that rely on the edge-type index.
 	tx.bufferSet(edgeTypeIndexKey(edge.Type, edge.ID), []byte{})
+	tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
 
 	// Track for read-your-writes
 	edgeCopy := copyEdge(edge)
@@ -731,8 +733,10 @@ func (tx *BadgerTransaction) UpdateEdge(edge *Edge) error {
 
 		tx.bufferDelete(outgoingIndexKey(oldEdge.StartNode, edge.ID))
 		tx.bufferDelete(incomingIndexKey(oldEdge.EndNode, edge.ID))
+		tx.bufferDelete(edgeBetweenIndexKey(oldEdge.StartNode, oldEdge.EndNode, oldEdge.Type, edge.ID))
 		tx.bufferSet(outgoingIndexKey(edge.StartNode, edge.ID), []byte{})
 		tx.bufferSet(incomingIndexKey(edge.EndNode, edge.ID), []byte{})
+		tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
 	}
 
 	// If type changed, update edge type index.
@@ -740,8 +744,14 @@ func (tx *BadgerTransaction) UpdateEdge(edge *Edge) error {
 		if oldEdge.Type != "" {
 			tx.bufferDelete(edgeTypeIndexKey(oldEdge.Type, edge.ID))
 		}
+		if oldEdge.StartNode == edge.StartNode && oldEdge.EndNode == edge.EndNode {
+			tx.bufferDelete(edgeBetweenIndexKey(oldEdge.StartNode, oldEdge.EndNode, oldEdge.Type, edge.ID))
+		}
 		if edge.Type != "" {
 			tx.bufferSet(edgeTypeIndexKey(edge.Type, edge.ID), []byte{})
+		}
+		if oldEdge.StartNode == edge.StartNode && oldEdge.EndNode == edge.EndNode {
+			tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
 		}
 	}
 
@@ -804,6 +814,7 @@ func (tx *BadgerTransaction) DeleteEdge(edgeID EdgeID) error {
 
 	// Buffer edge type index deletion.
 	tx.bufferDelete(edgeTypeIndexKey(edge.Type, edgeID))
+	tx.bufferDelete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edgeID))
 
 	// Track deletion
 	delete(tx.pendingEdges, edgeID)

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -212,6 +212,19 @@ func (tx *BadgerTransaction) bufferDelete(key []byte) {
 	tx.pendingDeletes[keyStr] = true
 }
 
+// bufferSetEdgeBetweenIndexes stages both exact relationship lookup indexes.
+func (tx *BadgerTransaction) bufferSetEdgeBetweenIndexes(edge *Edge) {
+	tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
+	tx.bufferSet(edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type), []byte(edge.ID))
+}
+
+// bufferDeleteEdgeBetweenIndexes stages set removal and conservatively clears
+// the head so later reads can self-heal from the set or legacy outgoing index.
+func (tx *BadgerTransaction) bufferDeleteEdgeBetweenIndexes(edge *Edge) {
+	tx.bufferDelete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID))
+	tx.bufferDelete(edgeBetweenHeadKey(edge.StartNode, edge.EndNode, edge.Type))
+}
+
 // flushBufferedWrites applies all buffered writes and deletes to the Badger transaction.
 // This is called at commit time to batch all writes together.
 func (tx *BadgerTransaction) flushBufferedWrites() error {
@@ -572,7 +585,7 @@ func (tx *BadgerTransaction) deleteEdgesWithPrefixBuffered(prefix []byte) (int64
 		tx.bufferDelete(outgoingIndexKey(edge.StartNode, edgeID))
 		tx.bufferDelete(incomingIndexKey(edge.EndNode, edgeID))
 		tx.bufferDelete(edgeTypeIndexKey(edge.Type, edgeID))
-		tx.bufferDelete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edgeID))
+		tx.bufferDeleteEdgeBetweenIndexes(edge)
 
 		deletedCount++
 		deletedIDs = append(deletedIDs, edgeID)
@@ -670,7 +683,7 @@ func (tx *BadgerTransaction) CreateEdge(edge *Edge) error {
 	// Without this, edges created inside implicit/explicit transactions are invisible
 	// to type-based scans and Cypher fast-paths that rely on the edge-type index.
 	tx.bufferSet(edgeTypeIndexKey(edge.Type, edge.ID), []byte{})
-	tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
+	tx.bufferSetEdgeBetweenIndexes(edge)
 
 	// Track for read-your-writes
 	edgeCopy := copyEdge(edge)
@@ -733,10 +746,10 @@ func (tx *BadgerTransaction) UpdateEdge(edge *Edge) error {
 
 		tx.bufferDelete(outgoingIndexKey(oldEdge.StartNode, edge.ID))
 		tx.bufferDelete(incomingIndexKey(oldEdge.EndNode, edge.ID))
-		tx.bufferDelete(edgeBetweenIndexKey(oldEdge.StartNode, oldEdge.EndNode, oldEdge.Type, edge.ID))
+		tx.bufferDeleteEdgeBetweenIndexes(oldEdge)
 		tx.bufferSet(outgoingIndexKey(edge.StartNode, edge.ID), []byte{})
 		tx.bufferSet(incomingIndexKey(edge.EndNode, edge.ID), []byte{})
-		tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
+		tx.bufferSetEdgeBetweenIndexes(edge)
 	}
 
 	// If type changed, update edge type index.
@@ -745,13 +758,13 @@ func (tx *BadgerTransaction) UpdateEdge(edge *Edge) error {
 			tx.bufferDelete(edgeTypeIndexKey(oldEdge.Type, edge.ID))
 		}
 		if oldEdge.StartNode == edge.StartNode && oldEdge.EndNode == edge.EndNode {
-			tx.bufferDelete(edgeBetweenIndexKey(oldEdge.StartNode, oldEdge.EndNode, oldEdge.Type, edge.ID))
+			tx.bufferDeleteEdgeBetweenIndexes(oldEdge)
 		}
 		if edge.Type != "" {
 			tx.bufferSet(edgeTypeIndexKey(edge.Type, edge.ID), []byte{})
 		}
 		if oldEdge.StartNode == edge.StartNode && oldEdge.EndNode == edge.EndNode {
-			tx.bufferSet(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edge.ID), []byte{})
+			tx.bufferSetEdgeBetweenIndexes(edge)
 		}
 	}
 
@@ -814,7 +827,7 @@ func (tx *BadgerTransaction) DeleteEdge(edgeID EdgeID) error {
 
 	// Buffer edge type index deletion.
 	tx.bufferDelete(edgeTypeIndexKey(edge.Type, edgeID))
-	tx.bufferDelete(edgeBetweenIndexKey(edge.StartNode, edge.EndNode, edge.Type, edgeID))
+	tx.bufferDeleteEdgeBetweenIndexes(edge)
 
 	// Track deletion
 	delete(tx.pendingEdges, edgeID)


### PR DESCRIPTION
## Why

PCG dogfood runs exposed a graph-size slope in idempotent relationship writes. The Cypher shape is ordinary `MERGE (start)-[:TYPE]->(end)`, but Badger-backed relationship lookup had to scan the start node outgoing edge index and then filter by end node and type. That means high-fanout nodes get slower as the graph fills, even when the write is logically an exact relationship-existence check.

This PR adds a direct edge-between lookup index so exact relationship checks can stay bounded by `(startID, endID, type)` instead of start-node out-degree.

## What changed

- Adds an edge-between Badger index keyed by start node, end node, relationship type, and edge ID.
- Maintains the index on edge create, update, delete, bulk, and transaction paths.
- Adds one-time startup backfill for existing stores using a marker key so older databases remain readable and automatically become indexed.
- Routes `GetEdgesBetween` / `GetEdgeBetween` through the direct index.
- Cleans the new prefix during database-prefix deletion.
- Documents the direct lookup path in the hot-path query cookbook.

## Verification

- `go test -tags 'noui nolocalllm' ./pkg/storage -run 'TestBadgerEngine_GetEdgeBetweenIndexMaintenance|TestBadgerEngine_EdgeBetweenIndexBackfill|TestBadgerEngine_GetEdgeBetween|TestKeyEncoding' -count=1`
- `go test -tags 'noui nolocalllm' ./pkg/storage -count=1`
- `go test -tags 'noui nolocalllm' ./pkg/storage ./pkg/cypher -count=1`
- `go build -tags 'noui nolocalllm' -o ./bin/nornicdb-headless-edge-index ./cmd/nornicdb`

I also tested the patched binary against a large stress repo from PCG dogfooding. The run drained healthy with `pending=0 in_flight=0 retrying=0 dead_letter=0 failed=0`. Canonical files completed 52 statements in 1.496s, Function completed 19,496 rows in 6.053s, Variable completed 118,768 rows in 62.340s, and max grouped execution stayed at 0.437s.

Follow-up medium-corpus proof also passed against a representative 23-repo corpus: projector finished 23/23, reducer finished 184 work items, and the queue ended at `pending=0 in_flight=0 retrying=0 dead_letter=0 failed=0`. In that run, the same large stress repo kept file relationship writes bounded: 52 file statements completed in 1.683s. Variable entity volume remained the tail at 69.750s, which is expected and separate from this relationship-existence fix.