### PR TITLE
Fix concurrent UNIQUE MERGE retries for namespaced schema backfill

### DIFF
--- a/pkg/bolt/cross_session_merge_unique_namespace_test.go
+++ b/pkg/bolt/cross_session_merge_unique_namespace_test.go
@@ -95,7 +95,7 @@ func TestBoltDatabaseManagerExecuteWriteUniqueMerge_DefaultNamespace(t *testing.
 		fmt.Sprintf("bolt://127.0.0.1:%d", port),
 		neo4jdriver.NoAuth(),
 		func(config *neo4jdriver.Config) {
-			config.MaxTransactionRetryTime = 1500 * time.Millisecond
+			config.MaxTransactionRetryTime = 5 * time.Second
 		},
 	)
 	require.NoError(t, err)
@@ -172,4 +172,225 @@ func TestBoltDatabaseManagerExecuteWriteUniqueMerge_DefaultNamespace(t *testing.
 	record, err := result.Single(ctx)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, record.Values[0])
+}
+
+func TestBoltDatabaseManagerExecuteWriteUniqueMerge_ProductionWrapperStackWithLookupIndex(t *testing.T) {
+	badger, err := storage.NewBadgerEngine(t.TempDir())
+	require.NoError(t, err)
+	wal, err := storage.NewWAL(t.TempDir(), nil)
+	require.NoError(t, err)
+	walStore := storage.NewWALEngine(badger, wal)
+	base := storage.NewAsyncEngine(walStore, nil)
+	mgr, err := multidb.NewDatabaseManager(base, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Close()
+	})
+
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		MaxConnections:  32,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	port := startBoltTestServer(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+		func(config *neo4jdriver.Config) {
+			config.MaxTransactionRetryTime = 5 * time.Second
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	setup := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	_, err = setup.Run(ctx,
+		"CREATE INDEX nornicdb_terraform_resource_uid_lookup IF NOT EXISTS FOR (n:TerraformResource) ON (n.uid)",
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = setup.Run(ctx,
+		"CREATE CONSTRAINT terraform_resource_uid_unique IF NOT EXISTS FOR (n:TerraformResource) REQUIRE n.uid IS UNIQUE",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close(ctx))
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+				AccessMode:   neo4jdriver.AccessModeWrite,
+				DatabaseName: "nornic",
+			})
+			defer func() {
+				_ = session.Close(ctx)
+			}()
+			_, execErr := session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+				result, runErr := tx.Run(ctx,
+					`UNWIND $rows AS row
+MERGE (r:TerraformResource {uid: row.uid})
+SET r.name = row.name`,
+					map[string]any{
+						"rows": []map[string]any{
+							{
+								"uid":  "prod-stack-same-uid",
+								"name": fmt.Sprintf("session%d", idx),
+							},
+						},
+					},
+				)
+				if runErr != nil {
+					return nil, runErr
+				}
+				_, consumeErr := result.Consume(ctx)
+				return nil, consumeErr
+			})
+			if execErr != nil {
+				failures[idx] = execErr.Error()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	check := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeRead,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = check.Close(ctx)
+	}()
+	result, err := check.Run(ctx,
+		"MATCH (r:TerraformResource {uid: $uid}) RETURN count(r)",
+		map[string]any{"uid": "prod-stack-same-uid"},
+	)
+	require.NoError(t, err)
+	record, err := result.Single(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, record.Values[0])
+}
+
+func TestBoltDatabaseManagerMergeExistingNodeAfterLateSchemaBootstrap(t *testing.T) {
+	badger, err := storage.NewBadgerEngine(t.TempDir())
+	require.NoError(t, err)
+	wal, err := storage.NewWAL(t.TempDir(), nil)
+	require.NoError(t, err)
+	base := storage.NewAsyncEngine(storage.NewWALEngine(badger, wal), nil)
+	mgr, err := multidb.NewDatabaseManager(base, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Close()
+	})
+
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		MaxConnections:  32,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	port := startBoltTestServer(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+		func(config *neo4jdriver.Config) {
+			config.MaxTransactionRetryTime = 5 * time.Second
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	setup := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	_, err = setup.Run(ctx,
+		"CREATE (r:TerraformResource {uid: $uid, name: 'before'})",
+		map[string]any{"uid": "late-schema-existing"},
+	)
+	require.NoError(t, err)
+	_, err = setup.Run(ctx,
+		"CREATE INDEX nornicdb_terraform_resource_uid_lookup IF NOT EXISTS FOR (n:TerraformResource) ON (n.uid)",
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = setup.Run(ctx,
+		"CREATE CONSTRAINT terraform_resource_uid_unique IF NOT EXISTS FOR (n:TerraformResource) REQUIRE n.uid IS UNIQUE",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close(ctx))
+	schema := base.GetSchemaForNamespace("nornic")
+	nodeID, valueFound, constraintExists, authoritative := schema.LookupUniqueConstraintValueForPlanning("TerraformResource", "uid", "late-schema-existing")
+	require.True(t, constraintExists, "expected TerraformResource.uid constraint to exist")
+	require.True(t, authoritative, "expected TerraformResource.uid cache to be authoritative after DDL backfill")
+	require.True(t, valueFound, "expected TerraformResource.uid cache to contain the preexisting node")
+	require.NotEmpty(t, nodeID, "expected unique cache to point at the preexisting node")
+	require.Regexp(t, "^nornic:", string(nodeID), "expected schema backfill to register storage-prefixed node IDs")
+	require.NotEmpty(t, schema.PropertyIndexLookup("TerraformResource", "uid", "late-schema-existing"), "expected lookup index to contain the preexisting node")
+
+	session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	_, err = session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, runErr := tx.Run(ctx,
+			`UNWIND $rows AS row
+MERGE (r:TerraformResource {uid: row.uid})
+SET r.name = row.name`,
+			map[string]any{
+				"rows": []map[string]any{
+					{"uid": "late-schema-existing", "name": "after"},
+				},
+			},
+		)
+		if runErr != nil {
+			return nil, runErr
+		}
+		_, consumeErr := result.Consume(ctx)
+		return nil, consumeErr
+	})
+	require.NoError(t, err)
+	require.NoError(t, session.Close(ctx))
+
+	check := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeRead,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = check.Close(ctx)
+	}()
+	result, err := check.Run(ctx,
+		"MATCH (r:TerraformResource {uid: $uid}) RETURN r.name, count(r)",
+		map[string]any{"uid": "late-schema-existing"},
+	)
+	require.NoError(t, err)
+	record, err := result.Single(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "after", record.Values[0])
+	require.EqualValues(t, 1, record.Values[1])
 }

--- a/pkg/bolt/cross_session_merge_unique_namespace_test.go
+++ b/pkg/bolt/cross_session_merge_unique_namespace_test.go
@@ -1,0 +1,175 @@
+package bolt
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/orneryd/nornicdb/pkg/multidb"
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoltCrossSessionMergeUniqueConflict_EshuDefaultNamespaceExplicitTx pins
+// the explicit transaction shape Eshu uses with DEFAULT_DATABASE=nornic.
+// Retried MERGE attempts must observe a peer transaction's committed UNIQUE
+// value through the nornic schema cache, not repeatedly choose CREATE and
+// surface commit-time UNIQUE violations.
+func TestBoltCrossSessionMergeUniqueConflict_EshuDefaultNamespaceExplicitTx(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	t.Cleanup(func() {
+		_ = baseStore.Close()
+	})
+	store := storage.NewNamespacedEngine(baseStore, "nornic")
+	_, port := startBoltIntegrationServerWithExplicitTx(t, store)
+
+	setup := openBoltTestConn(t, port)
+	runBoltQueryAndCollectRecords(t, setup,
+		"CREATE CONSTRAINT tr_uid IF NOT EXISTS FOR (r:TerraformResource) REQUIRE r.uid IS UNIQUE")
+	setup.Close()
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			err := runBoltExplicitMergeTx(t, port,
+				"TerraformResource", "uid", "eshu-same-uid",
+				fmt.Sprintf("session%d", idx))
+			if err != nil {
+				failures[idx] = err.Error()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	check := openBoltTestConn(t, port)
+	records := runBoltQueryAndCollectRecords(t, check,
+		"MATCH (r:TerraformResource {uid: 'eshu-same-uid'}) RETURN count(r)")
+	if len(records) != 1 || len(records[0]) < 1 {
+		t.Fatalf("expected one count row, got %v", records)
+	}
+	count, ok := records[0][0].(int64)
+	if !ok {
+		t.Fatalf("expected int64 count, got %T (value=%v)", records[0][0], records[0][0])
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one TerraformResource node, got %d", count)
+	}
+}
+
+// TestBoltDatabaseManagerExecuteWriteUniqueMerge_DefaultNamespace exercises the
+// real database-manager Bolt path used by Eshu's NornicDB deployment. A
+// commit-time UNIQUE conflict must become a successful retry because the next
+// ExecuteWrite attempt can MATCH the committed nornic-scoped node.
+func TestBoltDatabaseManagerExecuteWriteUniqueMerge_DefaultNamespace(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	mgr, err := multidb.NewDatabaseManager(base, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Close()
+	})
+
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		MaxConnections:  32,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	port := startBoltTestServer(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+		func(config *neo4jdriver.Config) {
+			config.MaxTransactionRetryTime = 1500 * time.Millisecond
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	setup := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	_, err = setup.Run(ctx,
+		"CREATE CONSTRAINT tr_uid IF NOT EXISTS FOR (r:TerraformResource) REQUIRE r.uid IS UNIQUE",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close(ctx))
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+				AccessMode:   neo4jdriver.AccessModeWrite,
+				DatabaseName: "nornic",
+			})
+			defer func() {
+				_ = session.Close(ctx)
+			}()
+			_, execErr := session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+				result, runErr := tx.Run(ctx,
+					"MERGE (r:TerraformResource {uid: $uid}) SET r.name = $name",
+					map[string]any{
+						"uid":  "dbmanager-same-uid",
+						"name": fmt.Sprintf("session%d", idx),
+					},
+				)
+				if runErr != nil {
+					return nil, runErr
+				}
+				_, consumeErr := result.Consume(ctx)
+				return nil, consumeErr
+			})
+			if execErr != nil {
+				failures[idx] = execErr.Error()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	check := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeRead,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = check.Close(ctx)
+	}()
+	result, err := check.Run(ctx,
+		"MATCH (r:TerraformResource {uid: $uid}) RETURN count(r)",
+		map[string]any{"uid": "dbmanager-same-uid"},
+	)
+	require.NoError(t, err)
+	record, err := result.Single(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, record.Values[0])
+}

--- a/pkg/bolt/cross_session_merge_unique_test.go
+++ b/pkg/bolt/cross_session_merge_unique_test.go
@@ -1,0 +1,193 @@
+package bolt
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+// TestBoltCrossSessionMergeUniqueConflict_Sequential reproduces the cross-
+// Bolt-session constraint-cache desync that surfaces in Eshu's v2.5 tfstate
+// drift verifier (eshu-hq/eshu#209). Two distinct Bolt sessions operate
+// against the same shared storage engine, in strict serial order:
+//
+//  1. Session 1 declares a UNIQUE constraint on a node property and MERGEs
+//     a node with uid="X".
+//  2. Session 1 closes its connection.
+//  3. Session 2 opens a fresh connection and MERGEs the same uid="X".
+//
+// The expected (and contractually correct) behavior: Session 2's MERGE
+// matches the now-committed node and SETs, with no UNIQUE violation. The
+// observed production behavior at timothyswt/nornicdb-amd64-cpu:v1.0.45
+// and at upstream NornicDB main (03f546f) is that Session 2's MERGE
+// planner treats the uid as absent, picks CREATE semantics, and the
+// commit-time storage UNIQUE check fires with
+//
+//	Constraint violation (UNIQUE on Label.[prop]):
+//	Node with prop=value already exists (nodeID: <Session 1's nodeID>)
+//
+// Returning a nodeID that the planner could not see during MERGE planning
+// is the split-brain signature: the storage layer sees the node, the
+// constraint cache used by MERGE does not. Retries within the second
+// session return the same nodeID every time, confirming the cache stays
+// empty for the new session for at least the retry window (~360ms).
+//
+// This test passes today (the MemoryEngine isolation case happens to
+// stay coherent) and serves as the contract pin. The concurrent variant
+// below is the one that goes red.
+func TestBoltCrossSessionMergeUniqueConflict_Sequential(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	_, port := startBoltIntegrationServer(t, store)
+
+	// Session 1: declare constraint, create the node, then disconnect.
+	session1 := openBoltTestConn(t, port)
+	runBoltQueryAndCollectRecords(t, session1,
+		"CREATE CONSTRAINT tr_uid IF NOT EXISTS FOR (r:TerraformResource) REQUIRE r.uid IS UNIQUE")
+	runBoltQueryAndCollectRecords(t, session1,
+		"MERGE (r:TerraformResource {uid: 'X'}) SET r.name = 'session1'")
+	session1.Close()
+
+	// Session 2: fresh connection. The MERGE on the same uid must MATCH the
+	// committed node, not CREATE+UNIQUE-fail.
+	session2 := openBoltTestConn(t, port)
+	runBoltQueryAndCollectRecords(t, session2,
+		"MERGE (r:TerraformResource {uid: 'X'}) SET r.name = 'session2'")
+
+	// Verify the final state: one node, name updated by session 2.
+	records := runBoltQueryAndCollectRecords(t, session2,
+		"MATCH (r:TerraformResource {uid: 'X'}) RETURN r.name, count(r)")
+	if len(records) != 1 {
+		t.Fatalf("expected one row, got %d (records=%v)", len(records), records)
+	}
+	row := records[0]
+	if len(row) < 2 {
+		t.Fatalf("row has fewer than 2 columns: %v", row)
+	}
+	if name, _ := row[0].(string); name != "session2" {
+		t.Fatalf("expected name=session2 (MATCH+SET branch), got %v (full row=%v)", row[0], row)
+	}
+}
+
+// TestBoltCrossSessionMergeUniqueConflict_Concurrent reproduces the
+// production failure shape exactly: two Bolt sessions racing to MERGE
+// the same uid against a UNIQUE-constrained label. Production has
+// bootstrap-index Pass 2 worker N and resolution-engine projector M (or
+// another bootstrap-index worker) both probing the constraint cache as
+// "uid absent" and both proceeding with CREATE semantics; the second
+// commit fires UNIQUE.
+//
+// Per the Eshu rule "Serialization Is Not A Fix"
+// (CLAUDE.md/AGENTS.md), the fix lives at the storage layer in
+// NornicDB, not at Eshu by single-threading the projector. This test
+// pins the storage contract: concurrent MERGE on the same uid must
+// converge — one writer creates, the other writer matches, neither
+// surfaces a UNIQUE violation to the client. If both attempt CREATE
+// and the storage uniquely fails the loser at commit time, the
+// constraint cache is the bug surface.
+func TestBoltCrossSessionMergeUniqueConflict_Concurrent(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	_, port := startBoltIntegrationServer(t, store)
+
+	// Schema setup on a throwaway connection.
+	setup := openBoltTestConn(t, port)
+	runBoltQueryAndCollectRecords(t, setup,
+		"CREATE CONSTRAINT tr_uid IF NOT EXISTS FOR (r:TerraformResource) REQUIRE r.uid IS UNIQUE")
+	setup.Close()
+
+	// concurrency=2 exercises the specific UNIQUE-on-MERGE race that this
+	// patch fixes: two transactions both pass the deferred constraint
+	// validation against an empty cache, then both commit, then the
+	// constraint cache holds two writes for the same key. Higher
+	// concurrency layers in a separate MVCC optimistic-concurrency error
+	// class (Neo.TransientError.Transaction.Outdated, "node ... changed
+	// after transaction start") that drivers and Eshu's RetryingExecutor
+	// already classify as retryable; that is out of scope for this fix.
+	const concurrency = 2
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+			if err != nil {
+				failures[idx] = fmt.Sprintf("dial: %v", err)
+				return
+			}
+			defer conn.Close()
+			if err := PerformHandshakeWithTesting(t, conn); err != nil {
+				failures[idx] = fmt.Sprintf("handshake: %v", err)
+				return
+			}
+			if err := SendHello(t, conn, nil); err != nil {
+				failures[idx] = fmt.Sprintf("hello: %v", err)
+				return
+			}
+			if _, _, err := ReadMessage(conn); err != nil {
+				failures[idx] = fmt.Sprintf("hello-ack: %v", err)
+				return
+			}
+			if err := SendRun(t, conn,
+				fmt.Sprintf("MERGE (r:TerraformResource {uid: 'X'}) SET r.name = 'session%d'", idx),
+				nil, nil); err != nil {
+				failures[idx] = fmt.Sprintf("run: %v", err)
+				return
+			}
+			msgType, msgData, err := ReadMessage(conn)
+			if err != nil {
+				failures[idx] = fmt.Sprintf("run-resp: %v", err)
+				return
+			}
+			if msgType == MsgFailure {
+				failures[idx] = fmt.Sprintf("MERGE returned failure: %s", string(msgData))
+				return
+			}
+			if err := SendPull(t, conn, nil); err != nil {
+				failures[idx] = fmt.Sprintf("pull: %v", err)
+				return
+			}
+			for {
+				mt, md, err := ReadMessage(conn)
+				if err != nil {
+					failures[idx] = fmt.Sprintf("pull-read: %v", err)
+					return
+				}
+				if mt == MsgFailure {
+					failures[idx] = fmt.Sprintf("commit-time failure: %s", string(md))
+					return
+				}
+				if mt == MsgSuccess {
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	// Verify exactly one node exists.
+	check := openBoltTestConn(t, port)
+	records := runBoltQueryAndCollectRecords(t, check,
+		"MATCH (r:TerraformResource {uid: 'X'}) RETURN count(r)")
+	if len(records) != 1 || len(records[0]) < 1 {
+		t.Fatalf("expected one count row, got %v", records)
+	}
+	count, ok := records[0][0].(int64)
+	if !ok {
+		t.Fatalf("expected int64 count, got %T (value=%v)", records[0][0], records[0][0])
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one TerraformResource node, got %d", count)
+	}
+}

--- a/pkg/bolt/cross_session_merge_unique_test.go
+++ b/pkg/bolt/cross_session_merge_unique_test.go
@@ -1,13 +1,153 @@
 package bolt
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/orneryd/nornicdb/pkg/storage"
 )
+
+// startBoltIntegrationServerWithExplicitTx wires the test Bolt server with a
+// SessionExecutorFactory + TransactionalExecutor (txCapableCypherQueryExecutor)
+// so BEGIN/RUN/COMMIT messages route to a real explicit BadgerTransaction
+// instead of being protocol-acknowledged-but-ignored. This matches the
+// runtime shape neo4j-go-driver session.ExecuteWrite emits from Eshu.
+func startBoltIntegrationServerWithExplicitTx(t *testing.T, store storage.Engine) (*Server, int) {
+	t.Helper()
+	executor := newTxCapableCypherQueryExecutor(store)
+	server := New(&Config{
+		Port:            0,
+		MaxConnections:  32,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, executor)
+	t.Cleanup(func() {
+		server.Close()
+	})
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			t.Logf("Server error: %v", err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	return server, server.listener.Addr().(*net.TCPAddr).Port
+}
+
+// driverRetryBudget mirrors neo4j-go-driver's default session.ExecuteWrite
+// retry budget. The driver retries TransientError-coded failures with
+// exponential backoff and bounded jitter for ~30s cumulative before
+// surfacing the final error. Tests cap the attempt count at 20 to keep
+// test wall time bounded while still proving the contract.
+const driverRetryBudget = 20
+
+// driverRetryBackoff returns a deterministic-but-jittered backoff per
+// attempt. The lock-step backoff of `attempt * fixedDelay` causes
+// concurrent retriers to wake up simultaneously and immediately re-collide;
+// real neo4j-go-driver jitter avoids that. We mirror the driver shape with
+// a 50ms*2^attempt envelope plus per-call pseudo-random jitter.
+func driverRetryBackoff(attempt int, jitterSeed int) time.Duration {
+	base := time.Duration(50<<uint(attempt)) * time.Millisecond
+	if base > 2*time.Second {
+		base = 2 * time.Second
+	}
+	jitter := time.Duration(((jitterSeed*1103515245+12345)>>16)&0x7fff) * time.Microsecond
+	return base + jitter
+}
+
+// isTransientCommitCode reports whether a Bolt failure message body wraps a
+// Neo.TransientError.* status code, which neo4j-go-driver classifies as
+// retryable in session.ExecuteWrite. Used by the test helpers to mimic the
+// driver's retry loop without pulling in the actual driver dependency.
+func isTransientCommitCode(failureBody []byte) bool {
+	return bytes.Contains(failureBody, []byte("Neo.TransientError."))
+}
+
+// runBoltExplicitMergeTx runs MERGE (label {uid:"X"}) SET name='sessionN'
+// inside an explicit BEGIN/RUN/PULL/COMMIT envelope over a single Bolt
+// connection. Returns the first error encountered. This is the wire shape
+// Eshu produces through neo4j-go-driver's session.ExecuteWrite.
+func runBoltExplicitMergeTx(t *testing.T, port int, label, prop, value string, sessionTag string) error {
+	t.Helper()
+	for attempt := 0; attempt < driverRetryBudget; attempt++ {
+		err, transient := runBoltExplicitMergeTxAttempt(t, port, label, prop, value, sessionTag)
+		if err == nil {
+			return nil
+		}
+		if !transient {
+			return err
+		}
+		time.Sleep(driverRetryBackoff(attempt, attempt*7919+int(time.Now().UnixNano()&0xffff)))
+	}
+	return fmt.Errorf("explicit-tx MERGE exhausted %d retries", driverRetryBudget)
+}
+
+// runBoltExplicitMergeTxAttempt runs one BEGIN/RUN/PULL/COMMIT attempt and
+// returns (err, transient). transient=true means a Neo.TransientError
+// surfaced and the caller should retry (mimics neo4j-go-driver behavior).
+func runBoltExplicitMergeTxAttempt(t *testing.T, port int, label, prop, value string, sessionTag string) (error, bool) {
+	t.Helper()
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		return fmt.Errorf("dial: %w", err), false
+	}
+	defer conn.Close()
+	if err := PerformHandshakeWithTesting(t, conn); err != nil {
+		return fmt.Errorf("handshake: %w", err), false
+	}
+	if err := SendHello(t, conn, nil); err != nil {
+		return fmt.Errorf("hello: %w", err), false
+	}
+	if _, _, err := ReadMessage(conn); err != nil {
+		return fmt.Errorf("hello-ack: %w", err), false
+	}
+	if err := SendBegin(t, conn, nil); err != nil {
+		return fmt.Errorf("begin: %w", err), false
+	}
+	if mt, md, err := ReadMessage(conn); err != nil {
+		return fmt.Errorf("begin-resp: %w", err), false
+	} else if mt == MsgFailure {
+		return fmt.Errorf("BEGIN failure: %s", string(md)), isTransientCommitCode(md)
+	}
+	query := fmt.Sprintf("MERGE (r:%s {%s: %q}) SET r.name = %q", label, prop, value, sessionTag)
+	if err := SendRun(t, conn, query, nil, nil); err != nil {
+		return fmt.Errorf("run: %w", err), false
+	}
+	if mt, md, err := ReadMessage(conn); err != nil {
+		return fmt.Errorf("run-resp: %w", err), false
+	} else if mt == MsgFailure {
+		return fmt.Errorf("RUN failure: %s", string(md)), isTransientCommitCode(md)
+	}
+	if err := SendPull(t, conn, nil); err != nil {
+		return fmt.Errorf("pull: %w", err), false
+	}
+	for {
+		mt, md, err := ReadMessage(conn)
+		if err != nil {
+			return fmt.Errorf("pull-read: %w", err), false
+		}
+		if mt == MsgFailure {
+			return fmt.Errorf("PULL failure: %s", string(md)), isTransientCommitCode(md)
+		}
+		if mt == MsgSuccess {
+			break
+		}
+	}
+	if err := SendCommit(t, conn); err != nil {
+		return fmt.Errorf("commit: %w", err), false
+	}
+	mt, md, err := ReadMessage(conn)
+	if err != nil {
+		return fmt.Errorf("commit-resp: %w", err), false
+	}
+	if mt == MsgFailure {
+		return fmt.Errorf("COMMIT failure: %s", string(md)), isTransientCommitCode(md)
+	}
+	return nil, false
+}
 
 // TestBoltCrossSessionMergeUniqueConflict_Sequential reproduces the cross-
 // Bolt-session constraint-cache desync that surfaces in Eshu's v2.5 tfstate
@@ -189,5 +329,227 @@ func TestBoltCrossSessionMergeUniqueConflict_Concurrent(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected exactly one TerraformResource node, got %d", count)
+	}
+}
+
+// runBoltUnwindMergeExplicitTx runs the exact query shape Eshu emits from
+// its projector and resolution-engine workers:
+//
+//	UNWIND $rows AS row MERGE (r:Label {uid: row.uid}) SET r.name = row.name
+//
+// inside an explicit BEGIN/RUN/PULL/COMMIT envelope. rows is a list of {uid,
+// name} maps. This is what neo4j-go-driver session.ExecuteWrite emits in
+// the v2.5 tfstate drift verifier path.
+func runBoltUnwindMergeExplicitTx(t *testing.T, port int, label string, rows []map[string]any) error {
+	t.Helper()
+	for attempt := 0; attempt < driverRetryBudget; attempt++ {
+		err, transient := runBoltUnwindMergeExplicitTxAttempt(t, port, label, rows)
+		if err == nil {
+			return nil
+		}
+		if !transient {
+			return err
+		}
+		time.Sleep(driverRetryBackoff(attempt, attempt*7919+int(time.Now().UnixNano()&0xffff)))
+	}
+	return fmt.Errorf("UNWIND explicit-tx MERGE exhausted %d retries", driverRetryBudget)
+}
+
+func runBoltUnwindMergeExplicitTxAttempt(t *testing.T, port int, label string, rows []map[string]any) (error, bool) {
+	t.Helper()
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		return fmt.Errorf("dial: %w", err), false
+	}
+	defer conn.Close()
+	if err := PerformHandshakeWithTesting(t, conn); err != nil {
+		return fmt.Errorf("handshake: %w", err), false
+	}
+	if err := SendHello(t, conn, nil); err != nil {
+		return fmt.Errorf("hello: %w", err), false
+	}
+	if _, _, err := ReadMessage(conn); err != nil {
+		return fmt.Errorf("hello-ack: %w", err), false
+	}
+	if err := SendBegin(t, conn, nil); err != nil {
+		return fmt.Errorf("begin: %w", err), false
+	}
+	if mt, md, err := ReadMessage(conn); err != nil {
+		return fmt.Errorf("begin-resp: %w", err), false
+	} else if mt == MsgFailure {
+		return fmt.Errorf("BEGIN failure: %s", string(md)), isTransientCommitCode(md)
+	}
+	query := fmt.Sprintf("UNWIND $rows AS row MERGE (r:%s {uid: row.uid}) SET r.name = row.name", label)
+	params := map[string]any{"rows": rows}
+	if err := SendRun(t, conn, query, params, nil); err != nil {
+		return fmt.Errorf("run: %w", err), false
+	}
+	if mt, md, err := ReadMessage(conn); err != nil {
+		return fmt.Errorf("run-resp: %w", err), false
+	} else if mt == MsgFailure {
+		return fmt.Errorf("RUN failure: %s", string(md)), isTransientCommitCode(md)
+	}
+	if err := SendPull(t, conn, nil); err != nil {
+		return fmt.Errorf("pull: %w", err), false
+	}
+	for {
+		mt, md, err := ReadMessage(conn)
+		if err != nil {
+			return fmt.Errorf("pull-read: %w", err), false
+		}
+		if mt == MsgFailure {
+			return fmt.Errorf("PULL failure: %s", string(md)), isTransientCommitCode(md)
+		}
+		if mt == MsgSuccess {
+			break
+		}
+	}
+	if err := SendCommit(t, conn); err != nil {
+		return fmt.Errorf("commit: %w", err), false
+	}
+	mt, md, err := ReadMessage(conn)
+	if err != nil {
+		return fmt.Errorf("commit-resp: %w", err), false
+	}
+	if mt == MsgFailure {
+		return fmt.Errorf("COMMIT failure: %s", string(md)), isTransientCommitCode(md)
+	}
+	return nil, false
+}
+
+// TestBoltCrossSessionMergeUniqueConflict_Concurrent_ExplicitTx reproduces
+// the same race as the *_Concurrent test, but framed inside an explicit
+// BEGIN/RUN/PULL/COMMIT envelope per goroutine — the exact wire shape Eshu
+// emits through neo4j-go-driver's session.ExecuteWrite. The implicit-tx
+// retry wrapper in pkg/cypher/executor.go does NOT run for explicit-tx
+// commits, so any commit-time UNIQUE surfaces verbatim to the client.
+//
+// Contract pinned: concurrent MERGEs from explicit transactions on the
+// same constrained key must converge. One transaction creates, the other
+// MATCHes the just-committed node, neither surfaces a UNIQUE violation,
+// and exactly one node exists at the end. If the constraint cache update
+// is not visible to a peer's planner before the peer's MERGE picks its
+// branch, both transactions pick CREATE, both pass deferred validation
+// against an empty cache, the per-(label, property) commit lock
+// serializes them, but the loser's commit-time validateAllConstraints
+// fires UNIQUE and the explicit-tx commit has no retry. This is the
+// failure mode the Eshu v2.5 tfstate drift verifier hits in production.
+func TestBoltCrossSessionMergeUniqueConflict_Concurrent_ExplicitTx(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	_, port := startBoltIntegrationServerWithExplicitTx(t, store)
+
+	// Schema setup on a throwaway connection.
+	setup := openBoltTestConn(t, port)
+	runBoltQueryAndCollectRecords(t, setup,
+		"CREATE CONSTRAINT tr_uid IF NOT EXISTS FOR (r:TerraformResource) REQUIRE r.uid IS UNIQUE")
+	setup.Close()
+
+	const concurrency = 2
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			err := runBoltExplicitMergeTx(t, port,
+				"TerraformResource", "uid", "X",
+				fmt.Sprintf("session%d", idx))
+			if err != nil {
+				failures[idx] = err.Error()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	// Verify exactly one node exists.
+	check := openBoltTestConn(t, port)
+	records := runBoltQueryAndCollectRecords(t, check,
+		"MATCH (r:TerraformResource {uid: 'X'}) RETURN count(r)")
+	if len(records) != 1 || len(records[0]) < 1 {
+		t.Fatalf("expected one count row, got %v", records)
+	}
+	count, ok := records[0][0].(int64)
+	if !ok {
+		t.Fatalf("expected int64 count, got %T (value=%v)", records[0][0], records[0][0])
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one TerraformResource node, got %d", count)
+	}
+}
+
+// TestBoltCrossSessionMergeUniqueConflict_Concurrent_UnwindExplicitTx
+// scales the explicit-tx reproduction toward the exact shape Eshu emits in
+// production: many concurrent Bolt sessions doing UNWIND $rows AS row
+// MERGE (...) SET ... on overlapping uid sets. Production fails with a
+// commit-time UNIQUE surfaced from COMMIT; Eshu's RetryingExecutor retries
+// 3x before exhausting. This unit test pins the storage contract: every
+// session's commit must converge regardless of overlap.
+func TestBoltCrossSessionMergeUniqueConflict_Concurrent_UnwindExplicitTx(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	_, port := startBoltIntegrationServerWithExplicitTx(t, store)
+
+	setup := openBoltTestConn(t, port)
+	runBoltQueryAndCollectRecords(t, setup,
+		"CREATE CONSTRAINT tr_uid IF NOT EXISTS FOR (r:TerraformResource) REQUIRE r.uid IS UNIQUE")
+	setup.Close()
+
+	const (
+		concurrency = 8
+		batchSize   = 50
+	)
+
+	uids := make([]string, batchSize)
+	for i := range uids {
+		uids[i] = fmt.Sprintf("res-%03d", i)
+	}
+
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for s := 0; s < concurrency; s++ {
+		wg.Add(1)
+		go func(sessionIdx int) {
+			defer wg.Done()
+			rows := make([]map[string]any, batchSize)
+			for i, uid := range uids {
+				rows[i] = map[string]any{
+					"uid":  uid,
+					"name": fmt.Sprintf("session%d-%s", sessionIdx, uid),
+				}
+			}
+			if err := runBoltUnwindMergeExplicitTx(t, port, "TerraformResource", rows); err != nil {
+				failures[sessionIdx] = err.Error()
+			}
+		}(s)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	check := openBoltTestConn(t, port)
+	records := runBoltQueryAndCollectRecords(t, check,
+		"MATCH (r:TerraformResource) RETURN count(r)")
+	if len(records) != 1 || len(records[0]) < 1 {
+		t.Fatalf("expected one count row, got %v", records)
+	}
+	count, ok := records[0][0].(int64)
+	if !ok {
+		t.Fatalf("expected int64 count, got %T (value=%v)", records[0][0], records[0][0])
+	}
+	if count != int64(batchSize) {
+		t.Errorf("expected exactly %d TerraformResource nodes, got %d", batchSize, count)
 	}
 }

--- a/pkg/bolt/database_manager_merge_unique_test.go
+++ b/pkg/bolt/database_manager_merge_unique_test.go
@@ -1,0 +1,126 @@
+package bolt
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/orneryd/nornicdb/pkg/multidb"
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoltDatabaseManagerExecuteWriteUniqueMerge_BadgerDefaultNamespaceWithLookupIndex(t *testing.T) {
+	base, err := storage.NewBadgerEngine(t.TempDir())
+	require.NoError(t, err)
+	mgr, err := multidb.NewDatabaseManager(base, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Close()
+	})
+
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		MaxConnections:  32,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	port := startBoltTestServer(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+		func(config *neo4jdriver.Config) {
+			config.MaxTransactionRetryTime = 5 * time.Second
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = driver.Close(context.Background())
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	setup := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	_, err = setup.Run(ctx,
+		"CREATE INDEX nornicdb_terraform_resource_uid_lookup IF NOT EXISTS FOR (n:TerraformResource) ON (n.uid)",
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = setup.Run(ctx,
+		"CREATE CONSTRAINT terraform_resource_uid_unique IF NOT EXISTS FOR (n:TerraformResource) REQUIRE n.uid IS UNIQUE",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close(ctx))
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	failures := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+				AccessMode:   neo4jdriver.AccessModeWrite,
+				DatabaseName: "nornic",
+			})
+			defer func() {
+				_ = session.Close(ctx)
+			}()
+			_, execErr := session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+				result, runErr := tx.Run(ctx,
+					`UNWIND $rows AS row
+MERGE (r:TerraformResource {uid: row.uid})
+SET r.name = row.name`,
+					map[string]any{
+						"rows": []map[string]any{
+							{
+								"uid":  "badger-dbmanager-same-uid",
+								"name": fmt.Sprintf("session%d", idx),
+							},
+						},
+					},
+				)
+				if runErr != nil {
+					return nil, runErr
+				}
+				_, consumeErr := result.Consume(ctx)
+				return nil, consumeErr
+			})
+			if execErr != nil {
+				failures[idx] = execErr.Error()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for idx, msg := range failures {
+		if msg != "" {
+			t.Errorf("session %d failed: %s", idx, msg)
+		}
+	}
+
+	check := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeRead,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		_ = check.Close(ctx)
+	}()
+	result, err := check.Run(ctx,
+		"MATCH (r:TerraformResource {uid: $uid}) RETURN count(r)",
+		map[string]any{"uid": "badger-dbmanager-same-uid"},
+	)
+	require.NoError(t, err)
+	record, err := result.Single(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, record.Values[0])
+}

--- a/pkg/bolt/server.go
+++ b/pkg/bolt/server.go
@@ -1865,8 +1865,23 @@ func mapBoltQueryError(err error) (code, message string) {
 // mapBoltCommitError preserves Bolt's commit-failed fallback for ordinary
 // errors while allowing retryable transaction conflicts to surface as Neo4j
 // transient errors.
+//
+// A commit-time UNIQUE constraint violation from a concurrent MERGE race is
+// resolvable by a fresh attempt: the loser, on retry, observes the peer's
+// now-committed node via the constraint cache and the MERGE matches. The
+// raw storage error does not wrap ErrTransactionConflict (it is built via
+// fmt.Errorf), so the standard sentinel-based mapper would classify it as
+// a ClientError. Pattern-match the error body via
+// nornicerrors.IsMergeCommitTimeUniqueConflict so neo4j-go-driver's
+// session.ExecuteWrite (and any retryable-error-aware client) auto-retries
+// against the post-commit cache state. Genuine duplicate-key violations
+// from non-MERGE writes will share the same body but originate from a path
+// that does not carry the commit-prefix substrings the classifier requires.
 func mapBoltCommitError(err error) (code, message string) {
 	code, message = mapBoltQueryError(err)
+	if err != nil && nornicerrors.IsMergeCommitTimeUniqueConflict(err) {
+		return nornicerrors.TransientOutdated, message
+	}
 	if code == "Neo.ClientError.Statement.SyntaxError" {
 		return "Neo.ClientError.Transaction.TransactionCommitFailed", message
 	}

--- a/pkg/cypher/executor.go
+++ b/pkg/cypher/executor.go
@@ -1812,10 +1812,104 @@ func (e *StorageExecutor) executeImplicitAsync(ctx context.Context, cypher strin
 	return e.executeWithoutTransaction(ctx, cypher, upperQuery)
 }
 
-// executeWithImplicitTransaction wraps a write query in an implicit transaction.
-// If any part of the query fails, all changes are rolled back atomically.
-// This prevents data corruption from partially executed queries.
+// mergeCommitRetryBudget bounds the number of additional implicit-transaction
+// attempts permitted after a commit-time UNIQUE constraint violation on a
+// MERGE-shaped query. Concurrent MERGE on the same constrained key can race
+// past the deferred-validation pass (each transaction sees the cache as
+// empty while the peer is in flight); the first commit lands, the second
+// commit fires UNIQUE at the storage layer. Re-running the implicit
+// transaction makes the loser see the now-committed peer node and converge
+// to MATCH semantics. Bounded so a genuine UNIQUE conflict (truly
+// duplicate user-provided values that no MERGE will ever resolve) still
+// fails fast.
+const mergeCommitRetryBudget = 5
+
+// mergeCommitRetryBaseDelay is the initial backoff before retrying a
+// commit-time MERGE/UNIQUE conflict. Doubles each attempt. Chosen so that
+// 5 retries span a window long enough to outlast a typical peer
+// transaction's commit, while still finishing within a single Bolt RUN
+// latency budget on success.
+const mergeCommitRetryBaseDelay = 50 * time.Millisecond
+
+// commitMergeRetryableError marks a "failed to commit implicit transaction"
+// error as resulting from a concurrent-MERGE race that a fresh attempt
+// would resolve. It is set only inside executeWithImplicitTransactionAttempt
+// and consumed only by executeWithImplicitTransaction's retry loop. The
+// wrapped error remains the original commit-time error so callers that
+// inspect error strings (e.g. "failed to commit implicit transaction")
+// observe unchanged behavior on the final attempt.
+type commitMergeRetryableError struct {
+	err error
+}
+
+func (e *commitMergeRetryableError) Error() string { return e.err.Error() }
+func (e *commitMergeRetryableError) Unwrap() error { return e.err }
+
+// isMergeCommitTimeUniqueConflict matches the storage-layer constraint
+// violation message that surfaces when a MERGE-driven CREATE loses a race
+// to a concurrent peer transaction. Both pre- and post-v1.0.45 NornicDB
+// shapes are accepted: older releases wrap as "failed to commit implicit
+// transaction: constraint violation:..." and v1.0.45+ wraps as
+// Neo.ClientError.Transaction.TransactionCommitFailed with body
+// "commit failed: constraint violation:...". Both describe the same race
+// class and are safe to retry on a MERGE-shaped statement.
+func isMergeCommitTimeUniqueConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "constraint violation") {
+		return false
+	}
+	if !strings.Contains(msg, "UNIQUE on") {
+		return false
+	}
+	if !strings.Contains(msg, "already exists") {
+		return false
+	}
+	return strings.Contains(msg, "failed to commit implicit transaction") ||
+		strings.Contains(msg, "commit failed") ||
+		strings.Contains(msg, "TransactionCommitFailed")
+}
+
+// executeWithImplicitTransaction wraps a write query in an implicit
+// transaction with bounded retry on commit-time UNIQUE conflicts for
+// MERGE-shaped statements. Without the retry, two Bolt sessions racing
+// to MERGE the same constrained key both pass the deferred-validation
+// pass against the (still-empty) constraint cache, both reach commit,
+// and the second commit fails with UNIQUE — even though MERGE's contract
+// is that the loser should MATCH the winning node, not fail. The retry
+// re-runs the entire implicit transaction; the next attempt sees the
+// peer's committed node and the MERGE matches.
+//
+// Non-MERGE queries and non-retryable commit failures (e.g. genuine
+// duplicate-key violations from user-provided data) bypass the retry
+// path and surface immediately.
 func (e *StorageExecutor) executeWithImplicitTransaction(ctx context.Context, cypher string, upperQuery string) (*ExecuteResult, error) {
+	isMergeQuery := strings.Contains(upperQuery, "MERGE")
+	for attempt := 0; ; attempt++ {
+		result, err := e.executeWithImplicitTransactionAttempt(ctx, cypher, upperQuery)
+		if err == nil {
+			return result, nil
+		}
+		var retryable *commitMergeRetryableError
+		if !isMergeQuery || attempt >= mergeCommitRetryBudget || !errors.As(err, &retryable) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(mergeCommitRetryBaseDelay << uint(attempt)):
+		}
+	}
+}
+
+// executeWithImplicitTransactionAttempt is the single-attempt body of
+// executeWithImplicitTransaction. On commit-time UNIQUE conflict for a
+// concurrent-MERGE race, it wraps the error in commitMergeRetryableError
+// so the outer wrapper can decide whether to retry. All other failure
+// modes return as-is.
+func (e *StorageExecutor) executeWithImplicitTransactionAttempt(ctx context.Context, cypher string, upperQuery string) (*ExecuteResult, error) {
 	parsedCypher, inlineEmbeddingEnabled := stripWithEmbeddingSuffix(cypher)
 	if inlineEmbeddingEnabled {
 		cypher = parsedCypher
@@ -1965,7 +2059,22 @@ func (e *StorageExecutor) executeWithImplicitTransaction(ctx context.Context, cy
 		if wal != nil && walSeqStart > 0 {
 			_, _ = wal.AppendTxAbort(dbName, txID, err.Error())
 		}
-		return nil, fmt.Errorf("failed to commit implicit transaction: %w", err)
+		wrapped := fmt.Errorf("failed to commit implicit transaction: %w", err)
+		// A commit-time UNIQUE constraint violation on a MERGE-shaped query
+		// signals a race with a peer transaction that committed a node with
+		// the same constrained property between this transaction's
+		// deferred-validation pass and its commit. The outer wrapper
+		// re-runs the implicit transaction so the loser observes the
+		// peer's now-committed node and the MERGE matches.
+		//
+		// Classify against the WRAPPED error so the commit-prefix substring
+		// the classifier looks for is present; tx.Commit's raw error wraps
+		// the constraint violation but does not add a "failed to commit"
+		// prefix on its own.
+		if isMergeCommitTimeUniqueConflict(wrapped) && strings.Contains(upperQuery, "MERGE") {
+			return nil, &commitMergeRetryableError{err: wrapped}
+		}
+		return nil, wrapped
 	}
 
 	// Attach receipt metadata if WAL markers were recorded.

--- a/pkg/cypher/executor.go
+++ b/pkg/cypher/executor.go
@@ -2272,6 +2272,20 @@ type transactionStorageWrapper struct {
 	mutatedNodeIDsMu sync.Mutex
 }
 
+func (w *transactionStorageWrapper) Namespace() string {
+	if w == nil {
+		return ""
+	}
+	return w.namespace
+}
+
+func (w *transactionStorageWrapper) GetEngine() storage.Engine {
+	if w == nil {
+		return nil
+	}
+	return w.underlying
+}
+
 func (w *transactionStorageWrapper) markMutatedNodeID(id storage.NodeID) {
 	if id == "" || w.mutatedNodeIDs == nil {
 		return

--- a/pkg/cypher/merge.go
+++ b/pkg/cypher/merge.go
@@ -244,13 +244,15 @@ func (e *StorageExecutor) findMergeNode(store storage.Engine, labels []string, p
 
 		for _, prop := range mergePropertyNamesSorted(props) {
 			val := props[prop]
-			nodeID, valueFound, constraintExists := schema.LookupUniqueConstraintValue(label, prop, val)
+			nodeID, valueFound, constraintExists, authoritative := schema.LookupUniqueConstraintValueForPlanning(label, prop, val)
 			if !constraintExists {
 				continue
 			}
-			schemaLookupUsed = true
 			e.markMergeSchemaLookupUsed()
 			if !valueFound {
+				if authoritative {
+					schemaLookupUsed = true
+				}
 				continue
 			}
 			for _, n := range e.loadMergeCandidateNodes(store, []storage.NodeID{nodeID}) {
@@ -258,6 +260,9 @@ func (e *StorageExecutor) findMergeNode(store storage.Engine, labels []string, p
 					e.cacheMergeNode(labels, props, n)
 					return n, nil
 				}
+			}
+			if authoritative {
+				schemaLookupUsed = true
 			}
 		}
 

--- a/pkg/cypher/merge_unique_cache_test.go
+++ b/pkg/cypher/merge_unique_cache_test.go
@@ -1,0 +1,51 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeUniqueConstraintNonAuthoritativeCacheFallsBackToScan verifies that
+// MERGE does not trust a missing UNIQUE-cache entry unless that cache has been
+// rebuilt or maintained authoritatively. Commit-time validation already falls
+// back to a label scan in this state; MERGE planning must do the same so it can
+// MATCH the committed node instead of choosing CREATE and failing at commit.
+func TestMergeUniqueConstraintNonAuthoritativeCacheFallsBackToScan(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	t.Cleanup(func() {
+		_ = baseStore.Close()
+	})
+	store := storage.NewNamespacedEngine(baseStore, "nornic")
+	_, err := store.CreateNode(&storage.Node{
+		ID:     "existing",
+		Labels: []string{"TerraformResource"},
+		Properties: map[string]interface{}{
+			"uid":  "cache-miss",
+			"name": "before",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.GetSchema().AddUniqueConstraint("tr_uid", "TerraformResource", "uid"))
+
+	exec := NewStorageExecutor(store)
+	_, err = exec.Execute(context.Background(),
+		"MERGE (r:TerraformResource {uid: $uid}) SET r.name = $name",
+		map[string]interface{}{
+			"uid":  "cache-miss",
+			"name": "after",
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := exec.Execute(context.Background(),
+		"MATCH (r:TerraformResource {uid: $uid}) RETURN r.name, count(r)",
+		map[string]interface{}{"uid": "cache-miss"},
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.Equal(t, "after", result.Rows[0][0])
+	require.EqualValues(t, 1, result.Rows[0][1])
+}

--- a/pkg/cypher/merge_unique_cache_test.go
+++ b/pkg/cypher/merge_unique_cache_test.go
@@ -49,3 +49,47 @@ func TestMergeUniqueConstraintNonAuthoritativeCacheFallsBackToScan(t *testing.T)
 	require.Equal(t, "after", result.Rows[0][0])
 	require.EqualValues(t, 1, result.Rows[0][1])
 }
+
+// TestUnwindMergeUniqueConstraintNonAuthoritativeCacheFallsBackToScan covers
+// the batched canonical-write path Eshu uses: UNWIND rows into MERGE node
+// upserts. It has the same cache rule as scalar MERGE; a non-authoritative
+// missing UNIQUE value must fall back to storage before CREATE is chosen.
+func TestUnwindMergeUniqueConstraintNonAuthoritativeCacheFallsBackToScan(t *testing.T) {
+	baseStore := storage.NewMemoryEngine()
+	t.Cleanup(func() {
+		_ = baseStore.Close()
+	})
+	store := storage.NewNamespacedEngine(baseStore, "nornic")
+	_, err := store.CreateNode(&storage.Node{
+		ID:     "existing",
+		Labels: []string{"TerraformResource"},
+		Properties: map[string]interface{}{
+			"uid":  "unwind-cache-miss",
+			"name": "before",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.GetSchema().AddUniqueConstraint("tr_uid", "TerraformResource", "uid"))
+
+	exec := NewStorageExecutor(store)
+	_, err = exec.Execute(context.Background(),
+		`UNWIND $rows AS row
+MERGE (r:TerraformResource {uid: row.uid})
+SET r.name = row.name`,
+		map[string]interface{}{
+			"rows": []map[string]interface{}{
+				{"uid": "unwind-cache-miss", "name": "after"},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := exec.Execute(context.Background(),
+		"MATCH (r:TerraformResource {uid: $uid}) RETURN r.name, count(r)",
+		map[string]interface{}{"uid": "unwind-cache-miss"},
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.Equal(t, "after", result.Rows[0][0])
+	require.EqualValues(t, 1, result.Rows[0][1])
+}

--- a/pkg/cypher/schema.go
+++ b/pkg/cypher/schema.go
@@ -75,6 +75,9 @@ func (e *StorageExecutor) executeSchemaCommand(ctx context.Context, cypher strin
 			"Schema DDL on composite databases requires a constituent target. " +
 			"Use USE <composite>.<alias> to target a specific constituent")
 	}
+	if err := flushPendingAsyncWritesBeforeSchemaDDL(e.storage); err != nil {
+		return nil, err
+	}
 
 	upper := strings.ToUpper(cypher)
 
@@ -104,6 +107,34 @@ func (e *StorageExecutor) executeSchemaCommand(ctx context.Context, cypher strin
 	}
 
 	return result, err
+}
+
+func flushPendingAsyncWritesBeforeSchemaDDL(engine storage.Engine) error {
+	visited := make(map[storage.Engine]bool)
+	for engine != nil && !visited[engine] {
+		visited[engine] = true
+
+		if async, ok := engine.(interface {
+			HasPendingWrites() bool
+			Flush() error
+		}); ok {
+			if async.HasPendingWrites() {
+				if err := async.Flush(); err != nil {
+					return fmt.Errorf("flush pending async writes before schema DDL: %w", err)
+				}
+			}
+		}
+
+		switch wrapper := engine.(type) {
+		case interface{ GetEngine() storage.Engine }:
+			engine = wrapper.GetEngine()
+		case interface{ GetInnerEngine() storage.Engine }:
+			engine = wrapper.GetInnerEngine()
+		default:
+			engine = nil
+		}
+	}
+	return nil
 }
 
 // executeCreateConstraint handles CREATE CONSTRAINT commands.
@@ -1428,7 +1459,8 @@ func (e *StorageExecutor) backfillPropertyIndex(label string, properties []strin
 		if !ok {
 			continue
 		}
-		if err := schema.PropertyIndexInsert(label, property, node.ID, value); err != nil {
+		nodeID := storage.EnsureNodeIDDatabasePrefixForEngine(e.storage, node.ID)
+		if err := schema.PropertyIndexInsert(label, property, nodeID, value); err != nil {
 			return fmt.Errorf("failed to backfill property index %s(%s): %w", label, property, err)
 		}
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	stderrors "errors"
+	"strings"
 
 	"github.com/orneryd/nornicdb/pkg/storage"
 )
@@ -48,5 +49,49 @@ func MapTransientTransactionError(err error) (string, bool) {
 		stderrors.Is(err, ErrMVCCSnapshotHardExpired) {
 		return TransientOutdated, true
 	}
+	if IsMergeCommitTimeUniqueConflict(err) {
+		return TransientOutdated, true
+	}
 	return "", false
+}
+
+// IsMergeCommitTimeUniqueConflict reports whether an error looks like a
+// commit-time UNIQUE constraint violation from a concurrent-MERGE race, as
+// opposed to a user-supplied duplicate-key violation in a CREATE. The
+// distinction matters for protocol-level retry classification: a MERGE race
+// is resolvable by a fresh attempt (the loser observes the peer's now-
+// committed node and matches), while a user duplicate-key in CREATE is not.
+//
+// The classifier matches both pre- and post-v1.0.45 NornicDB wraps:
+//   - older releases: "failed to commit implicit transaction: constraint
+//     violation: Constraint violation (UNIQUE on Label.[prop]): Node with
+//     prop=value already exists (nodeID: ...)"
+//   - newer (explicit-tx commit): "commit failed: constraint violation:
+//     Constraint violation (UNIQUE on Label.[prop]): Node with prop=value
+//     already exists (nodeID: ...)"
+//
+// We classify by message shape because the underlying storage error is a
+// plain fmt.Errorf without a sentinel wrap, and threading a MERGE-shape
+// signal from the cypher executor through the storage layer is a larger
+// design change than this surgical fix. The shape is precise enough that
+// only MERGE/UNIQUE races match it — duplicate-key CREATEs share the
+// same body but originate from a different call site that does not carry
+// the "commit failed"/"failed to commit implicit transaction" prefix.
+func IsMergeCommitTimeUniqueConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "constraint violation") {
+		return false
+	}
+	if !strings.Contains(msg, "UNIQUE on") {
+		return false
+	}
+	if !strings.Contains(msg, "already exists") {
+		return false
+	}
+	return strings.Contains(msg, "failed to commit implicit transaction") ||
+		strings.Contains(msg, "commit failed") ||
+		strings.Contains(msg, "TransactionCommitFailed")
 }

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -2332,16 +2332,28 @@ func (tx *BadgerTransaction) checkTemporalConstraint(node *Node, c Constraint) e
 
 // validateAllConstraints performs final validation before commit.
 // acquireUniqueConstraintCommitLocks collects the unique constraints touched
-// by this transaction's pending nodes and acquires per-(label, property)
-// mutexes on each affected schema. Returns a release function that unlocks
-// in reverse order; safe to defer.
+// by this transaction's pending nodes and acquires per-(label, property,
+// value) mutexes on each affected schema. Returns a release function that
+// unlocks in reverse order; safe to defer.
+//
+// Locks are per-value, not per-constraint: a transaction adding nodes with
+// uids "X" and "Y" acquires two separate locks; a peer transaction with
+// uids "X" and "Z" serializes only against the "X" lock and commits its
+// "Z" write in parallel. This was changed from coarser per-(label,
+// property) granularity that effectively serialized every writer touching
+// a UNIQUE-constrained property — see uniqueConstraintLockKey doc.
 //
 // Locks are partitioned by namespace because each namespace has its own
 // SchemaManager and its own constraint registry — a transaction that spans
-// multiple namespaces locks each namespace's affected constraints
-// independently. Namespaces are processed in sorted order so that two
-// transactions touching overlapping namespaces always acquire locks in the
-// same order, eliminating the AB-BA deadlock risk.
+// multiple namespaces locks each namespace's affected values independently.
+// Namespaces are processed in sorted order so that two transactions
+// touching overlapping namespaces always acquire locks in the same order,
+// eliminating the AB-BA deadlock risk.
+//
+// Pending nodes with non-comparable property values skip lock acquisition
+// for that property. Constraint validation still fires at commit time;
+// commit-window serialization is best-effort for non-comparable types
+// (which UNIQUE-constrained Eshu/Neo4j workloads do not use in practice).
 func (tx *BadgerTransaction) acquireUniqueConstraintCommitLocks() func() {
 	if len(tx.pendingNodes) == 0 {
 		return func() {}
@@ -2365,13 +2377,25 @@ func (tx *BadgerTransaction) acquireUniqueConstraintCommitLocks() func() {
 				continue
 			}
 			prop := c.Properties[0]
-			if _, has := node.Properties[prop]; !has {
+			rawValue, has := node.Properties[prop]
+			if !has {
+				continue
+			}
+			canonicalValue, ok := uniqueConstraintValueKey(rawValue)
+			if !ok {
+				// Non-comparable value: skip lock acquisition. Validation
+				// still runs at commit; commit-window serialization is
+				// best-effort for these (no constraint cache anyway).
 				continue
 			}
 			if perNamespace[dbName] == nil {
 				perNamespace[dbName] = make(map[uniqueConstraintLockKey]struct{})
 			}
-			perNamespace[dbName][uniqueConstraintLockKey{label: c.Label, property: prop}] = struct{}{}
+			perNamespace[dbName][uniqueConstraintLockKey{
+				label:    c.Label,
+				property: prop,
+				value:    canonicalValue,
+			}] = struct{}{}
 		}
 	}
 	if len(perNamespace) == 0 {

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1366,6 +1367,22 @@ func (tx *BadgerTransaction) Commit() error {
 		return err
 	}
 
+	// Acquire per-(label, property) commit locks for every unique constraint
+	// touched by this transaction's pending nodes. Held across
+	// validateAllConstraints + badgerTx.Commit + the post-commit
+	// RegisterUniqueValue calls below so that a peer transaction touching the
+	// same constraint cannot pass validation against an empty cache while we
+	// are still committing. Without this lock, two concurrent transactions
+	// that both add a node with the same constrained property value both pass
+	// the deferred validation (cache empty for both), both reach
+	// badgerTx.Commit (Badger writes them under distinct node IDs so the KV
+	// layer does not detect the conflict), and both call RegisterUniqueValue —
+	// the second overwriting the first — leaving the UNIQUE constraint
+	// silently violated in storage. See cross_session_merge_unique_test.go
+	// for the reproduction.
+	releaseCommitLocks := tx.acquireUniqueConstraintCommitLocks()
+	defer releaseCommitLocks()
+
 	// Final constraint validation before commit
 	if err := tx.validateAllConstraints(); err != nil {
 		tx.closeLocked(TxStatusRolledBack, true, nil)
@@ -2314,6 +2331,78 @@ func (tx *BadgerTransaction) checkTemporalConstraint(node *Node, c Constraint) e
 }
 
 // validateAllConstraints performs final validation before commit.
+// acquireUniqueConstraintCommitLocks collects the unique constraints touched
+// by this transaction's pending nodes and acquires per-(label, property)
+// mutexes on each affected schema. Returns a release function that unlocks
+// in reverse order; safe to defer.
+//
+// Locks are partitioned by namespace because each namespace has its own
+// SchemaManager and its own constraint registry — a transaction that spans
+// multiple namespaces locks each namespace's affected constraints
+// independently. Namespaces are processed in sorted order so that two
+// transactions touching overlapping namespaces always acquire locks in the
+// same order, eliminating the AB-BA deadlock risk.
+func (tx *BadgerTransaction) acquireUniqueConstraintCommitLocks() func() {
+	if len(tx.pendingNodes) == 0 {
+		return func() {}
+	}
+	perNamespace := make(map[string]map[uniqueConstraintLockKey]struct{})
+	for _, node := range tx.pendingNodes {
+		if node == nil {
+			continue
+		}
+		dbName, _, ok := ParseDatabasePrefix(string(node.ID))
+		if !ok {
+			continue
+		}
+		schema := tx.engine.GetSchemaForNamespace(dbName)
+		if schema == nil {
+			continue
+		}
+		constraints := schema.GetConstraintsForLabels(node.Labels)
+		for _, c := range constraints {
+			if c.Type != ConstraintUnique || len(c.Properties) != 1 {
+				continue
+			}
+			prop := c.Properties[0]
+			if _, has := node.Properties[prop]; !has {
+				continue
+			}
+			if perNamespace[dbName] == nil {
+				perNamespace[dbName] = make(map[uniqueConstraintLockKey]struct{})
+			}
+			perNamespace[dbName][uniqueConstraintLockKey{label: c.Label, property: prop}] = struct{}{}
+		}
+	}
+	if len(perNamespace) == 0 {
+		return func() {}
+	}
+
+	namespaces := make([]string, 0, len(perNamespace))
+	for ns := range perNamespace {
+		namespaces = append(namespaces, ns)
+	}
+	sort.Strings(namespaces)
+
+	releases := make([]func(), 0, len(namespaces))
+	for _, ns := range namespaces {
+		schema := tx.engine.GetSchemaForNamespace(ns)
+		if schema == nil {
+			continue
+		}
+		keys := make([]uniqueConstraintLockKey, 0, len(perNamespace[ns]))
+		for k := range perNamespace[ns] {
+			keys = append(keys, k)
+		}
+		releases = append(releases, schema.acquireUniqueConstraintCommitLocks(keys))
+	}
+	return func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}
+}
+
 func (tx *BadgerTransaction) validateAllConstraints() error {
 	for _, node := range tx.pendingNodes {
 		if err := tx.validateNodeConstraints(node); err != nil {

--- a/pkg/storage/constraint_validation.go
+++ b/pkg/storage/constraint_validation.go
@@ -68,12 +68,13 @@ func RefreshUniqueConstraintValuesForEngine(engine Engine, schema *SchemaManager
 		if node == nil {
 			continue
 		}
+		storageNodeID := EnsureNodeIDDatabasePrefixForEngine(engine, node.ID)
 		for _, label := range node.Labels {
 			for propName, propValue := range node.Properties {
-				if err := schema.CheckUniqueConstraint(label, propName, propValue, node.ID); err != nil {
+				if err := schema.CheckUniqueConstraint(label, propName, propValue, storageNodeID); err != nil {
 					return fmt.Errorf("refresh unique constraint values: %w", err)
 				}
-				schema.RegisterUniqueValue(label, propName, propValue, node.ID)
+				schema.RegisterUniqueValue(label, propName, propValue, storageNodeID)
 			}
 		}
 	}

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -74,6 +74,16 @@ func (c Constraint) EffectiveEntityType() ConstraintEntityType {
 type SchemaManager struct {
 	mu sync.RWMutex
 
+	// Per-(label, property) commit-time mutexes for unique constraints.
+	// Acquired by BadgerTransaction.Commit BEFORE validateAllConstraints and
+	// released AFTER RegisterUniqueValue, so that two transactions touching
+	// the same unique constraint cannot both pass validation against an
+	// empty cache and both register conflicting values. Created lazily on
+	// first acquisition; the registry mutex guards only the map itself, the
+	// per-key mutexes are independent.
+	uniqueConstraintCommitLocksMu sync.Mutex
+	uniqueConstraintCommitLocks   map[uniqueConstraintLockKey]*sync.Mutex
+
 	// Constraints
 	uniqueConstraints       map[string]*UniqueConstraint      // key: "Label:property"
 	constraints             map[string]Constraint             // key: constraint name, stores all constraint types
@@ -694,6 +704,73 @@ func isComparableConstraintValue(value interface{}) bool {
 		return true
 	}
 	return reflect.TypeOf(value).Comparable()
+}
+
+// uniqueConstraintLockKey identifies one (label, property) pair for the
+// purpose of acquiring a commit-time mutex. Two transactions whose pending
+// nodes touch overlapping keys serialize at commit; transactions touching
+// disjoint constraints commit in parallel.
+type uniqueConstraintLockKey struct {
+	label    string
+	property string
+}
+
+// acquireUniqueConstraintCommitLocks acquires per-(label, property) mutexes
+// in a deterministic order (sorted by label, then property) and returns a
+// release function. Deterministic ordering eliminates the AB-BA deadlock
+// risk when two transactions both touch the same N>1 constraints.
+//
+// Duplicate keys in the input are deduplicated. An empty input returns a
+// no-op release function so callers can safely defer the result regardless
+// of whether locks were acquired.
+//
+// The lock guards the entire commit window — validateAllConstraints,
+// badgerTx.Commit, and the RegisterUniqueValue calls that publish committed
+// values to the constraint cache — so a subsequent transaction's
+// validation always observes a coherent cache.
+func (sm *SchemaManager) acquireUniqueConstraintCommitLocks(keys []uniqueConstraintLockKey) func() {
+	if len(keys) == 0 {
+		return func() {}
+	}
+	deduped := keys[:0:0]
+	seen := make(map[uniqueConstraintLockKey]struct{}, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		deduped = append(deduped, k)
+	}
+	sort.Slice(deduped, func(i, j int) bool {
+		if deduped[i].label != deduped[j].label {
+			return deduped[i].label < deduped[j].label
+		}
+		return deduped[i].property < deduped[j].property
+	})
+
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	if sm.uniqueConstraintCommitLocks == nil {
+		sm.uniqueConstraintCommitLocks = make(map[uniqueConstraintLockKey]*sync.Mutex)
+	}
+	locks := make([]*sync.Mutex, 0, len(deduped))
+	for _, k := range deduped {
+		m, ok := sm.uniqueConstraintCommitLocks[k]
+		if !ok {
+			m = &sync.Mutex{}
+			sm.uniqueConstraintCommitLocks[k] = m
+		}
+		locks = append(locks, m)
+	}
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+
+	for _, m := range locks {
+		m.Lock()
+	}
+	return func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}
 }
 
 // RegisterUniqueValue registers a value for a unique constraint.

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -706,28 +706,50 @@ func isComparableConstraintValue(value interface{}) bool {
 	return reflect.TypeOf(value).Comparable()
 }
 
-// uniqueConstraintLockKey identifies one (label, property) pair for the
-// purpose of acquiring a commit-time mutex. Two transactions whose pending
-// nodes touch overlapping keys serialize at commit; transactions touching
-// disjoint constraints commit in parallel.
+// uniqueConstraintLockKey identifies one (label, property, value) triple for
+// the purpose of acquiring a commit-time mutex. Two transactions whose
+// pending nodes touch the same (label, property, value) serialize at commit;
+// transactions touching disjoint values commit in parallel — the lock
+// granularity is per-key-value, not per-constraint.
+//
+// The value is stored in its canonical comparable form returned by
+// uniqueConstraintValueKey so semantically equal but type-distinct values
+// (e.g. int and int64) hash to the same lock and serialize correctly. Values
+// that are not comparable cannot acquire a lock; their constraint is still
+// validated at commit but without commit-window serialization. (In practice
+// every UNIQUE-constrained property in Eshu and Neo4j-compatible workloads
+// uses comparable scalar types — strings, ints, floats, bools.)
+//
+// Lock granularity history: an earlier per-(label, property) design
+// effectively serialized every writer touching any value of a constrained
+// property. Under bootstrap-index Pass 2 fan-out (8 projector workers + the
+// collector + the ingester all writing TerraformResource nodes with
+// disjoint uids), this collapsed throughput to single-writer levels — a
+// "serialization workaround" in disguise. Per-value locking lets disjoint
+// writers commit concurrently while still preventing the silent-overwrite
+// race that motivated the lock.
 type uniqueConstraintLockKey struct {
 	label    string
 	property string
+	value    interface{}
 }
 
-// acquireUniqueConstraintCommitLocks acquires per-(label, property) mutexes
-// in a deterministic order (sorted by label, then property) and returns a
-// release function. Deterministic ordering eliminates the AB-BA deadlock
-// risk when two transactions both touch the same N>1 constraints.
+// acquireUniqueConstraintCommitLocks acquires per-(label, property, value)
+// mutexes in a deterministic order (sorted by label, then property, then a
+// stable string form of the value) and returns a release function.
+// Deterministic ordering eliminates the AB-BA deadlock risk when two
+// transactions both touch overlapping sets of constrained values.
 //
 // Duplicate keys in the input are deduplicated. An empty input returns a
 // no-op release function so callers can safely defer the result regardless
 // of whether locks were acquired.
 //
-// The lock guards the entire commit window — validateAllConstraints,
-// badgerTx.Commit, and the RegisterUniqueValue calls that publish committed
-// values to the constraint cache — so a subsequent transaction's
-// validation always observes a coherent cache.
+// The lock guards the entire commit window for its specific value —
+// validateAllConstraints, badgerTx.Commit, and the RegisterUniqueValue call
+// that publishes the committed value to the constraint cache — so a
+// subsequent transaction touching the same value always observes a coherent
+// cache. Transactions touching disjoint values acquire disjoint locks and
+// commit in parallel.
 func (sm *SchemaManager) acquireUniqueConstraintCommitLocks(keys []uniqueConstraintLockKey) func() {
 	if len(keys) == 0 {
 		return func() {}
@@ -745,7 +767,10 @@ func (sm *SchemaManager) acquireUniqueConstraintCommitLocks(keys []uniqueConstra
 		if deduped[i].label != deduped[j].label {
 			return deduped[i].label < deduped[j].label
 		}
-		return deduped[i].property < deduped[j].property
+		if deduped[i].property != deduped[j].property {
+			return deduped[i].property < deduped[j].property
+		}
+		return fmt.Sprintf("%v", deduped[i].value) < fmt.Sprintf("%v", deduped[j].value)
 	})
 
 	sm.uniqueConstraintCommitLocksMu.Lock()

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -646,25 +646,35 @@ func (sm *SchemaManager) CheckUniqueConstraint(label, property string, value int
 // whether the value is present, and the third reports whether the unique
 // constraint exists.
 func (sm *SchemaManager) LookupUniqueConstraintValue(label, property string, value interface{}) (NodeID, bool, bool) {
+	nodeID, found, exists, _ := sm.LookupUniqueConstraintValueForPlanning(label, property, value)
+	return nodeID, found, exists
+}
+
+// LookupUniqueConstraintValueForPlanning returns the node currently registered
+// for a single-property uniqueness constraint value, plus whether the derived
+// value cache is authoritative. Planners may trust absence only when
+// authoritative is true; otherwise they must retain a scan fallback because the
+// cache may not have been rebuilt from storage yet.
+func (sm *SchemaManager) LookupUniqueConstraintValueForPlanning(label, property string, value interface{}) (NodeID, bool, bool, bool) {
 	sm.mu.RLock()
 	key := fmt.Sprintf("%s:%s", label, property)
 	constraint, exists := sm.uniqueConstraints[key]
 	sm.mu.RUnlock()
 	if !exists || value == nil {
-		return "", false, exists
+		return "", false, exists, false
 	}
 	valueKey, ok := uniqueConstraintValueKey(value)
 	if !ok {
-		return "", false, true
+		return "", false, true, false
 	}
 	if !isComparableConstraintValue(value) {
-		return "", true, false
+		return "", true, false, false
 	}
 
 	constraint.mu.RLock()
 	defer constraint.mu.RUnlock()
 	nodeID, found := constraint.values[valueKey]
-	return nodeID, found, true
+	return nodeID, found, true, constraint.valuesAuthoritative
 }
 
 func (sm *SchemaManager) lookupUniqueConstraintValueForValidation(label, property string, value interface{}) (NodeID, bool, bool, bool) {

--- a/pkg/storage/unique_lock_granularity_test.go
+++ b/pkg/storage/unique_lock_granularity_test.go
@@ -1,0 +1,169 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestUniqueConstraintCommitLocks_DisjointValuesAreParallel pins the
+// contract that two transactions whose pending nodes touch disjoint values
+// for the same (label, property) constraint commit in parallel — they do
+// NOT serialize on each other.
+//
+// Earlier per-(label, property) granularity collapsed throughput to
+// single-writer levels under bootstrap-index Pass 2 fan-out: 8 projector
+// workers + collector + ingester all writing TerraformResource nodes with
+// disjoint uids would serialize at the commit boundary, an effective
+// WORKERS=1 contract in disguise. This test fails (deadlock or timeout)
+// under the old coarse granularity and passes under per-value granularity.
+func TestUniqueConstraintCommitLocks_DisjointValuesAreParallel(t *testing.T) {
+	sm := &SchemaManager{}
+
+	// T1 holds the lock for value "X" indefinitely (until we signal).
+	t1Acquired := make(chan struct{})
+	t1Release := make(chan struct{})
+	t1Done := make(chan struct{})
+	go func() {
+		defer close(t1Done)
+		release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{
+			{label: "TerraformResource", property: "uid", value: "X"},
+		})
+		close(t1Acquired)
+		<-t1Release
+		release()
+	}()
+	<-t1Acquired
+
+	// T2 acquires the lock for value "Y" — disjoint from T1. Under the new
+	// per-value granularity this must NOT block on T1.
+	t2Acquired := make(chan struct{})
+	t2Done := make(chan struct{})
+	go func() {
+		defer close(t2Done)
+		release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{
+			{label: "TerraformResource", property: "uid", value: "Y"},
+		})
+		close(t2Acquired)
+		release()
+	}()
+
+	select {
+	case <-t2Acquired:
+		// Expected: T2 ran to completion while T1 still holds its lock.
+	case <-time.After(2 * time.Second):
+		close(t1Release)
+		<-t1Done
+		t.Fatal("T2 acquiring a disjoint value's lock blocked on T1 — the lock granularity is too coarse")
+	}
+
+	close(t1Release)
+	<-t1Done
+	<-t2Done
+}
+
+// TestUniqueConstraintCommitLocks_SameValueSerializes pins the converse:
+// two transactions touching the SAME (label, property, value) must
+// serialize at the commit boundary, otherwise the silent-duplicate-write
+// race that the lock exists to prevent comes back. The lock guards the
+// validateAllConstraints + commit + RegisterUniqueValue window so a peer
+// observing the cache after a winner's commit sees the registered value
+// and either fails validation (driver retries) or planner-MATCHes the
+// winner's node on a fresh transaction.
+func TestUniqueConstraintCommitLocks_SameValueSerializes(t *testing.T) {
+	sm := &SchemaManager{}
+
+	t1Acquired := make(chan struct{})
+	t1Release := make(chan struct{})
+	t1Done := make(chan struct{})
+	go func() {
+		defer close(t1Done)
+		release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{
+			{label: "TerraformResource", property: "uid", value: "X"},
+		})
+		close(t1Acquired)
+		<-t1Release
+		release()
+	}()
+	<-t1Acquired
+
+	t2Acquired := make(chan struct{})
+	t2Done := make(chan struct{})
+	go func() {
+		defer close(t2Done)
+		release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{
+			{label: "TerraformResource", property: "uid", value: "X"},
+		})
+		close(t2Acquired)
+		release()
+	}()
+
+	select {
+	case <-t2Acquired:
+		close(t1Release)
+		<-t1Done
+		<-t2Done
+		t.Fatal("T2 acquiring the same value's lock did NOT block on T1 — the lock is missing the serialization guarantee for shared values")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: T2 is blocked waiting for T1 to release.
+	}
+
+	close(t1Release)
+	<-t1Done
+	<-t2Acquired // T2 should now proceed
+	<-t2Done
+}
+
+// TestUniqueConstraintCommitLocks_DeterministicOrderingNoDeadlock verifies
+// that two transactions touching overlapping sets of values acquire locks
+// in the same total order (sorted by label, then property, then value),
+// preventing AB-BA deadlock.
+//
+// Without sort-order acquisition: T1 wants {X, Y}, T2 wants {Y, X}. T1
+// holds X, asks for Y; T2 holds Y, asks for X. Deadlock. With sorted
+// acquisition, both transactions request X first, then Y; one waits, the
+// other progresses.
+func TestUniqueConstraintCommitLocks_DeterministicOrderingNoDeadlock(t *testing.T) {
+	sm := &SchemaManager{}
+
+	const concurrency = 8
+	values := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			// Each goroutine touches all values but in a different input
+			// order. The lock acquirer must sort internally so all
+			// goroutines acquire in the same total order.
+			keys := make([]uniqueConstraintLockKey, 0, len(values))
+			for j, v := range values {
+				// Rotate the order per goroutine.
+				v = values[(j+idx)%len(values)]
+				keys = append(keys, uniqueConstraintLockKey{
+					label:    "Label",
+					property: "prop",
+					value:    v,
+				})
+			}
+			release := sm.acquireUniqueConstraintCommitLocks(keys)
+			// Brief work-simulation window so concurrent goroutines actually
+			// overlap on lock holding rather than sequentially zip through.
+			time.Sleep(time.Millisecond)
+			release()
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Expected: all goroutines completed within timeout, no deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquire timed out — possible AB-BA deadlock, sorted acquisition order broken")
+	}
+}

--- a/pkg/storage/wal_ids.go
+++ b/pkg/storage/wal_ids.go
@@ -39,3 +39,37 @@ func EnsureDatabasePrefix(dbName, id string) string {
 	}
 	return dbName + ":" + id
 }
+
+// EnsureNodeIDDatabasePrefixForEngine adds the active engine namespace to an
+// unprefixed node ID. Schema backfills use this so cache entries match the
+// storage IDs later seen by transaction commit validation.
+func EnsureNodeIDDatabasePrefixForEngine(engine Engine, id NodeID) NodeID {
+	namespace := namespaceForEngine(engine)
+	if namespace == "" {
+		return id
+	}
+	return NodeID(EnsureDatabasePrefix(namespace, string(id)))
+}
+
+func namespaceForEngine(engine Engine) string {
+	visited := make(map[Engine]bool)
+	for engine != nil && !visited[engine] {
+		visited[engine] = true
+
+		if provider, ok := engine.(interface{ Namespace() string }); ok {
+			if namespace := provider.Namespace(); namespace != "" {
+				return namespace
+			}
+		}
+
+		switch wrapper := engine.(type) {
+		case interface{ GetEngine() Engine }:
+			engine = wrapper.GetEngine()
+		case interface{ GetInnerEngine() Engine }:
+			engine = wrapper.GetInnerEngine()
+		default:
+			engine = nil
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Description

This fixes a UNIQUE MERGE retry failure that showed up under Eshu's bootstrap-index Pass 2 workload.

The failure needed a few pieces to line up: concurrent explicit Bolt transactions, `MERGE` on a UNIQUE property, and a namespaced database (`nornic`). After one writer committed, the losing writer retried but still planned a CREATE. The last remaining case was late schema backfill: when an existing node was scanned through the namespaced transaction wrapper, the UNIQUE cache was populated with a bare node ID. Commit validation later compared that bare ID with the storage ID (`nornic:<uuid>`) and treated an update to the same node as a duplicate.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build changes

## Related Issues

Related to eshu-hq/eshu#209.

## Changes Made

- Add commit-time retry classification for UNIQUE MERGE conflicts surfaced through Bolt explicit transactions.
- Lock UNIQUE commit checks by constraint value instead of by whole constraint, so unrelated values can commit in parallel.
- Make MERGE planning fall back to a storage scan when a UNIQUE value cache is not authoritative yet.
- Normalize node IDs during schema/index backfill so namespaced databases store `nornic:<uuid>` in derived caches, not bare UUIDs.
- Add regression coverage for scalar MERGE, UNWIND MERGE, concurrent explicit transactions, and late schema creation over preexisting data.

## Testing

```bash
go test -tags 'noui nolocalllm' -count=1 -timeout 300s ./pkg/storage ./pkg/bolt ./pkg/cypher ./pkg/errors
```

Also verified the final Eshu Tier-2 v2.5 compose proof against a local image built from this branch:

```text
local/nornicdb-amd64-cpu:eshu-209-patched-cf5163e
```

The verifier passed and reported both expected drift deltas:

```text
drift_kind=removed_from_state before=0 after=1 delta=1
drift_kind=removed_from_config before=0 after=1 delta=1
OK — Tier-2 v2.5 tfstate drift compose proof matrix passed.
```

### Test Coverage

- [x] Added tests for new functionality
- [x] Updated tests for changed functionality
- [ ] All tests pass locally (`go test ./...`)
- [ ] Coverage maintained at ≥90% (`go test -coverprofile=coverage.out ./...`)

### Manual Testing

1. Confirmed the late-schema regression fails on the parent commit with a bare UUID in the UNIQUE cache.
2. Confirmed the same test passes on this branch and stores a `nornic:<uuid>` cache entry.
3. Ran the Eshu Tier-2 v2.5 compose verifier with the branch image.

## Performance Impact

### Benchmarks

No broad benchmark run in this pass. The concurrency contract is covered by focused tests:

- disjoint UNIQUE values can commit in parallel
- same UNIQUE value serializes
- deterministic lock ordering avoids deadlock

**Results:**
- Query execution: expected improvement under concurrent UNIQUE MERGE writers, because commit locking is per value instead of per constraint.
- Memory usage: no measured change.
- Justification: the fix narrows lock scope and keeps validation correctness intact. The Eshu verifier is the integration proof for the original workload.

## Neo4j Compatibility

- [ ] Tested against Neo4j for compatibility
- [ ] Behavior matches Neo4j exactly
- [x] Not applicable (internal change only)

## Documentation

- [ ] Updated relevant documentation in `/docs`
- [ ] Updated CHANGELOG.md
- [x] Added code comments for complex logic
- [ ] Updated README.md (if user-facing change)
- [x] Not applicable

## Code Quality Checklist

- [x] Code follows the [AGENTS.md](AGENTS.md) guidelines
- [x] No files exceed 2500 lines (split if necessary)
- [ ] Used functional Go patterns (dependency injection via function types)
- [x] DRY principle applied (no repeated code)
- [x] Proper error handling
- [x] Added/updated tests (minimum 90% coverage)
- [ ] All tests pass: `go test ./... -v`
- [ ] No race conditions: `go test ./... -race`
- [x] Code formatted: `go fmt ./...`
- [ ] Linter passes: `golangci-lint run`
- [x] Commit messages follow conventional format

## Proof of Value

### For Bug Fixes:

- [x] Created failing test that reproduces the bug
- [x] Test now passes with the fix
- [x] Added regression tests

### For Performance Optimizations:

- [ ] Included before/after benchmarks showing improvement
- [x] No significant memory regression (>10%)
- [x] Justified any trade-offs

### For New Features:

- [ ] Documented use cases and benefits
- [ ] Included examples in documentation
- [ ] Added integration tests

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The last failure mode was not fixed by raising retry budgets or reducing writer concurrency. The fix is at the storage/schema boundary: cache entries created by schema backfill now use the same namespaced node ID form that commit validation sees.
