### PR TITLE
fix(mcp,heimdall): return cosine similarity from discover, not RRF rank score

### DIFF
--- a/pkg/heimdall/metrics.go
+++ b/pkg/heimdall/metrics.go
@@ -443,7 +443,8 @@ func (e *QueryExecutor) Discover(ctx context.Context, query string, nodeTypes []
 
 			type fused struct {
 				best     *SemanticSearchResult
-				scoreRRF float64
+				scoreRRF float64 // outer RRF used for ordering across chunks
+				bestSim  float64 // strongest underlying similarity across chunks
 			}
 			fusedByID := make(map[string]*fused)
 
@@ -466,12 +467,13 @@ func (e *QueryExecutor) Discover(ctx context.Context, query string, nodeTypes []
 					}
 					f := fusedByID[r.ID]
 					if f == nil {
-						f = &fused{best: r}
+						f = &fused{best: r, bestSim: r.Score}
 						fusedByID[r.ID] = f
 					}
-					// Outer RRF: 1/(k + rank), rank is 1-based.
+					// Outer RRF: 1/(k + rank), rank is 1-based. Used for ordering only.
 					f.scoreRRF += 1.0 / (outerRRFK + float64(rank+1))
-					if f.best == nil || r.Score > f.best.Score {
+					if r.Score > f.bestSim {
+						f.bestSim = r.Score
 						f.best = r
 					}
 				}
@@ -498,11 +500,15 @@ func (e *QueryExecutor) Discover(ctx context.Context, query string, nodeTypes []
 					if f.best == nil {
 						continue
 					}
+					// Surface the strongest underlying similarity (cosine when
+					// available), NOT the outer RRF rank-derived score. This
+					// restores meaningful min_similarity threshold semantics
+					// downstream.
 					searchResults = append(searchResults, &SemanticSearchResult{
 						ID:         f.best.ID,
 						Labels:     f.best.Labels,
 						Properties: f.best.Properties,
-						Score:      f.scoreRRF,
+						Score:      f.bestSim,
 					})
 				}
 			}

--- a/pkg/heimdall/metrics_discover_chunk_test.go
+++ b/pkg/heimdall/metrics_discover_chunk_test.go
@@ -123,6 +123,82 @@ func loadLargeDocQuery(t *testing.T) string {
 	return query
 }
 
+// TestQueryExecutor_Discover_SimilarityIsBestScore is a regression test for the
+// scoring bug where the outer RRF rank-decay score (`1/(60+rank)`, capped at
+// ~0.0164 for rank 1) leaked through as `Similarity` instead of the strongest
+// underlying score reported by the searcher. The bug made `min_similarity`
+// thresholds useless across the discover surface.
+//
+// The test stages three candidate hits at different scores per chunk and
+// asserts the executor surfaces the strongest score per node (max across
+// chunks), not the rank-derived RRF value.
+func TestQueryExecutor_Discover_SimilarityIsBestScore(t *testing.T) {
+	emb := &testEmbedder{}
+	searcher := &scoringSearcher{
+		// Two chunks each see the same node "match" at different scores.
+		// Best score = 0.92; the outer-RRF top-rank score would be 1/(60+1) = ~0.0164.
+		batches: [][]*SemanticSearchResult{
+			{
+				{ID: "match", Labels: []string{"Memory"}, Properties: map[string]interface{}{"title": "match"}, Score: 0.55},
+				{ID: "weak", Labels: []string{"Memory"}, Properties: map[string]interface{}{"title": "weak"}, Score: 0.20},
+			},
+			{
+				{ID: "match", Labels: []string{"Memory"}, Properties: map[string]interface{}{"title": "match"}, Score: 0.92},
+			},
+		},
+	}
+	exec := NewQueryExecutorWithSearch(&stubQueryDB{}, searcher, emb, 5*time.Second)
+
+	// Long query forces the multi-chunk fusion path.
+	longQuery := loadLargeDocQuery(t)
+	res, err := exec.Discover(context.Background(), longQuery, nil, 5, 1)
+	require.NoError(t, err)
+	require.Equal(t, "vector", res.Method)
+	require.NotEmpty(t, res.Results)
+
+	var matchSim float64
+	for _, r := range res.Results {
+		if r.Title == "match" {
+			matchSim = r.Similarity
+			break
+		}
+	}
+	require.InDelta(t, 0.92, matchSim, 1e-6,
+		"expected match.Similarity = best raw score across chunks (0.92), got %.6f — looks like RRF rank score leaked through", matchSim)
+}
+
+// scoringSearcher rotates through a list of result batches on each
+// HybridSearch call so tests can stage per-chunk scoring scenarios.
+type scoringSearcher struct {
+	mu      sync.Mutex
+	batches [][]*SemanticSearchResult
+	idx     int
+}
+
+func (s *scoringSearcher) HybridSearch(ctx context.Context, query string, queryEmbedding []float32, labels []string, limit int) ([]*SemanticSearchResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.batches) == 0 {
+		return nil, nil
+	}
+	batch := s.batches[s.idx%len(s.batches)]
+	s.idx++
+	return batch, nil
+}
+
+func (s *scoringSearcher) Search(ctx context.Context, query string, labels []string, limit int) ([]*SemanticSearchResult, error) {
+	return nil, nil
+}
+func (s *scoringSearcher) Neighbors(ctx context.Context, nodeID string) ([]string, error) {
+	return nil, nil
+}
+func (s *scoringSearcher) GetEdgesForNode(ctx context.Context, nodeID string) ([]*GraphEdge, error) {
+	return nil, nil
+}
+func (s *scoringSearcher) GetNode(ctx context.Context, nodeID string) (*NodeData, error) {
+	return nil, nil
+}
+
 func TestQueryExecutor_Discover_ChunksLongQueriesForVectorSearch(t *testing.T) {
 	emb := &testEmbedder{failIfTokensGreater: 512}
 	searcher := &testSearcher{}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -913,7 +913,8 @@ func (s *Server) handleDiscover(ctx context.Context, args map[string]interface{}
 						title    string
 						preview  string
 						props    map[string]any
-						scoreRRF float64
+						scoreRRF float64 // outer RRF, used for ordering across chunks
+						bestSim  float64 // max cosine similarity observed across chunks
 					}
 					fusedByID := make(map[string]*fused)
 
@@ -944,19 +945,33 @@ func (s *Server) handleDiscover(ctx context.Context, args map[string]interface{}
 									preview:  r.ContentPreview,
 									props:    r.Properties,
 									scoreRRF: 0,
+									bestSim:  0,
 								}
 								fusedByID[id] = f
 							}
-							// Outer RRF: 1/(k + rank), rank is 1-based.
+							// Outer RRF: 1/(k + rank), rank is 1-based. Used only for ordering.
 							f.scoreRRF += 1.0 / (outerRRFK + float64(rank+1))
+							// Track the strongest underlying score for this node.
+							// search.SearchResult.Similarity carries the cosine score (or
+							// reranker bi-score when stage-2 rerank is enabled, or BM25
+							// raw score for BM25-only hits); see search.enrichResults.
+							if r.Similarity > f.bestSim {
+								f.bestSim = r.Similarity
+							}
 						}
 					}
 
 					// Build and sort fused list.
 					fusedList := make([]*fused, 0, len(fusedByID))
 					for _, f := range fusedByID {
-						// Apply threshold to fused score.
-						if minScore > 0 && f.scoreRRF < minScore {
+						// Threshold is applied against the actual underlying similarity
+						// (cosine for vector hits; raw BM25 for lexical-only hits) so
+						// callers can use min_similarity meaningfully — e.g. 0.3 ≈
+						// topically related, 0.5 ≈ strong cosine match. Prior behaviour
+						// compared against the outer RRF score, which is rank-derived
+						// (~0.0164 at rank 1 → 0.0091 at rank 50) and made the threshold
+						// useless.
+						if minScore > 0 && f.bestSim < minScore {
 							continue
 						}
 						fusedList = append(fusedList, f)
@@ -981,7 +996,7 @@ func (s *Server) handleDiscover(ctx context.Context, args map[string]interface{}
 							Type:           getLabelType(f.labels),
 							Title:          f.title,
 							ContentPreview: f.preview,
-							Similarity:     f.scoreRRF,
+							Similarity:     f.bestSim,
 							Properties:     sanitizePropertiesForLLM(props),
 						}
 						if depth > 1 {
@@ -1009,12 +1024,17 @@ func (s *Server) handleDiscover(ctx context.Context, args map[string]interface{}
 				results := make([]SearchResult, 0, len(resp.Results))
 				for _, r := range resp.Results {
 					props := toInterfaceMap(r.Properties)
+					// BM25-only fallback: r.Score is the raw BM25 score (no 0-1
+					// cosine semantics). Surface r.Similarity instead, which the
+					// search service sets to the actual cosine when available and
+					// to the BM25 score in the pure-BM25 path. Keeps min_similarity
+					// thresholds workable across both code paths.
 					res := SearchResult{
 						ID:             normalizeNodeElementID(r.ID),
 						Type:           getLabelType(r.Labels),
 						Title:          r.Title,
 						ContentPreview: r.ContentPreview,
-						Similarity:     r.Score,
+						Similarity:     r.Similarity,
 						Properties:     sanitizePropertiesForLLM(props),
 					}
 					if depth > 1 {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1024,11 +1024,12 @@ func (s *Server) handleDiscover(ctx context.Context, args map[string]interface{}
 				results := make([]SearchResult, 0, len(resp.Results))
 				for _, r := range resp.Results {
 					props := toInterfaceMap(r.Properties)
-					// BM25-only fallback: r.Score is the raw BM25 score (no 0-1
-					// cosine semantics). Surface r.Similarity instead, which the
-					// search service sets to the actual cosine when available and
-					// to the BM25 score in the pure-BM25 path. Keeps min_similarity
-					// thresholds workable across both code paths.
+					// BM25-only fallback: r.Score is the outer fused/RRF ranking
+					// score, not the raw backend similarity value. Surface
+					// r.Similarity instead, which the search service sets to the
+					// actual cosine when available and to the BM25 score in the
+					// pure-BM25 path. Keeps min_similarity thresholds workable
+					// across both code paths.
 					res := SearchResult{
 						ID:             normalizeNodeElementID(r.ID),
 						Type:           getLabelType(r.Labels),

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -184,7 +184,11 @@ func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]floa
 	m.batchTexts = append([]string(nil), texts...)
 	result := make([][]float32, len(texts))
 	for i := range texts {
-		result[i] = make([]float32, 1024)
+		if m.embedding != nil {
+			result[i] = append([]float32(nil), m.embedding...)
+		} else {
+			result[i] = make([]float32, 1024)
+		}
 	}
 	return result, nil
 }
@@ -968,6 +972,110 @@ func TestHandleDiscover_VectorBranchWithManualEmbeddings(t *testing.T) {
 	require.NoError(t, err)
 	discover := result.(DiscoverResult)
 	require.Equal(t, "vector", discover.Method)
+}
+
+// TestHandleDiscover_SimilarityIsCosineNotRRF is a regression test for the bug
+// where `similarity` in the discover response was the outer RRF rank-decay
+// score (~0.0164 at rank 1, 0.0091 at rank 50) instead of the underlying
+// cosine score. The RRF rank score is by construction identical across
+// queries (it only depends on rank position), making `min_similarity`
+// thresholds useless.
+//
+// This test sets up two nodes with controlled embeddings: a "match" node
+// whose embedding equals the query embedding (cosine = 1.0) and a "miss"
+// node whose embedding is orthogonal (cosine = 0.0). It then asserts:
+//
+//  1. The returned `similarity` for the match is approximately 1.0 — i.e.
+//     clearly NOT 0.0164 (which would mean RRF rank-1 score leaked through).
+//  2. The match outranks the miss.
+//  3. A `min_similarity=0.5` threshold drops the orthogonal node — the
+//     threshold semantics only work if `similarity` is in cosine space.
+func TestHandleDiscover_SimilarityIsCosineNotRRF(t *testing.T) {
+	db, err := nornicdb.Open("", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	engine := db.GetStorage()
+
+	matchVec := make([]float32, 1024)
+	matchVec[0] = 1.0 // unit vector along axis 0
+	missVec := make([]float32, 1024)
+	missVec[1] = 1.0 // orthogonal to matchVec
+
+	_, err = engine.CreateNode(&storage.Node{
+		ID:     "match-node",
+		Labels: []string{"Memory"},
+		Properties: map[string]interface{}{
+			"title":   "Match",
+			"content": "cosine-similar to the query",
+		},
+		ChunkEmbeddings: [][]float32{matchVec},
+	})
+	require.NoError(t, err)
+	_, err = engine.CreateNode(&storage.Node{
+		ID:     "miss-node",
+		Labels: []string{"Memory"},
+		Properties: map[string]interface{}{
+			"title":   "Miss",
+			"content": "orthogonal to the query",
+		},
+		ChunkEmbeddings: [][]float32{missVec},
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.BuildSearchIndexes(context.Background()))
+
+	// Embedder echoes matchVec for every query — query embedding == match-node embedding.
+	embedder := &mockEmbedder{embedding: matchVec}
+	serverCfg := DefaultServerConfig()
+	serverCfg.Embedder = embedder
+	serverCfg.EmbeddingEnabled = true
+	server := NewServer(db, serverCfg)
+
+	result, err := server.handleDiscover(context.Background(), map[string]interface{}{
+		"query": "anything — embedder ignores the text",
+		"limit": 5,
+		"depth": 0,
+	})
+	require.NoError(t, err)
+	discover := result.(DiscoverResult)
+	require.Equal(t, "vector", discover.Method)
+	require.NotEmpty(t, discover.Results, "expected match-node to appear in results")
+
+	// Locate the match-node similarity in the response.
+	var matchSim float64
+	var matchFound bool
+	for _, r := range discover.Results {
+		if r.Title == "Match" {
+			matchSim = r.Similarity
+			matchFound = true
+			break
+		}
+	}
+	require.True(t, matchFound, "match-node not in results")
+
+	// The smoking gun: the RRF rank-1 score is 1/(60+1) ≈ 0.01639. Cosine
+	// of a unit vector with itself is 1.0. Anything in cosine territory
+	// (≥ 0.5) proves we're surfacing the real similarity, not RRF.
+	require.Greater(t, matchSim, 0.5,
+		"match-node similarity should be cosine (~1.0), got %.4f — looks like RRF rank score leaked through", matchSim)
+
+	// And min_similarity threshold semantics: a 0.5 threshold should drop
+	// the orthogonal miss-node. If similarity were the RRF rank score
+	// (≤ 0.0164), this threshold would drop *everything* including the match.
+	thresholded, err := server.handleDiscover(context.Background(), map[string]interface{}{
+		"query":          "anything — embedder ignores the text",
+		"limit":          5,
+		"min_similarity": 0.5,
+		"depth":          0,
+	})
+	require.NoError(t, err)
+	td := thresholded.(DiscoverResult)
+	require.NotEmpty(t, td.Results, "min_similarity=0.5 dropped everything — similarity is not cosine")
+	for _, r := range td.Results {
+		require.GreaterOrEqual(t, r.Similarity, 0.5,
+			"result %q below threshold (sim=%.4f) — min_similarity filter is broken", r.Title, r.Similarity)
+		require.NotEqual(t, "Miss", r.Title, "orthogonal miss-node passed the 0.5 threshold")
+	}
 }
 
 func TestHandleDiscover_StorageError(t *testing.T) {


### PR DESCRIPTION
## Summary

- `discover`'s `similarity` field was the outer RRF rank-decay score (`1/(60+rank)`, capped at ~0.0164 at rank 1, decaying to ~0.0091 at rank 50). Because that value depends only on rank position, every query returned an identical top-to-bottom score sequence regardless of content, making the `min_similarity` parameter useless.
- This PR makes both fusion paths (`pkg/mcp/server.go:handleDiscover` and `pkg/heimdall/metrics.go:Discover`) surface the strongest underlying similarity across chunks (cosine for vector hits, BM25 raw for lexical-only hits), while keeping outer RRF for sort order so multi-chunk fusion stability is preserved.
- The BM25-only fallback in `pkg/mcp` also previously surfaced `r.Score` (raw BM25) as `similarity`; it now uses `r.Similarity`, keeping the field's semantics consistent across code paths.
- Adds two targeted regression tests that fail under the old behaviour and pass under the new.

## Reproducer (before fix)

```js
// MCP discover via the tool surface
const r1 = await discover({ query: 'completely random nonsense', limit: 5, min_similarity: 0 })
const r2 = await discover({ query: 'Diego is 3 years old',       limit: 5, min_similarity: 0 })
console.log(r1.results.map(r => r.similarity))
// [0.01639, 0.01613, 0.01587, 0.01562, 0.01538]
console.log(r2.results.map(r => r.similarity))
// [0.01639, 0.01613, 0.01587, 0.01562, 0.01538]   ← identical sequence
```

`r2`'s _IDs_ are query-correct (vector search works) — but the `similarity` numbers are the rank-decay function `1/(60+k)`, not cosine. Any caller using `min_similarity > 0.02` silently filters everything, including the topical match.

## Root cause

`fuseRRF` already preserves the underlying cosine score in `search.SearchResult.Similarity`. Both fusion paths (per-chunk RRF) then overwrote it with the outer rank score:

- `pkg/mcp/server.go` — `Similarity: f.scoreRRF` on the result
- `pkg/heimdall/metrics.go` — `Score: f.scoreRRF` on the intermediate `SemanticSearchResult`, then propagated as `Similarity: r.Score`

## Fix

Each fused entry now tracks `bestSim` (max underlying `r.Similarity`/`r.Score` across chunks). That value is surfaced as the result's similarity and is what `min_similarity` filters against. Outer RRF still drives sort order — sort stability across multi-chunk fusion is what RRF is for.

```go
// pkg/mcp/server.go (handleDiscover, vector path)
type fused struct {
    ...
    scoreRRF float64 // outer RRF used for ordering across chunks
    bestSim  float64 // max underlying similarity (cosine or BM25 raw)
}

f.scoreRRF += 1.0 / (outerRRFK + float64(rank+1))
if r.Similarity > f.bestSim {
    f.bestSim = r.Similarity
}
...
if minScore > 0 && f.bestSim < minScore { continue }
...
res := SearchResult{..., Similarity: f.bestSim}
```

Same structural change in `pkg/heimdall/metrics.go`.

The BM25-only fallback in `pkg/mcp` now reads `r.Similarity` rather than `r.Score`, so raw BM25 fused scores don't leak into the same field that elsewhere carries cosine.

## Behaviour after fix

```
discover('Diego son age')    →  top similarity 0.66–0.73   (cosine; topical match)
discover('Nathan')           →  top similarity 5–8         (BM25-dominant, exact-string hits)
discover('orthogonal query') →  results have low cosine values OR drop out at min_sim ≥ 0.3
```

`similarity` is now in two regimes depending on which retrieval pathway dominated for a given node: cosine `[0, 1]` for vector-pipeline hits, raw BM25 (typically 1–40) for BM25-only hits. Any threshold ≥ ~0.3 still filters cosine noise; lexical-only hits effectively bypass the threshold by design (a strong exact-string match is rarely something the caller wants to filter out).

## Tests

`pkg/mcp/server_test.go`:
- `TestHandleDiscover_SimilarityIsCosineNotRRF` — sets up a `match` node whose embedding equals the query embedding and a `miss` node with an orthogonal embedding. Asserts (1) the match surfaces with cosine ~1.0, not ~0.0164; (2) `min_similarity=0.5` drops the orthogonal miss but keeps the match.

`pkg/heimdall/metrics_discover_chunk_test.go`:
- `TestQueryExecutor_Discover_SimilarityIsBestScore` — stages two chunk batches scoring the same node at 0.55 and 0.92 across the multi-chunk fusion path. Asserts the surfaced `Similarity` is 0.92 (max across chunks), not the cumulative outer-RRF score (~0.0328) the old code produced.

Both tests have been confirmed to fail without the fix and pass with it.

A small enabling change is made to `mockEmbedder.EmbedBatch` so it honours the configurable `embedding` field (previously only `Embed` did). This keeps the existing default (zero vectors) unchanged for prior tests.

## Test plan

- [x] `go test ./pkg/mcp/` (passes including new regression test)
- [x] `go test ./pkg/heimdall/` (passes including new regression test)
- [x] Reverted the fix locally and confirmed both new tests fail at the documented values (0.01639 for mcp, 0.03279 for heimdall — exactly the RRF rank-decay values)
- [x] Probe against live local NornicDB after rebuild: unrelated queries no longer share a top-score sequence; topical queries surface cosine ~0.7 for relevant hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)