### PR TITLE
fix(cypher): route transactional match merge before create

### DIFF
--- a/docs/performance/hot-path-query-cookbook.md
+++ b/docs/performance/hot-path-query-cookbook.md
@@ -494,6 +494,13 @@ LIMIT 1;
 
 Use when the API needs immediate confirmed view of updated data.
 
+Explicit transaction dispatch must preserve the same routing as implicit
+execution for `MATCH ... MERGE ... ON CREATE SET` shapes: classify the statement
+as `MATCH ... MERGE` before checking for `MATCH ... CREATE`, because `ON CREATE
+SET` is a MERGE modifier rather than a CREATE clause. This keeps constrained
+MERGE lookups on the `MergeSchemaLookupUsed` path inside `BEGIN`/`COMMIT`
+sessions and avoids accidentally falling back to relationship-create parsing.
+
 ### 7.3 Bulk Ingestion With UNWIND
 
 ```cypher

--- a/pkg/cypher/transaction.go
+++ b/pkg/cypher/transaction.go
@@ -450,13 +450,14 @@ func (e *StorageExecutor) executeQueryAgainstStorage(ctx context.Context, cypher
 		if findKeywordIndex(cypher, "OPTIONAL MATCH") > 0 {
 			return e.executeCompoundMatchOptionalMatch(ctx, cypher)
 		}
-		// Check for compound MATCH...CREATE queries
-		if findKeywordIndex(cypher, "CREATE") > 0 {
-			return e.executeCompoundMatchCreate(ctx, cypher)
-		}
 		// Check for compound MATCH...MERGE queries
 		if findKeywordIndex(cypher, "MERGE") > 0 {
 			return e.executeCompoundMatchMerge(ctx, cypher)
+		}
+		// Check for compound MATCH...CREATE queries. This must stay after
+		// MATCH...MERGE because MERGE modifiers contain ON CREATE SET.
+		if findKeywordIndex(cypher, "CREATE") > 0 {
+			return e.executeCompoundMatchCreate(ctx, cypher)
 		}
 		return e.executeMatch(ctx, cypher)
 	case strings.HasPrefix(upper, "OPTIONAL MATCH"):

--- a/pkg/cypher/transaction_namespace_test.go
+++ b/pkg/cypher/transaction_namespace_test.go
@@ -28,6 +28,21 @@ func countFromResult(t *testing.T, result *ExecuteResult) int64 {
 	}
 }
 
+func executeExplicitTransactionQueryForTrace(t *testing.T, exec *StorageExecutor, ctx context.Context, query string) (*ExecuteResult, HotPathTrace) {
+	t.Helper()
+	_, err := exec.Execute(ctx, "BEGIN", nil)
+	require.NoError(t, err)
+
+	exec.resetHotPathTrace()
+	result, err := exec.Execute(ctx, strings.TrimSpace(query), nil)
+	require.NoError(t, err)
+	trace := exec.LastHotPathTrace()
+
+	_, err = exec.Execute(ctx, "COMMIT", nil)
+	require.NoError(t, err)
+	return result, trace
+}
+
 func TestExplicitTransaction_NamespacedCreateCommit(t *testing.T) {
 	baseStore := newTestMemoryEngine(t)
 	store := storage.NewNamespacedEngine(baseStore, "test")
@@ -245,6 +260,71 @@ func TestExecuteQueryAgainstStorage_DispatchCoverage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExplicitTransaction_MatchMergeOnCreateRoutesToMerge(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	for _, stmt := range []string{
+		"CREATE CONSTRAINT dispatch_source_uid_unique IF NOT EXISTS FOR (n:DispatchSource) REQUIRE n.uid IS UNIQUE",
+		"CREATE CONSTRAINT dispatch_target_uid_unique IF NOT EXISTS FOR (n:DispatchTarget) REQUIRE n.uid IS UNIQUE",
+	} {
+		_, err := exec.Execute(ctx, stmt, nil)
+		require.NoError(t, err)
+	}
+
+	_, err := exec.Execute(ctx, "CREATE (:DispatchSource {uid: 'source-1'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:DispatchTarget {uid: 'target-existing', created: false})", nil)
+	require.NoError(t, err)
+
+	result, trace := executeExplicitTransactionQueryForTrace(t, exec, ctx, `
+		MATCH (s:DispatchSource {uid: 'source-1'})
+		MERGE (t:DispatchTarget {uid: 'target-1'})
+		ON CREATE SET t.created = true
+		MERGE (s)-[rel:DISPATCHES_TO]->(t)
+		ON CREATE SET rel.created = true
+		RETURN t.uid
+	`)
+	require.NotNil(t, result)
+	require.Len(t, result.Rows, 1)
+	require.Equal(t, "target-1", result.Rows[0][0])
+	require.True(t, trace.MergeSchemaLookupUsed,
+		"MATCH...MERGE with ON CREATE SET must route through merge handling and use schema lookup")
+	require.False(t, trace.MergeScanFallbackUsed,
+		"DispatchTarget.uid has a unique constraint; label scan fallback is not justified")
+
+	verifyCreated, err := exec.Execute(ctx, `
+		MATCH (s:DispatchSource {uid: 'source-1'})-[rel:DISPATCHES_TO]->(t:DispatchTarget {uid: 'target-1'})
+		RETURN t.created, count(rel)
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, verifyCreated.Rows, 1)
+	require.Equal(t, true, verifyCreated.Rows[0][0])
+	require.Equal(t, int64(1), verifyCreated.Rows[0][1])
+
+	result, trace = executeExplicitTransactionQueryForTrace(t, exec, ctx, `
+		MATCH (s:DispatchSource {uid: 'source-1'})
+		MERGE (t:DispatchTarget {uid: 'target-existing'})
+		ON CREATE SET t.created = true
+		ON MATCH SET t.matched = true
+		SET t.lastSeen = 'tx'
+		MERGE (s)-[rel:DISPATCHES_TO]->(t)
+		ON CREATE SET rel.created = true
+		RETURN t.uid, t.matched, t.lastSeen
+	`)
+	require.NotNil(t, result)
+	require.Len(t, result.Rows, 1)
+	require.Equal(t, "target-existing", result.Rows[0][0])
+	require.Equal(t, true, result.Rows[0][1])
+	require.Equal(t, "tx", result.Rows[0][2])
+	require.True(t, trace.MergeSchemaLookupUsed,
+		"MATCH...MERGE with ON MATCH SET and standalone SET must stay on merge handling")
+	require.False(t, trace.MergeScanFallbackUsed,
+		"matched DispatchTarget.uid has a unique constraint; label scan fallback is not justified")
 }
 
 func TestExecuteQueryAgainstStorage_ShowDispatchWithDatabaseManager(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes explicit-transaction dispatch for `MATCH ... MERGE ... ON CREATE SET` statements.

The explicit transaction path was checking for `MATCH ... CREATE` before `MATCH ... MERGE`. That means a valid MERGE statement containing `ON CREATE SET` could be classified as a CREATE shape, because `ON CREATE SET` includes the word `CREATE` even though it is a MERGE modifier, not a standalone CREATE clause.

The normal executor already routes this shape as `MATCH ... MERGE`. This change makes the transaction dispatcher preserve the same ordering.

## Why this matters beyond one downstream user

Any Neo4j-compatible client using explicit transactions can emit this common Cypher pattern:

```cypher
MATCH (s:Source {uid: 'source-1'})
MERGE (t:Target {uid: 'target-1'})
ON CREATE SET t.created = true
MERGE (s)-[rel:ROUTES_TO]->(t)
ON CREATE SET rel.created = true
RETURN t.uid
```

That should stay on the MERGE path so unique constraints and schema lookups are honored. Classifying it as CREATE can skip the intended MERGE handler and produce incorrect or empty transaction results for a normal Cypher idiom.

## Changes

- Route `MATCH ... MERGE` before `MATCH ... CREATE` in the explicit transaction dispatcher.
- Add a regression test proving `MATCH ... MERGE ... ON CREATE SET` returns the expected row and uses schema lookup instead of scan fallback.
- Document the routing rule in the hot-path cookbook so future dispatcher work treats `ON CREATE SET` as a MERGE modifier.

## Validation

Focused RED/GREEN:

- Added the regression test on v1.1.1 first and confirmed it failed with an empty result.
- Applied the router ordering fix and confirmed the same test passes.

Local package gates:

```bash
go test -tags 'noui nolocalllm' ./pkg/cypher -run TestExecuteQueryAgainstStorage_MatchMergeOnCreateRoutesToMerge -count=1
go test -tags 'noui nolocalllm' ./pkg/cypher -run 'Transaction|Merge|Dispatch' -count=1
go test -tags 'noui nolocalllm' ./pkg/storage -count=1
go test -tags 'noui nolocalllm' ./pkg/cypher -count=1
go test -tags 'noui nolocalllm' ./pkg/bolt ./pkg/txsession -count=1
go test -tags 'noui nolocalllm' ./pkg/cypher ./pkg/storage ./pkg/bolt ./pkg/txsession -count=1
git diff --check
```

Benchmark smoke:

```bash
go test -tags 'noui nolocalllm' ./pkg/cypher -run '^$' -bench 'BenchmarkUnwindMergeBatch_OriginalTextUpsert|BenchmarkUnwindMergeBatch_HopUpsert' -benchtime=5x -count=1
```

Full sweep note:

```bash
go test -tags 'noui nolocalllm' ./...
```

The full sweep reached the expected local-LLM/plugin build blockers on this checkout (`pkg/heimdall`, `pkg/localllm`, and plugin linking in `pkg/nornicdb`). The touched and adjacent Cypher/Bolt/storage transaction packages listed above all pass.

Runtime proof:

- Built a Linux amd64 CPU/headless Docker image from this branch.
- Ran a direct HTTP transaction against the image with the `MATCH ... MERGE ... ON CREATE SET` shape above.
- Result returned `target-remote-1` with no transaction errors.
- Ran a focused downstream compose E2E smoke with pprof enabled on NornicDB and the client runtimes.
- Clean run terminal state: fact work `68 succeeded`, workflow work `22 completed`, no failed/retrying/dead-letter work, no `UNWIND MERGE ... not found` errors.
- Preserved-volume restart terminal state: fact work `111 succeeded`, workflow work `45 completed`, no open work, no real runtime errors.

Performance/diagnostics observation:

- NornicDB pprof was enabled during the focused runtime proof.
- In the captured 20s window, NornicDB sampled only 80ms CPU, while the client ingester was CPU-bound in filesystem/gitignore matching. This change did not introduce an observed NornicDB hot loop in the smoke proof.
