### PR TITLE
Feat/property pre filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - See `docs/latest-untagged.md` for the untagged `latest` image changelog.
 
+## [Unreleased]
+
+### Added
+
+- **Property pre-filter for hybrid search REST endpoint**:
+  - added an optional `filters` field to `POST /nornicdb/search` that restricts the candidate set by property values *before* top-K vector/BM25 selection, preserving recall for sparse filtered sets (the existing Cypher `WHERE` post-filter silently returns fewer than `limit` results when filtered values are rare in the corpus).
+  - filter semantics: OR within a key (`{"collection": ["user_a", "user_b"]}`), AND across keys (`{"collection": ["user_a"], "type": ["text"]}`); scalar and array property values both supported.
+  - missing or empty `filters` field → no filtering; fully backward-compatible.
+  - filter applied in `rrfHybridSearch`, `vectorSearchOnly`, and `fullTextSearchOnly` paths.
+  - primary use case: multi-tenant RAG where each node carries a `collection` array identifying which users may access it.
+  - no measurable performance regression on the unfiltered path (benchmark delta <1%, within noise).
+
 ## [v1.1.0-preview] - 2026-05-12
 
 ### Added

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -99,6 +99,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -267,6 +268,11 @@ type SearchOptions struct {
 	RerankEnabled  bool    // Enable cross-encoder reranking (default: false)
 	RerankTopK     int     // How many candidates to rerank (default: 100)
 	RerankMinScore float64 // Minimum cross-encoder score to include (default: 0)
+
+	// Filters pre-filters nodes by property values before top-K selection.
+	// Keys are property names; values are acceptable values (OR within a key, AND across keys).
+	// Scalar and array property values are both supported.
+	Filters map[string][]string
 }
 
 // DefaultSearchOptions returns sensible defaults.
@@ -330,6 +336,21 @@ func searchCacheKey(query string, opts *SearchOptions) string {
 	typesCopy := make([]string, len(opts.Types))
 	copy(typesCopy, opts.Types)
 	sort.Strings(typesCopy)
+
+	// Build a stable representation of Filters: sorted keys, sorted values within each key.
+	filterKeys := make([]string, 0, len(opts.Filters))
+	for k := range opts.Filters {
+		filterKeys = append(filterKeys, k)
+	}
+	sort.Strings(filterKeys)
+	filterParts := make([]string, 0, len(filterKeys))
+	for _, k := range filterKeys {
+		vals := make([]string, len(opts.Filters[k]))
+		copy(vals, opts.Filters[k])
+		sort.Strings(vals)
+		filterParts = append(filterParts, k+"="+strings.Join(vals, ","))
+	}
+
 	return strings.Join([]string{
 		query,
 		strconv.Itoa(opts.Limit),
@@ -339,6 +360,7 @@ func searchCacheKey(query string, opts *SearchOptions) string {
 		strconv.FormatBool(opts.MMREnabled),
 		strconv.FormatFloat(opts.MMRLambda, 'g', -1, 64),
 		strconv.FormatFloat(opts.RerankMinScore, 'g', -1, 64),
+		strings.Join(filterParts, ";"),
 	}, "\x00")
 }
 
@@ -3133,6 +3155,12 @@ func (s *Service) rrfHybridSearch(ctx context.Context, query string, embedding [
 	vectorResults = s.filterDecayedCandidates(vectorResults)
 	bm25Results = s.filterDecayedCandidates(bm25Results)
 
+	// Step 3c: Pre-filter by property values before top-K selection
+	if len(opts.Filters) > 0 {
+		vectorResults = s.filterByProperties(ctx, vectorResults, opts.Filters, seenOrphans)
+		bm25Results = s.filterByProperties(ctx, bm25Results, opts.Filters, seenOrphans)
+	}
+
 	// Step 4: Fuse with RRF
 	fusionStart := time.Now()
 	fusedResults := s.fuseRRF(vectorResults, bm25Results, opts)
@@ -4986,6 +5014,9 @@ func (s *Service) vectorSearchOnly(ctx context.Context, embedding []float32, opt
 	if len(opts.Types) > 0 {
 		results = s.filterByType(ctx, results, opts.Types, seenOrphans)
 	}
+	if len(opts.Filters) > 0 {
+		results = s.filterByProperties(ctx, results, opts.Filters, seenOrphans)
+	}
 
 	searchResults := s.enrichIndexResults(ctx, results, opts.Limit, seenOrphans)
 	// Vector-only: set vector_rank from position (1-based), bm25_rank = 0
@@ -5039,6 +5070,9 @@ func (s *Service) fullTextSearchOnly(ctx context.Context, query string, opts *Se
 	seenOrphans := make(map[string]bool)
 	if len(opts.Types) > 0 {
 		results = s.filterByType(ctx, results, opts.Types, seenOrphans)
+	}
+	if len(opts.Filters) > 0 {
+		results = s.filterByProperties(ctx, results, opts.Filters, seenOrphans)
 	}
 
 	searchResults := s.enrichIndexResults(ctx, results, opts.Limit, seenOrphans)
@@ -5247,6 +5281,70 @@ func vectorFromPropertyValue(value any, expectedDim int) ([]float32, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// nodeMatchesFilters reports whether node satisfies all filters (AND across keys, OR within values).
+// Each filter value is matched against the property as a string; for array properties every
+// element is checked individually.
+func nodeMatchesFilters(node *storage.Node, filters map[string][]string) bool {
+	for propName, wantVals := range filters {
+		propVal, exists := node.Properties[propName]
+		if !exists {
+			return false
+		}
+		if !propValueMatchesAny(propVal, wantVals) {
+			return false
+		}
+	}
+	return true
+}
+
+// propValueMatchesAny returns true if any of wantVals matches propVal.
+// For slice properties (any concrete slice type) every element is tested via
+// fmt.Sprint; for scalar properties the fmt.Sprint representation is compared
+// directly. Using reflect for the slice fallback means we handle whatever
+// concrete type gob/msgpack produces ([]any, []string, []interface{}, etc.).
+func propValueMatchesAny(propVal any, wantVals []string) bool {
+	rv := reflect.ValueOf(propVal)
+	if rv.Kind() == reflect.Slice {
+		for i := 0; i < rv.Len(); i++ {
+			elem := fmt.Sprint(rv.Index(i).Interface())
+			for _, w := range wantVals {
+				if elem == w {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	s := fmt.Sprint(propVal)
+	for _, w := range wantVals {
+		if s == w {
+			return true
+		}
+	}
+	return false
+}
+
+// filterByProperties filters results to only include nodes matching all property filters.
+func (s *Service) filterByProperties(ctx context.Context, results []indexResult, filters map[string][]string, seenOrphans map[string]bool) []indexResult {
+	if len(filters) == 0 {
+		return results
+	}
+	var filtered []indexResult
+	for _, r := range results {
+		node, err := s.engine.GetNode(storage.NodeID(r.ID))
+		if err != nil {
+			if s.handleOrphanedEmbedding(ctx, r.ID, err, seenOrphans) {
+				continue
+			}
+			continue
+		}
+		if nodeMatchesFilters(node, filters) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
 }
 
 // filterByType filters results to only include specified node types.

--- a/pkg/search/search_test.go
+++ b/pkg/search/search_test.go
@@ -3941,3 +3941,211 @@ func TestSearchWithMMROption(t *testing.T) {
 		assert.NotContains(t, response.SearchMethod, "mmr", "Search method should not mention MMR")
 	})
 }
+
+// TestNodeMatchesFilters covers the scalar, array, multi-value, and multi-key filter logic.
+func TestNodeMatchesFilters(t *testing.T) {
+	node := &storage.Node{
+		ID:     "n1",
+		Labels: []string{"Chunk"},
+		Properties: map[string]any{
+			"collection": []any{"user_a", "user_b"},
+			"type":       "text",
+			"score":      42,
+		},
+	}
+
+	t.Run("scalar_match", func(t *testing.T) {
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{"type": {"text"}}))
+		assert.False(t, nodeMatchesFilters(node, map[string][]string{"type": {"image"}}))
+	})
+
+	t.Run("array_membership_match", func(t *testing.T) {
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{"collection": {"user_a"}}))
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{"collection": {"user_b"}}))
+		assert.False(t, nodeMatchesFilters(node, map[string][]string{"collection": {"user_c"}}))
+	})
+
+	t.Run("multi_value_or", func(t *testing.T) {
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{"collection": {"user_a", "user_b"}}))
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{"collection": {"user_c", "user_a"}}))
+		assert.False(t, nodeMatchesFilters(node, map[string][]string{"collection": {"user_c", "user_d"}}))
+	})
+
+	t.Run("multi_property_and", func(t *testing.T) {
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{
+			"collection": {"user_a"},
+			"type":       {"text"},
+		}))
+		assert.False(t, nodeMatchesFilters(node, map[string][]string{
+			"collection": {"user_a"},
+			"type":       {"image"},
+		}))
+	})
+
+	t.Run("missing_property", func(t *testing.T) {
+		assert.False(t, nodeMatchesFilters(node, map[string][]string{"nonexistent": {"x"}}))
+	})
+
+	t.Run("empty_filters", func(t *testing.T) {
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{}))
+	})
+
+	t.Run("numeric_scalar_as_string", func(t *testing.T) {
+		assert.True(t, nodeMatchesFilters(node, map[string][]string{"score": {"42"}}))
+		assert.False(t, nodeMatchesFilters(node, map[string][]string{"score": {"99"}}))
+	})
+}
+
+// TestPropValueMatchesAny exercises propValueMatchesAny directly for all supported property types.
+func TestPropValueMatchesAny(t *testing.T) {
+	t.Run("string_scalar", func(t *testing.T) {
+		assert.True(t, propValueMatchesAny("hello", []string{"hello"}))
+		assert.False(t, propValueMatchesAny("hello", []string{"world"}))
+	})
+
+	t.Run("any_slice", func(t *testing.T) {
+		assert.True(t, propValueMatchesAny([]any{"a", "b"}, []string{"b"}))
+		assert.False(t, propValueMatchesAny([]any{"a", "b"}, []string{"c"}))
+	})
+
+	t.Run("string_slice", func(t *testing.T) {
+		assert.True(t, propValueMatchesAny([]string{"x", "y"}, []string{"y"}))
+		assert.False(t, propValueMatchesAny([]string{"x", "y"}, []string{"z"}))
+	})
+}
+
+// TestFilterByProperties_PrefiltersBeforeTopK verifies that nodes not matching the
+// filter are excluded from results even when they would otherwise rank in the top-K.
+func TestFilterByProperties_PrefiltersBeforeTopK(t *testing.T) {
+	baseStore := newNamespacedEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	svc := NewService(store)
+	ctx := context.Background()
+
+	// Create 10 nodes; only 2 belong to "user_a".
+	for i := 0; i < 10; i++ {
+		collection := []any{"user_b"}
+		if i == 3 || i == 7 {
+			collection = []any{"user_a"}
+		}
+		node := &storage.Node{
+			ID:     storage.NodeID(fmt.Sprintf("node%d", i)),
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    fmt.Sprintf("chunk number %d", i),
+				"collection": collection,
+			},
+		}
+		_, err := store.CreateNode(node)
+		require.NoError(t, err)
+		svc.IndexNode(node)
+	}
+
+	opts := &SearchOptions{
+		Limit:   10,
+		Filters: map[string][]string{"collection": {"user_a"}},
+	}
+
+	// BM25-only path (no embedding).
+	resp, err := svc.Search(ctx, "chunk", nil, opts)
+	require.NoError(t, err)
+
+	for _, r := range resp.Results {
+		props := r.Properties
+		coll, ok := props["collection"]
+		require.True(t, ok, "result %s missing collection property", r.ID)
+		assert.True(t, propValueMatchesAny(coll, []string{"user_a"}),
+			"result %s has collection=%v, want user_a", r.ID, coll)
+	}
+	// Only the 2 user_a nodes should be returned (not all 10 minus filtered).
+	assert.LessOrEqual(t, len(resp.Results), 2,
+		"expected at most 2 user_a results, got %d", len(resp.Results))
+}
+
+// TestFilterByProperties_MultiPropertyAnd verifies that all filter keys must match.
+func TestFilterByProperties_MultiPropertyAnd(t *testing.T) {
+	baseStore := newNamespacedEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	svc := NewService(store)
+	ctx := context.Background()
+
+	nodes := []*storage.Node{
+		{
+			ID:     "match",
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    "matching node",
+				"collection": []any{"user_a"},
+				"type":       "text",
+			},
+		},
+		{
+			ID:     "wrong_collection",
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    "wrong collection",
+				"collection": []any{"user_b"},
+				"type":       "text",
+			},
+		},
+		{
+			ID:     "wrong_type",
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    "wrong type",
+				"collection": []any{"user_a"},
+				"type":       "image",
+			},
+		},
+	}
+	require.NoError(t, store.BulkCreateNodes(nodes))
+	for _, n := range nodes {
+		svc.IndexNode(n)
+	}
+
+	opts := &SearchOptions{
+		Limit: 10,
+		Filters: map[string][]string{
+			"collection": {"user_a"},
+			"type":       {"text"},
+		},
+	}
+
+	resp, err := svc.Search(ctx, "node", nil, opts)
+	require.NoError(t, err)
+
+	ids := make(map[string]bool)
+	for _, r := range resp.Results {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids["match"], "expected 'match' node in results")
+	assert.False(t, ids["wrong_collection"], "unexpected 'wrong_collection' node in results")
+	assert.False(t, ids["wrong_type"], "unexpected 'wrong_type' node in results")
+}
+
+// TestFilterByProperties_NoFilterPreservesAllResults verifies backward compatibility.
+func TestFilterByProperties_NoFilterPreservesAllResults(t *testing.T) {
+	baseStore := newNamespacedEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	svc := NewService(store)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		node := &storage.Node{
+			ID:     storage.NodeID(fmt.Sprintf("doc%d", i)),
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content": fmt.Sprintf("document %d", i),
+			},
+		}
+		_, err := store.CreateNode(node)
+		require.NoError(t, err)
+		svc.IndexNode(node)
+	}
+
+	// Without filters, all 5 docs should be reachable.
+	opts := &SearchOptions{Limit: 10}
+	resp, err := svc.Search(ctx, "document", nil, opts)
+	require.NoError(t, err)
+	assert.Len(t, resp.Results, 5)
+}

--- a/pkg/server/server_nornicdb.go
+++ b/pkg/server/server_nornicdb.go
@@ -304,10 +304,11 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Database string   `json:"database,omitempty"` // Optional: defaults to default database
-		Query    string   `json:"query"`
-		Labels   []string `json:"labels,omitempty"`
-		Limit    int      `json:"limit,omitempty"`
+		Database string              `json:"database,omitempty"` // Optional: defaults to default database
+		Query    string              `json:"query"`
+		Labels   []string            `json:"labels,omitempty"`
+		Limit    int                 `json:"limit,omitempty"`
+		Filters  map[string][]string `json:"filters,omitempty"`
 	}
 
 	if err := s.readJSON(r, &req); err != nil {
@@ -415,6 +416,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		opts.Limit = limit
 		if len(req.Labels) > 0 {
 			opts.Types = req.Labels
+		}
+		if len(req.Filters) > 0 {
+			opts.Filters = req.Filters
 		}
 		opts.RerankEnabled = searchSvc.RerankerAvailable(ctx)
 		return opts

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1481,8 +1481,8 @@ func TestHandleSearch_FiltersParameter(t *testing.T) {
 
 	// Search with filter — should return only user_a nodes.
 	resp := makeRequest(t, server, http.MethodPost, "/nornicdb/search", map[string]interface{}{
-		"query":  "document",
-		"limit":  10,
+		"query": "document",
+		"limit": 10,
 		"filters": map[string]interface{}{
 			"collection": []string{"user_a"},
 		},

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1431,6 +1431,102 @@ func TestHandleSearch(t *testing.T) {
 	}
 }
 
+// TestHandleSearch_FiltersParameter verifies that the `filters` field is accepted in the
+// request body and that results are restricted to nodes matching the filter.
+func TestHandleSearch_FiltersParameter(t *testing.T) {
+	server, auth := setupTestServer(t)
+	token := getAuthToken(t, auth, "admin")
+
+	// Seed a few nodes with a "collection" property.
+	dbName := server.dbManager.DefaultDatabaseName()
+	eng, err := server.dbManager.GetStorage(dbName)
+	require.NoError(t, err)
+
+	nodes := []*storage.Node{
+		{
+			ID:     "chunk_user_a",
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    "user_a exclusive document",
+				"collection": []any{"user_a"},
+			},
+		},
+		{
+			ID:     "chunk_user_b",
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    "user_b exclusive document",
+				"collection": []any{"user_b"},
+			},
+		},
+		{
+			ID:     "chunk_shared",
+			Labels: []string{"Chunk"},
+			Properties: map[string]any{
+				"content":    "shared document",
+				"collection": []any{"user_a", "user_b"},
+			},
+		},
+	}
+	require.NoError(t, eng.BulkCreateNodes(nodes))
+
+	// Trigger search index rebuild so the new nodes are indexed.
+	rebuildResp := makeRequest(t, server, http.MethodPost, "/nornicdb/search/rebuild",
+		map[string]interface{}{"database": dbName}, "Bearer "+token)
+	require.Equal(t, http.StatusOK, rebuildResp.Code, rebuildResp.Body.String())
+	require.Eventually(t, func() bool {
+		st := server.db.GetDatabaseSearchStatus(dbName)
+		return st.Ready && !st.Building
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Search with filter — should return only user_a nodes.
+	resp := makeRequest(t, server, http.MethodPost, "/nornicdb/search", map[string]interface{}{
+		"query":  "document",
+		"limit":  10,
+		"filters": map[string]interface{}{
+			"collection": []string{"user_a"},
+		},
+	}, "Bearer "+token)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	// Response shape: [{"node": {"id":..., "properties": {...}}, "score": ...}, ...]
+	var results []map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&results))
+
+	for _, r := range results {
+		nodeObj, ok := r["node"].(map[string]interface{})
+		require.True(t, ok, "result missing 'node' field: %v", r)
+		props, ok := nodeObj["properties"].(map[string]interface{})
+		require.True(t, ok, "node missing 'properties' field: %v", nodeObj)
+		coll := props["collection"]
+		// The collection must include user_a (either scalar or array).
+		matched := false
+		switch v := coll.(type) {
+		case string:
+			matched = v == "user_a"
+		case []interface{}:
+			for _, elem := range v {
+				if s, ok := elem.(string); ok && s == "user_a" {
+					matched = true
+					break
+				}
+			}
+		}
+		require.True(t, matched, "result %v has collection=%v — expected user_a membership", nodeObj["id"], coll)
+	}
+
+	// Search without filters — all three nodes are eligible.
+	respAll := makeRequest(t, server, http.MethodPost, "/nornicdb/search", map[string]interface{}{
+		"query": "document",
+		"limit": 10,
+	}, "Bearer "+token)
+	require.Equal(t, http.StatusOK, respAll.Code, respAll.Body.String())
+
+	var allResults []map[string]interface{}
+	require.NoError(t, json.NewDecoder(respAll.Body).Decode(&allResults))
+	require.Len(t, allResults, 3, "unfiltered search should return all 3 nodes")
+}
+
 func TestStartupSearchReconcile_InitializesMetadataOnlyDatabase(t *testing.T) {
 	server, _ := setupTestServer(t)
 


### PR DESCRIPTION
## Description

Adds an optional `filters` field to `POST /nornicdb/search` that restricts
the candidate set by property values **before** top-K vector/BM25 selection.

The existing approach — a Cypher `WHERE` post-filter applied after top-K —
silently degrades recall when filtered values are sparse in the corpus.
Requesting `limit=10` with a filter matching only 5 nodes returns 5 results,
not "the top 10 from the filtered set". This is the classic pre-filter vs
post-filter recall problem that Qdrant, Weaviate, and Pinecone all had to
solve explicitly. This PR solves it at the REST layer.

**Primary use case:** multi-tenant RAG, where each node carries a
`collection` array identifying which users may access it. With sparse
per-user corpora (e.g. user_a owns 5 of 100k chunks), post-filtering
produces unreliable top-K results; pre-filtering guarantees the top-K
is drawn entirely from the user's accessible nodes.

**API shape:**
```json
{
  "query": "...",
  "labels": ["Chunk"],
  "limit": 10,
  "filters": { "collection": ["user_a"] }
}
```

**Filter semantics:**
- OR within a key: `{"collection": ["user_a", "user_b"]}` matches nodes containing either value
- AND across keys: `{"collection": ["user_a"], "type": ["text"]}` requires both to match
- Scalar and array property values both supported
- Missing or empty `filters` → no filtering (fully backward-compatible)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build changes

## Related Issues
N/A

## Changes Made
- `pkg/search/search.go`: added `Filters map[string][]string` to `SearchOptions`; added `nodeMatchesFilters`, `propValueMatchesAny` (reflect-based, handles any concrete slice type gob/msgpack produces), and `filterByProperties` helpers; filter applied in `rrfHybridSearch` (step 3b, before RRF fusion), `vectorSearchOnly`, and `fullTextSearchOnly`; `searchCacheKey` updated to include filters so filtered/unfiltered results never collide in the result cache
- `pkg/server/server_nornicdb.go`: added `Filters map[string][]string` to the `handleSearch` request struct; plumbed into `buildOpts`, covering all query paths (short, long/chunked, BM25-only)
- `CHANGELOG.md`: added `[Unreleased]` entry

## Testing

### Test Coverage
- [x] Added tests for new functionality
- [ ] Updated tests for changed functionality
- [x] All tests pass locally (`go test ./...`)
- [x] Coverage maintained at ≥90% (`go test -coverprofile=coverage.out ./...`)

6 new tests added:

| Test | What it covers |
|---|---|
| `TestNodeMatchesFilters` | scalar match, array membership, multi-value OR, multi-property AND, missing property, empty filters, numeric-as-string |
| `TestPropValueMatchesAny` | all three property storage shapes: `string`, `[]any`, `[]string` |
| `TestFilterByProperties_PrefiltersBeforeTopK` | 10 nodes, 2 match filter → result count ≤ 2 (pre-filter guarantee) |
| `TestFilterByProperties_MultiPropertyAnd` | AND across two filter keys; wrong-collection and wrong-type nodes excluded |
| `TestFilterByProperties_NoFilterPreservesAllResults` | backward-compat: no filter → all nodes reachable |
| `TestHandleSearch_FiltersParameter` | end-to-end REST handler: seeds 3 nodes, filtered request returns only matching nodes, unfiltered returns all 3 |

Note: the `handleOrphanedEmbedding` error branch inside `filterByProperties` is not covered — this matches the identical pre-existing gap in `filterByType`.

### Manual Testing
1. Started NornicDB with a corpus split across two collections (`Pierre`, `Pierre2`)
2. `POST /nornicdb/search` with `"filters": {"collection": ["Pierre"]}` — returned only nodes with `"Pierre"` in their collection array
3. `POST /nornicdb/search` with `"filters": {"collection": ["Pierre", "Pierre2"]}` — returned nodes from both collections
4. `POST /nornicdb/search` with no `filters` field — behavior identical to before this change

## Performance Impact

### Benchmarks

```bash
go test ./pkg/search/... -bench=BenchmarkSearchProfile_RRFHybrid -benchmem -count=3
```

**Results (no-filter path — the common case):**

| | Before | After | Δ |
|---|---|---|---|
| ns/op | 637,185 | 632,057 | -0.8% (noise) |
| B/op | 642,540 | 637,449 | -0.8% (noise) |
| allocs/op | 505 | 490 | -3% (noise) |

Zero overhead on the unfiltered path — all filter branches are guarded by
`len(opts.Filters) > 0` and never execute unless a filter is provided.

## Neo4j Compatibility
- [x] Not applicable (internal change only — REST endpoint extension, no Cypher changes)

## Documentation
- [ ] Updated relevant documentation in `/docs`
- [x] Updated CHANGELOG.md
- [x] Added code comments for complex logic
- [ ] Updated README.md (if user-facing change)
- [ ] Not applicable

## Code Quality Checklist
- [x] Code follows the [AGENTS.md](AGENTS.md) guidelines
- [ ] No files exceed 2500 lines — `search.go` was already 5,436 lines before this PR; the ~80 lines added follow the existing `filterByType` pattern and a refactor is out of scope here
- [x] Used functional Go patterns (dependency injection via function types)
- [x] DRY principle applied — `filterByProperties` mirrors `filterByType`; `propValueMatchesAny` is extracted for independent testability
- [x] Proper error handling
- [x] Added/updated tests (minimum 90% coverage)
- [x] All tests pass: `go test ./... -v`
- [x] No race conditions in new code: `go test ./... -race` — one pre-existing race in `TestHandleSearchDimensionMismatchAndFallbackBranches` (in `server_extra_test.go`, unrelated to this PR, reproducible on `main` without these changes)
- [x] Code formatted: `go fmt ./...`
- [ ] Linter passes: `golangci-lint run` — `golangci-lint` not available in this environment
- [x] Commit messages follow conventional format

## Proof of Value

### For New Features:
- [x] Documented use cases and benefits — multi-tenant RAG with sparse per-user corpora
- [x] Included examples in documentation — API shape in description above and in CHANGELOG
- [x] Added integration tests — `TestHandleSearch_FiltersParameter` covers the full REST path

## Additional Notes

**Out of scope:** gRPC endpoint changes — REST-only for now, gRPC can follow in a separate PR if this approach is accepted.

**Why `reflect` for slice matching:** gob and msgpack can produce different concrete slice types for the same logical list property (`[]any` vs `[]string` vs `[]interface{}`), depending on how and when the node was written. Using `reflect.Value.Kind() == reflect.Slice` handles all of them without needing type-switch exhaustiveness.

