### PR TITLE
fix(storage): chunk recovery restore batches

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -267,6 +267,8 @@ export NORNICDB_AUTO_RECOVER_ON_CORRUPTION=true
 - If the persistent store still fails to open:
   - Preserves your original directory by renaming it to `<dataDir>.corrupted-<timestamp>`
   - Rebuilds a fresh store from **snapshot + WAL replay** (or WAL-only if no snapshots exist yet)
+- Treats missing tokenized property-key dictionary entries (`property key id ... not in dictionary`) as corruption signals.
+- Splits large restore batches into smaller Badger transactions when a full restore exceeds Badger's transaction-size limit.
 
 **Safety notes**:
 - Auto-recovery is **not attempted** for encrypted stores (to avoid data loss when the encryption key is wrong).

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -249,6 +249,13 @@ On startup, NornicDB will:
 - **Rename** your original directory to `<dataDir>.corrupted-<timestamp>` (for forensics)
 - Rebuild a fresh store and restore recovered nodes/edges
 
+Startup errors that report `property key id ... not in dictionary` are treated
+as corruption signals. That error means a persisted node or edge references a
+tokenized property-key dictionary entry that is missing from the store, so the
+safe recovery path is snapshot + WAL replay into a fresh store. Large recovery
+restores are split into smaller Badger transactions automatically when the
+backend rejects the full restore batch as too large.
+
 3. **If recovery can’t run**
 
 - Ensure the container has write access to the volume
@@ -424,4 +431,3 @@ docker logs nornicdb > nornicdb.log 2>&1
 - **[Monitoring](monitoring.md)** - Health monitoring
 - **[Deployment](deployment.md)** - Deployment guide
 - **[Scaling](scaling.md)** - Performance tuning
-

--- a/docs/property-key-dictionary.md
+++ b/docs/property-key-dictionary.md
@@ -102,6 +102,10 @@ The hot-path decoder in V2 stores **rejects** any non-V2 body with a hard error.
 
 If a body references a dictionary ID with no reverse-map entry, the decoder returns `property key id %d not in dictionary for namespace %q` rather than silently dropping the property. Tests assert this error contract on exact message text — callers parse it for diagnostic output.
 
+That error is also a startup corruption signal for the auto-recovery path. When
+WAL or snapshot artifacts are available, NornicDB can rebuild a fresh store from
+those artifacts instead of asking the operator to delete the data directory.
+
 ### Cypher property-name semantics
 
 Tokenization changes WHAT is stored, not WHEN a property exists.

--- a/pkg/nornicdb/storage_recovery.go
+++ b/pkg/nornicdb/storage_recovery.go
@@ -38,6 +38,7 @@ func looksLikeCorruption(err error) bool {
 		strings.Contains(s, "manifest") ||
 		strings.Contains(s, "log truncate required") ||
 		strings.Contains(s, "badger") && strings.Contains(s, "truncate") ||
+		strings.Contains(s, "property key id") && strings.Contains(s, "not in dictionary") ||
 		strings.Contains(s, "value log")
 }
 
@@ -170,11 +171,11 @@ func recoverBadgerFromSnapshotAndWAL(dataDir string, badgerOpts storage.BadgerOp
 	}
 
 	// Restore recovered state into the fresh store.
-	if err := newStore.BulkCreateNodes(nodes); err != nil {
+	if err := storage.BulkCreateNodesForRecovery(newStore, nodes); err != nil {
 		_ = newStore.Close()
 		return nil, backupDir, fmt.Errorf("auto-recover: failed to restore nodes into fresh store: %w", err)
 	}
-	if err := newStore.BulkCreateEdges(edges); err != nil {
+	if err := storage.BulkCreateEdgesForRecovery(newStore, edges); err != nil {
 		_ = newStore.Close()
 		return nil, backupDir, fmt.Errorf("auto-recover: failed to restore edges into fresh store: %w", err)
 	}

--- a/pkg/nornicdb/storage_recovery_test.go
+++ b/pkg/nornicdb/storage_recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,6 +87,7 @@ func TestStorageRecoveryHelpers_HeuristicsAndArtifacts(t *testing.T) {
 		require.False(t, looksLikeCorruption(nil))
 		require.True(t, looksLikeCorruption(fmt.Errorf("manifest checksum mismatch")))
 		require.True(t, looksLikeCorruption(fmt.Errorf("badger value log truncate required")))
+		require.True(t, looksLikeCorruption(fmt.Errorf("schema: rebuild unique values: decode node: property key id 179 not in dictionary for namespace %q", "nornic")))
 		require.False(t, looksLikeCorruption(fmt.Errorf("permission denied")))
 	})
 
@@ -210,6 +212,99 @@ func TestRecoverBadgerFromSnapshotAndWAL_SnapshotAndWALReplay(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, storage.NodeID("test:seed-1"), edge.StartNode)
 	require.Equal(t, storage.NodeID("test:seed-2"), edge.EndNode)
+}
+
+func TestRecoverBadgerFromSnapshotAndWAL_RestoresLargeNodeSetInChunks(t *testing.T) {
+	dataDir := t.TempDir()
+	snapshotDir := filepath.Join(dataDir, "snapshots")
+	require.NoError(t, os.MkdirAll(snapshotDir, 0755))
+
+	const nodeCount = 12000
+	nodes := make([]*storage.Node, 0, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		nodes = append(nodes, &storage.Node{
+			ID:     storage.NodeID(fmt.Sprintf("test:node-%03d", i)),
+			Labels: []string{"Recovered"},
+			Properties: map[string]any{
+				"payload": strings.Repeat("x", 128),
+			},
+		})
+	}
+	require.NoError(t, storage.SaveSnapshot(&storage.Snapshot{
+		Sequence:  1,
+		Timestamp: time.Now(),
+		Nodes:     nodes,
+		Version:   "1.0",
+	}, filepath.Join(snapshotDir, "snapshot-current.json")))
+
+	recovered, backupDir, err := recoverBadgerFromSnapshotAndWAL(dataDir, storage.BadgerOptions{
+		DataDir:   dataDir,
+		LowMemory: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, recovered)
+	require.NotEmpty(t, backupDir)
+	t.Cleanup(func() { _ = recovered.Close() })
+	t.Cleanup(func() { _ = os.RemoveAll(backupDir) })
+
+	recoveredNodes, err := recovered.AllNodes()
+	require.NoError(t, err)
+	require.Len(t, recoveredNodes, nodeCount)
+
+	node, err := recovered.GetNode(storage.NodeID("test:node-047"))
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("x", 128), node.Properties["payload"])
+}
+
+func TestRecoverBadgerFromSnapshotAndWAL_RestoresLargeEdgeSetInChunks(t *testing.T) {
+	dataDir := t.TempDir()
+	snapshotDir := filepath.Join(dataDir, "snapshots")
+	require.NoError(t, os.MkdirAll(snapshotDir, 0755))
+
+	nodes := []*storage.Node{
+		{ID: "test:start", Labels: []string{"Recovered"}},
+		{ID: "test:end", Labels: []string{"Recovered"}},
+	}
+	const edgeCount = 12000
+	edges := make([]*storage.Edge, 0, edgeCount)
+	for i := 0; i < edgeCount; i++ {
+		edges = append(edges, &storage.Edge{
+			ID:        storage.EdgeID(fmt.Sprintf("test:edge-%05d", i)),
+			StartNode: "test:start",
+			EndNode:   "test:end",
+			Type:      "RECOVERED",
+			Properties: map[string]any{
+				"payload": strings.Repeat("x", 128),
+			},
+		})
+	}
+	require.NoError(t, storage.SaveSnapshot(&storage.Snapshot{
+		Sequence:  1,
+		Timestamp: time.Now(),
+		Nodes:     nodes,
+		Edges:     edges,
+		Version:   "1.0",
+	}, filepath.Join(snapshotDir, "snapshot-current.json")))
+
+	recovered, backupDir, err := recoverBadgerFromSnapshotAndWAL(dataDir, storage.BadgerOptions{
+		DataDir:   dataDir,
+		LowMemory: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, recovered)
+	require.NotEmpty(t, backupDir)
+	t.Cleanup(func() { _ = recovered.Close() })
+	t.Cleanup(func() { _ = os.RemoveAll(backupDir) })
+
+	recoveredEdges, err := recovered.AllEdges()
+	require.NoError(t, err)
+	require.Len(t, recoveredEdges, edgeCount)
+
+	edge, err := recovered.GetEdge(storage.EdgeID("test:edge-00047"))
+	require.NoError(t, err)
+	require.Equal(t, storage.NodeID("test:start"), edge.StartNode)
+	require.Equal(t, storage.NodeID("test:end"), edge.EndNode)
+	require.Equal(t, strings.Repeat("x", 128), edge.Properties["payload"])
 }
 
 func TestRecoverBadgerFromSnapshotAndWAL_WALReplayError(t *testing.T) {

--- a/pkg/storage/wal.go
+++ b/pkg/storage/wal.go
@@ -2333,10 +2333,10 @@ func RecoverWithTransactions(walDir, snapshotPath string) (*MemoryEngine, *Trans
 			}
 			// Wrap engine with NamespacedEngine for snapshot restore (snapshot nodes have unprefixed IDs)
 			namespacedEngine := NewNamespacedEngine(engine, dbName)
-			if err := namespacedEngine.BulkCreateNodes(snapshot.Nodes); err != nil {
+			if err := BulkCreateNodesForRecovery(namespacedEngine, snapshot.Nodes); err != nil {
 				return nil, result, fmt.Errorf("wal: failed to restore nodes: %w", err)
 			}
-			if err := namespacedEngine.BulkCreateEdges(snapshot.Edges); err != nil {
+			if err := BulkCreateEdgesForRecovery(namespacedEngine, snapshot.Edges); err != nil {
 				return nil, result, fmt.Errorf("wal: failed to restore edges: %w", err)
 			}
 		}
@@ -2568,10 +2568,10 @@ func RecoverFromWALWithResult(walDir, snapshotPath string) (*MemoryEngine, Repla
 			}
 
 			namespacedEngine := NewNamespacedEngine(engine, dbName)
-			if err := namespacedEngine.BulkCreateNodes(snapshot.Nodes); err != nil {
+			if err := BulkCreateNodesForRecovery(namespacedEngine, snapshot.Nodes); err != nil {
 				return nil, result, fmt.Errorf("wal: failed to restore nodes: %w", err)
 			}
-			if err := namespacedEngine.BulkCreateEdges(snapshot.Edges); err != nil {
+			if err := BulkCreateEdgesForRecovery(namespacedEngine, snapshot.Edges); err != nil {
 				return nil, result, fmt.Errorf("wal: failed to restore edges: %w", err)
 			}
 		}

--- a/pkg/storage/wal_recovery_chunking.go
+++ b/pkg/storage/wal_recovery_chunking.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+// BulkCreateNodesForRecovery creates recovered nodes while adapting to backend
+// transaction limits. It preserves the normal bulk path unless the backend says
+// the requested transaction is too large.
+func BulkCreateNodesForRecovery(engine Engine, nodes []*Node) error {
+	if len(nodes) == 0 {
+		return nil
+	}
+	if err := engine.BulkCreateNodes(nodes); err != nil {
+		if !isRecoveryBatchTooLarge(err) || len(nodes) == 1 {
+			return err
+		}
+		mid := len(nodes) / 2
+		if err := BulkCreateNodesForRecovery(engine, nodes[:mid]); err != nil {
+			return err
+		}
+		return BulkCreateNodesForRecovery(engine, nodes[mid:])
+	}
+	return nil
+}
+
+// BulkCreateEdgesForRecovery creates recovered edges while adapting to backend
+// transaction limits. A single oversized edge still returns the original error.
+func BulkCreateEdgesForRecovery(engine Engine, edges []*Edge) error {
+	if len(edges) == 0 {
+		return nil
+	}
+	if err := engine.BulkCreateEdges(edges); err != nil {
+		if !isRecoveryBatchTooLarge(err) || len(edges) == 1 {
+			return err
+		}
+		mid := len(edges) / 2
+		if err := BulkCreateEdgesForRecovery(engine, edges[:mid]); err != nil {
+			return err
+		}
+		return BulkCreateEdgesForRecovery(engine, edges[mid:])
+	}
+	return nil
+}
+
+func isRecoveryBatchTooLarge(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, badger.ErrTxnTooBig) || strings.Contains(err.Error(), badger.ErrTxnTooBig.Error())
+}

--- a/pkg/storage/wal_recovery_chunking_test.go
+++ b/pkg/storage/wal_recovery_chunking_test.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverFromWALWithResult_RestoresLargeEdgeSnapshotInChunks(t *testing.T) {
+	dataDir := t.TempDir()
+	snapshotDir := filepath.Join(dataDir, "snapshots")
+	require.NoError(t, os.MkdirAll(snapshotDir, 0755))
+
+	nodes := []*Node{
+		{ID: "test:start", Labels: []string{"Recovered"}},
+		{ID: "test:end", Labels: []string{"Recovered"}},
+	}
+	const edgeCount = 12000
+	edges := make([]*Edge, 0, edgeCount)
+	for i := 0; i < edgeCount; i++ {
+		edges = append(edges, &Edge{
+			ID:        EdgeID(fmt.Sprintf("test:edge-%05d", i)),
+			StartNode: "test:start",
+			EndNode:   "test:end",
+			Type:      "RECOVERED",
+			Properties: map[string]any{
+				"payload": strings.Repeat("x", 128),
+			},
+		})
+	}
+
+	snapshotPath := filepath.Join(snapshotDir, "snapshot-current.json")
+	require.NoError(t, SaveSnapshot(&Snapshot{
+		Sequence:  1,
+		Timestamp: time.Now(),
+		Nodes:     nodes,
+		Edges:     edges,
+		Version:   "1.0",
+	}, snapshotPath))
+
+	recovered, result, err := RecoverFromWALWithResult(filepath.Join(dataDir, "wal"), snapshotPath)
+	require.NoError(t, err)
+	require.NotNil(t, recovered)
+	require.Zero(t, result.Failed)
+	t.Cleanup(func() { _ = recovered.Close() })
+
+	recoveredEdges, err := recovered.AllEdges()
+	require.NoError(t, err)
+	require.Len(t, recoveredEdges, edgeCount)
+
+	edge, err := recovered.GetEdge(EdgeID("test:edge-00047"))
+	require.NoError(t, err)
+	require.Equal(t, NodeID("test:start"), edge.StartNode)
+	require.Equal(t, NodeID("test:end"), edge.EndNode)
+	require.Equal(t, strings.Repeat("x", 128), edge.Properties["payload"])
+}


### PR DESCRIPTION
## Summary

- classify missing tokenized property-key dictionary entries as startup corruption signals
- restore snapshot/WAL recovery batches with adaptive splitting when Badger rejects an oversized transaction
- reuse the recovery chunking path for auto-recovery fresh-store restores
- document the corruption signal and large-restore behavior for operators

## Why this helps NornicDB

A valid recovered graph can still be too large for a single Badger write transaction during recovery. Before this change, recovery could fail with `Txn is too big to fit into one request` while restoring a large node or edge set, even though the snapshot/WAL data was otherwise usable. This affects any NornicDB deployment with large recovery artifacts, not a downstream-specific query shape.

The property-key dictionary decode error is also a storage corruption signal: a persisted body references a tokenized property key that is not present in the dictionary. When recovery artifacts exist, startup should treat that like other recoverable corruption signatures and rebuild from snapshot/WAL rather than requiring manual data-directory deletion.

## Test Evidence

RED before the fix:

```bash
go test -tags "noui nolocalllm" ./pkg/nornicdb -run "TestStorageRecoveryHelpers_HeuristicsAndArtifacts|TestRecoverBadgerFromSnapshotAndWAL_RestoresLargeNodeSetInChunks" -count=1
```

Failed as expected because the dictionary error was not classified as corruption and large restore returned `Txn is too big to fit into one request`.

GREEN after the fix:

```bash
go test -tags "noui nolocalllm" ./pkg/nornicdb -run "TestStorageRecoveryHelpers_HeuristicsAndArtifacts|TestRecoverBadgerFromSnapshotAndWAL_RestoresLargeNodeSetInChunks|TestRecoverBadgerFromSnapshotAndWAL_RestoresLargeEdgeSetInChunks" -count=1
go test -tags "noui nolocalllm" ./pkg/storage -run "TestRecoverFromWALWithResult_RestoresLargeEdgeSnapshotInChunks|TestRecoverFromWALWithResult|TestRecoverWithTransactions|TestBadgerEngine_BulkCreateNodes|TestBadgerEngine_BulkCreateEdges" -count=1
go test -tags "noui nolocalllm" ./pkg/storage -count=1
go test -tags "noui nolocalllm" ./pkg/nornicdb -skip TestLoadPluginsFromDir -count=1
git diff --check
```

Additional local checks:

```bash
go test -tags "noui nolocalllm" ./pkg/nornicdb -count=1
```

This currently fails on this machine only in `TestLoadPluginsFromDir` because the plugin build cannot link `llama_darwin_arm64`. The same package passes with only that plugin-load test skipped, as shown above.

```bash
golangci-lint run ./pkg/nornicdb ./pkg/storage
```

This reports existing repo-wide lint findings in unrelated files; no new lint finding was identified in the changed recovery files.

## Compatibility

The normal bulk write path is unchanged. Recovery uses the existing bulk call first, then splits only when the backend returns Badger's transaction-too-large error. A single oversized node or edge still returns the original error instead of being hidden.
