### PR TITLE
Admin Import Tool, Documentation, and Scenario Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ metrics-doc-gen
 !cmd/metrics-doc-gen
 *.pyc
 site
+nornicdb-admin

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ metrics-doc-gen
 *.pyc
 site
 nornicdb-admin
+!cmd/nornicdb-admin

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ BGE_RERANKER_URL := https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/reso
 .PHONY: deploy-all deploy-arm64-all deploy-amd64-all
 .PHONY: build-llama-cpu push-llama-cpu deploy-llama-cpu ensure-llama-cpu
 .PHONY: build-llama-cuda push-llama-cuda deploy-llama-cuda ensure-llama-cuda
-.PHONY: build build-ui build-binary build-localllm build-headless build-localllm-headless sync-version test lint-slog install-hooks clean images help macos-menubar macos-install macos-uninstall macos-all macos-clean macos-package macos-package-lite macos-package-full macos-package-all macos-package-signed
+.PHONY: build build-ui build-binary build-admin build-localllm build-headless build-localllm-headless sync-version test lint-slog install-hooks clean images help macos-menubar macos-install macos-uninstall macos-all macos-clean macos-package macos-package-lite macos-package-full macos-package-all macos-package-signed
 .PHONY: download-models download-bge download-qwen download-bge-reranker check-models
 .PHONY: antlr-generate antlr-clean antlr-test antlr-test-full test-parsers
 
@@ -796,6 +796,9 @@ else
 endif
 endif
 
+build-admin: sync-version
+	go build -ldflags "$(BUILD_LDFLAGS)" -o bin/nornicdb-admin$(BIN_EXT) ./cmd/nornicdb-admin
+
 # Build plugins only if platform supports Go plugins (Linux/macOS, not Windows)
 build-plugins-if-supported:
 ifeq ($(OS),Windows_NT)
@@ -919,6 +922,57 @@ endif
 # Note: CGO is disabled for cross-compilation (pure Go, no Metal/CUDA)
 
 .PHONY: cross-linux-amd64 cross-linux-arm64 cross-rpi cross-rpi-zero cross-windows cross-all
+
+# Admin binary cross-compilation mirrors the main binary targets.
+.PHONY: cross-linux-amd64-admin cross-linux-arm64-admin cross-rpi-admin cross-rpi-zero-admin cross-windows-admin cross-all-admin
+
+cross-linux-amd64-admin:
+	@echo "Building admin binary for Linux x86_64..."
+ifeq ($(HOST_OS),windows)
+	@set CGO_ENABLED=0 && set GOOS=linux && set GOARCH=amd64 && go build -o bin/nornicdb-admin-linux-amd64 ./cmd/nornicdb-admin
+else
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/nornicdb-admin-linux-amd64 ./cmd/nornicdb-admin
+endif
+	@echo "bin/nornicdb-admin-linux-amd64"
+
+cross-linux-arm64-admin:
+	@echo "Building admin binary for Linux ARM64..."
+ifeq ($(HOST_OS),windows)
+	@set CGO_ENABLED=0 && set GOOS=linux && set GOARCH=arm64 && go build -o bin/nornicdb-admin-linux-arm64 ./cmd/nornicdb-admin
+else
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/nornicdb-admin-linux-arm64 ./cmd/nornicdb-admin
+endif
+	@echo "bin/nornicdb-admin-linux-arm64"
+
+cross-rpi-admin:
+	@echo "Building admin binary for Raspberry Pi (64-bit ARM)..."
+ifeq ($(HOST_OS),windows)
+	@set CGO_ENABLED=0 && set GOOS=linux && set GOARCH=arm64 && go build -o bin/nornicdb-admin-rpi64 ./cmd/nornicdb-admin
+else
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/nornicdb-admin-rpi64 ./cmd/nornicdb-admin
+endif
+	@echo "bin/nornicdb-admin-rpi64"
+
+cross-rpi-zero-admin:
+	@echo "Building admin binary for Raspberry Pi Zero (ARMv6)..."
+ifeq ($(HOST_OS),windows)
+	@set CGO_ENABLED=0 && set GOOS=linux && set GOARCH=arm && set GOARM=6 && go build -o bin/nornicdb-admin-rpi-zero ./cmd/nornicdb-admin
+else
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -o bin/nornicdb-admin-rpi-zero ./cmd/nornicdb-admin
+endif
+	@echo "bin/nornicdb-admin-rpi-zero"
+
+cross-windows-admin:
+	@echo "Building admin binary for Windows x86_64..."
+ifeq ($(HOST_OS),windows)
+	@set CGO_ENABLED=0 && set GOOS=windows && set GOARCH=amd64 && go build -o bin/nornicdb-admin.exe ./cmd/nornicdb-admin
+else
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o bin/nornicdb-admin.exe ./cmd/nornicdb-admin
+endif
+	@echo "bin/nornicdb-admin.exe"
+
+cross-all-admin: cross-linux-amd64-admin cross-linux-arm64-admin cross-rpi-admin cross-rpi-zero-admin cross-windows-admin
+	@echo "Admin cross-compilation complete!"
 
 # Linux x86_64 (standard servers, VPS, Docker hosts)
 cross-linux-amd64:

--- a/cmd/nornicdb-admin/main.go
+++ b/cmd/nornicdb-admin/main.go
@@ -1,0 +1,218 @@
+// Package main provides the NornicDB admin CLI entrypoint.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orneryd/nornicdb/pkg/adminimport"
+	"github.com/orneryd/nornicdb/pkg/buildinfo"
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "nornicdb-admin",
+		Short: "Administrative tools for NornicDB",
+	}
+
+	dataDir := rootCmd.PersistentFlags().String("data-dir", "./data", "Target data directory")
+
+	databaseCmd := &cobra.Command{Use: "database", Short: "Database administration commands"}
+	importCmd := &cobra.Command{Use: "import", Short: "Import CSV data into an offline database"}
+
+	fullCmd := &cobra.Command{
+		Use:   "full <db-name>",
+		Short: "Run a full offline import",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runImportFull(args[0], *dataDir, cmd)
+		},
+	}
+	fullCmd.Flags().StringSlice("nodes", nil, "Node CSV source (repeatable)")
+	fullCmd.Flags().StringSlice("relationships", nil, "Relationship CSV source (repeatable)")
+	fullCmd.Flags().String("from-path", "", "Directory containing Neo4j-compatible CSV files")
+	fullCmd.Flags().String("schema", "", "Cypher schema file to apply after load")
+	fullCmd.Flags().Bool("build-indexes", true, "Build search indexes after import")
+	fullCmd.Flags().Bool("skip-bad-relationships", false, "Skip relationships that reference missing nodes")
+	fullCmd.Flags().Bool("skip-duplicate-nodes", false, "Skip duplicate node IDs")
+	fullCmd.Flags().Bool("normalize-types", true, "Normalize imported property values")
+	fullCmd.Flags().Bool("ignore-extra-columns", false, "Ignore extra CSV columns")
+	fullCmd.Flags().Bool("ignore-empty-strings", false, "Treat empty strings as null")
+	fullCmd.Flags().String("report-file", "", "Write a JSON report")
+	fullCmd.Flags().String("id-type", "string", "ID type: string or integer")
+	fullCmd.Flags().Int("bad-tolerance", 0, "Number of bad rows tolerated before abort")
+	fullCmd.Flags().Int("chunk-size", 1000, "Rows per bulk write chunk")
+	fullCmd.Flags().String("delimiter", ",", "Field delimiter")
+	fullCmd.Flags().String("array-delimiter", ";", "Array delimiter")
+	fullCmd.Flags().String("vector-delimiter", ";", "Vector delimiter")
+	fullCmd.Flags().String("quote", "\"", "Quote character")
+	fullCmd.Flags().String("constraints-file", "", "Deprecated alias for --schema")
+	fullCmd.Flags().Bool("verbose", false, "Verbose logging")
+
+	incrementalCmd := &cobra.Command{
+		Use:   "incremental <db-name>",
+		Short: "Reserved incremental import command",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("database import incremental is not implemented yet")
+		},
+	}
+
+	importCmd.AddCommand(fullCmd, incrementalCmd)
+	exportCmd := &cobra.Command{Use: "export", Short: "Export database data for offline migration"}
+	exportNeo4jCSVCmd := &cobra.Command{
+		Use:   "neo4j-csv <db-name>",
+		Short: "Export a database as Neo4j-compatible CSV files",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExportNeo4jCSV(args[0], *dataDir, cmd)
+		},
+	}
+	exportNeo4jCSVCmd.Flags().String("to-path", "", "Output directory for Neo4j-compatible CSV files")
+	exportNeo4jCSVCmd.Flags().String("delimiter", ",", "Field delimiter")
+	exportNeo4jCSVCmd.Flags().String("array-delimiter", ";", "Array delimiter")
+	exportNeo4jCSVCmd.Flags().String("vector-delimiter", ";", "Vector delimiter")
+	exportNeo4jCSVCmd.Flags().String("quote", "\"", "Quote character")
+	exportCmd.AddCommand(exportNeo4jCSVCmd)
+	databaseCmd.AddCommand(importCmd)
+	databaseCmd.AddCommand(exportCmd)
+	databaseCmd.AddCommand(&cobra.Command{Use: "info <db-name>", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("database info is not implemented yet")
+	}})
+	rootCmd.AddCommand(databaseCmd)
+	serverCmd := &cobra.Command{Use: "server", Short: "Server commands"}
+	serverCmd.AddCommand(&cobra.Command{Use: "status", Short: "Show server status", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("server status is not implemented yet")
+	}})
+	rootCmd.AddCommand(serverCmd)
+	rootCmd.AddCommand(&cobra.Command{Use: "version", Short: "Print version", Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(buildinfo.DisplayVersion())
+	}})
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runImportFull(dbName string, dataDir string, cmd *cobra.Command) error {
+	nodes, _ := cmd.Flags().GetStringSlice("nodes")
+	rels, _ := cmd.Flags().GetStringSlice("relationships")
+	fromPath, _ := cmd.Flags().GetString("from-path")
+	reportFile, _ := cmd.Flags().GetString("report-file")
+	schemaFile, _ := cmd.Flags().GetString("schema")
+	idType, _ := cmd.Flags().GetString("id-type")
+	delimiter, _ := cmd.Flags().GetString("delimiter")
+	arrayDelimiter, _ := cmd.Flags().GetString("array-delimiter")
+	vectorDelimiter, _ := cmd.Flags().GetString("vector-delimiter")
+	quote, _ := cmd.Flags().GetString("quote")
+	chunkSize, _ := cmd.Flags().GetInt("chunk-size")
+	normalize, _ := cmd.Flags().GetBool("normalize-types")
+	ignoreExtra, _ := cmd.Flags().GetBool("ignore-extra-columns")
+	ignoreEmpty, _ := cmd.Flags().GetBool("ignore-empty-strings")
+	buildIndexes, _ := cmd.Flags().GetBool("build-indexes")
+	skipBad, _ := cmd.Flags().GetBool("skip-bad-relationships")
+	skipDup, _ := cmd.Flags().GetBool("skip-duplicate-nodes")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	badTol, _ := cmd.Flags().GetInt("bad-tolerance")
+	constraintsFile, _ := cmd.Flags().GetString("constraints-file")
+	if schemaFile == "" {
+		schemaFile = constraintsFile
+	}
+	if fromPath != "" && schemaFile == "" {
+		candidate := adminimport.DefaultNeo4jCSVNornicSchemaPath(fromPath)
+		if _, err := os.Stat(candidate); err == nil {
+			schemaFile = candidate
+		} else {
+			candidate = adminimport.DefaultNeo4jCSVSchemaPath(fromPath)
+			if _, err := os.Stat(candidate); err == nil {
+				schemaFile = candidate
+			}
+		}
+	}
+	if fromPath != "" {
+		discoveredNodes, discoveredRels, err := adminimport.DiscoverNeo4jCSVSources(fromPath, adminimport.Options{
+			Delimiter:       firstRune(delimiter, ','),
+			ArrayDelimiter:  firstRune(arrayDelimiter, ';'),
+			VectorDelimiter: firstRune(vectorDelimiter, ';'),
+			Quote:           firstRune(quote, '"'),
+		})
+		if err != nil {
+			return err
+		}
+		nodes = append(nodes, discoveredNodes...)
+		rels = append(rels, discoveredRels...)
+	}
+
+	engine, err := storage.NewBadgerEngine(dataDir)
+	if err != nil {
+		return err
+	}
+	defer engine.Close()
+
+	report, err := adminimport.ImportFull(context.Background(), engine, adminimport.Options{
+		DatabaseName:         dbName,
+		NodeSources:          nodes,
+		RelSources:           rels,
+		DataDir:              dataDir,
+		Delimiter:            firstRune(delimiter, ','),
+		ArrayDelimiter:       firstRune(arrayDelimiter, ';'),
+		VectorDelimiter:      firstRune(vectorDelimiter, ';'),
+		Quote:                firstRune(quote, '"'),
+		IDType:               idType,
+		NormalizeTypes:       normalize,
+		IgnoreExtraColumns:   ignoreExtra,
+		IgnoreEmptyStrings:   ignoreEmpty,
+		BadTolerance:         badTol,
+		SkipBadRelationships: skipBad,
+		SkipDuplicateNodes:   skipDup,
+		ReportFile:           reportFile,
+		SchemaFile:           schemaFile,
+		BuildIndexes:         buildIndexes,
+		ChunkSize:            chunkSize,
+		Verbose:              verbose,
+	})
+	if err != nil {
+		return err
+	}
+	_ = report
+	return nil
+}
+
+func runExportNeo4jCSV(dbName string, dataDir string, cmd *cobra.Command) error {
+	toPath, _ := cmd.Flags().GetString("to-path")
+	delimiter, _ := cmd.Flags().GetString("delimiter")
+	arrayDelimiter, _ := cmd.Flags().GetString("array-delimiter")
+	vectorDelimiter, _ := cmd.Flags().GetString("vector-delimiter")
+	quote, _ := cmd.Flags().GetString("quote")
+	if strings.TrimSpace(toPath) == "" {
+		return fmt.Errorf("--to-path is required")
+	}
+
+	engine, err := storage.NewBadgerEngine(dataDir)
+	if err != nil {
+		return err
+	}
+	defer engine.Close()
+
+	namespaced := storage.NewNamespacedEngine(engine, dbName)
+	return adminimport.ExportNeo4jCSV(namespaced, adminimport.Neo4jCSVExportOptions{
+		OutputDir:       toPath,
+		Delimiter:       firstRune(delimiter, ','),
+		ArrayDelimiter:  firstRune(arrayDelimiter, ';'),
+		VectorDelimiter: firstRune(vectorDelimiter, ';'),
+		Quote:           firstRune(quote, '"'),
+	})
+}
+
+func firstRune(value string, fallback rune) rune {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return []rune(value)[0]
+}

--- a/cmd/nornicdb-admin/main.go
+++ b/cmd/nornicdb-admin/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -15,6 +16,12 @@ import (
 )
 
 func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(exitCodeForError(err))
+	}
+}
+
+func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "nornicdb-admin",
 		Short: "Administrative tools for NornicDB",
@@ -94,9 +101,7 @@ func main() {
 		fmt.Println(buildinfo.DisplayVersion())
 	}})
 
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+	return rootCmd
 }
 
 func runImportFull(dbName string, dataDir string, cmd *cobra.Command) error {
@@ -215,4 +220,17 @@ func firstRune(value string, fallback rune) rune {
 		return fallback
 	}
 	return []rune(value)[0]
+}
+
+func exitCodeForError(err error) int {
+	if err == nil {
+		return adminimport.ExitOK
+	}
+	var importErr *adminimport.Error
+	if errors.As(err, &importErr) {
+		if importErr.ExitCode > 0 {
+			return importErr.ExitCode
+		}
+	}
+	return 1
 }

--- a/cmd/nornicdb-admin/main_test.go
+++ b/cmd/nornicdb-admin/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/adminimport"
+)
+
+func TestExitCodeForError_UsesImportExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: adminimport.ExitOK},
+		{name: "plain error", err: errors.New("boom"), want: 1},
+		{name: "csv", err: &adminimport.Error{ExitCode: adminimport.ExitCSV, Message: "csv"}, want: adminimport.ExitCSV},
+		{name: "wrapped", err: errors.New((&adminimport.Error{ExitCode: adminimport.ExitDuplicateID, Message: "dup"}).Error()), want: 1},
+		{name: "wrapped as", err: wrapErr(&adminimport.Error{ExitCode: adminimport.ExitBadRelationship, Message: "bad"}), want: adminimport.ExitBadRelationship},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCodeForError(tt.err); got != tt.want {
+				t.Fatalf("exitCodeForError() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func wrapErr(err error) error {
+	return &wrapped{err: err}
+}
+
+type wrapped struct {
+	err error
+}
+
+func (w *wrapped) Error() string { return "wrapped: " + w.err.Error() }
+func (w *wrapped) Unwrap() error { return w.err }

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ If you know your goal, start in **"Find by task"**. If you are debugging, start 
 - Configure deployment/runtime: [Configuration](operations/configuration.md), [Environment Variables](operations/environment-variables.md)
 - Deploy with Docker: [Docker Deployment](getting-started/docker-deployment.md), [Operations Docker](operations/docker.md)
 - Observe/operate production: [Monitoring](operations/monitoring.md), [Backup & Restore](operations/backup-restore.md)
+- Offline bulk import: [nornicdb-admin](operations/admin-tool.md)
 - Migrate from Neo4j drivers/schemas: [Migration Guide](neo4j-migration/README.md)
 
 ## Find by Issue

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -27,6 +27,7 @@ This section is the canonical runbook set for deploying, operating, and recoveri
 - MVCC retention and historical reads: [../user-guides/historical-reads-mvcc-retention.md](../user-guides/historical-reads-mvcc-retention.md)
 - Storage encoding format and migration details: [storage-serialization.md](storage-serialization.md)
 - CLI workflows: [cli-commands.md](cli-commands.md)
+- Offline admin import workflow: [admin-tool.md](admin-tool.md)
 
 ## Incident Routing
 

--- a/docs/operations/admin-tool.md
+++ b/docs/operations/admin-tool.md
@@ -61,7 +61,7 @@ The directory importer:
 
 - scans for `*.csv`, `*.csv.gz`, and single-member `*.zip` CSV files
 - classifies node vs relationship files from their CSV headers
-- automatically uses `schema.cypher` from that same directory when present and `--schema` is not set
+- automatically uses `schema.nornic.json` (preferred) or `schema.cypher` from that same directory when present and `--schema` is not set
 
 This makes it possible to import a full offline package produced by `database export neo4j-csv` with a single command.
 

--- a/docs/operations/admin-tool.md
+++ b/docs/operations/admin-tool.md
@@ -8,6 +8,8 @@ Use `nornicdb-admin` when you need to:
 
 - load a database from CSV into an empty target
 - import Neo4j-style node and relationship files
+- import a whole Neo4j-compatible CSV package from a directory
+- export a NornicDB database as a Neo4j-compatible offline package
 - run an import that should build search artifacts after load
 - verify the resulting database by namespace after import
 
@@ -45,6 +47,24 @@ Example `relationships.csv`:
 u1,u2,KNOWS,2024
 ```
 
+## Import From A Directory
+
+If you already have a folder containing Neo4j-compatible CSV files, use `--from-path` instead of repeating `--nodes` and `--relationships`.
+
+```bash
+nornicdb-admin database import full mydb \
+  --from-path=./neo4j-export \
+  --data-dir=./data
+```
+
+The directory importer:
+
+- scans for `*.csv`, `*.csv.gz`, and single-member `*.zip` CSV files
+- classifies node vs relationship files from their CSV headers
+- automatically uses `schema.cypher` from that same directory when present and `--schema` is not set
+
+This makes it possible to import a full offline package produced by `database export neo4j-csv` with a single command.
+
 ## Multi-File Sources
 
 The first file in a source must contain the header. Additional files in the same source are read as data files.
@@ -66,10 +86,36 @@ nornicdb-admin database import full beta --nodes=Person=beta.csv --data-dir=./da
 
 Re-importing into an existing target database is rejected.
 
+## Export A Neo4j-Compatible Package
+
+`database export neo4j-csv` writes a filesystem package that can be imported back with `--from-path`.
+
+```bash
+nornicdb-admin database export neo4j-csv mydb \
+  --to-path=./neo4j-export \
+  --data-dir=./data
+```
+
+When schema exists, the export also writes `schema.cypher` alongside the CSV files.
+
+Typical output:
+
+- `nodes.csv`
+- `relationships.csv`
+- `schema.cypher` when the database has exportable constraints or indexes
+
+Roundtrip back into a fresh target:
+
+```bash
+nornicdb-admin database export neo4j-csv mydb --to-path=./neo4j-export --data-dir=./data
+nornicdb-admin database import full restored --from-path=./neo4j-export --data-dir=./restored-data
+```
+
 ## Common Flags
 
 - `--nodes` - Node CSV sources. Repeatable.
 - `--relationships` - Relationship CSV sources. Repeatable.
+- `--from-path` - Directory containing Neo4j-compatible CSV files for auto-discovery.
 - `--data-dir` - Target data directory.
 - `--schema` - Cypher file applied after the data load.
 - `--report-file` - JSON report written after import.
@@ -82,6 +128,7 @@ Re-importing into an existing target database is rejected.
 - The target database must be empty.
 - Missing source files fail before any writes begin.
 - Composite IDs, labels, vector properties, and named embeddings are supported through the CSV header dialect in the admin import plan.
+- `database export neo4j-csv` emits Neo4j-compatible CSV plus `schema.cypher` when the current database schema can be expressed as Cypher DDL.
 - After import, verify the loaded data by opening the namespace through the storage API or by starting the database normally.
 
 ## Recovery

--- a/docs/operations/admin-tool.md
+++ b/docs/operations/admin-tool.md
@@ -1,0 +1,95 @@
+# nornicdb-admin
+
+`nornicdb-admin` is the offline operator CLI for NornicDB. Use it for bulk CSV import and other database administration tasks that should not go through the live Bolt server.
+
+## When to use it
+
+Use `nornicdb-admin` when you need to:
+
+- load a database from CSV into an empty target
+- import Neo4j-style node and relationship files
+- run an import that should build search artifacts after load
+- verify the resulting database by namespace after import
+
+## Build
+
+```bash
+make build-admin
+```
+
+This produces `bin/nornicdb-admin` on the current platform.
+
+## Basic Usage
+
+```bash
+nornicdb-admin database import full mydb \
+  --nodes=Person=people.csv \
+  --relationships=KNOWS=relationships.csv \
+  --data-dir=./data \
+  --schema=./schema.cypher \
+  --report-file=./import-report.json
+```
+
+Example `people.csv`:
+
+```csv
+:ID,name:string,age:int,:LABEL
+u1,Alice,34,Person;User
+u2,Bob,29,Person
+```
+
+Example `relationships.csv`:
+
+```csv
+:START_ID,:END_ID,:TYPE,since:int
+u1,u2,KNOWS,2024
+```
+
+## Multi-File Sources
+
+The first file in a source must contain the header. Additional files in the same source are read as data files.
+
+```bash
+nornicdb-admin database import full mydb \
+  --nodes=Person=people-header.csv,people-part-2.csv \
+  --relationships=WORKS_AT=works-at-header.csv,works-at-part-2.csv
+```
+
+## Different Database Targets
+
+Each database name is isolated inside the same storage directory.
+
+```bash
+nornicdb-admin database import full alpha --nodes=Person=alpha.csv --data-dir=./data
+nornicdb-admin database import full beta --nodes=Person=beta.csv --data-dir=./data
+```
+
+Re-importing into an existing target database is rejected.
+
+## Common Flags
+
+- `--nodes` - Node CSV sources. Repeatable.
+- `--relationships` - Relationship CSV sources. Repeatable.
+- `--data-dir` - Target data directory.
+- `--schema` - Cypher file applied after the data load.
+- `--report-file` - JSON report written after import.
+- `--build-indexes` - Build search indexes after import.
+- `--skip-bad-relationships` - Continue past unresolved relationship rows.
+- `--skip-duplicate-nodes` - Ignore duplicate import IDs.
+
+## Usage Notes
+
+- The target database must be empty.
+- Missing source files fail before any writes begin.
+- Composite IDs, labels, vector properties, and named embeddings are supported through the CSV header dialect in the admin import plan.
+- After import, verify the loaded data by opening the namespace through the storage API or by starting the database normally.
+
+## Recovery
+
+If import fails, remove or reset the target database directory before retrying. The importer writes in chunks, so partial data can remain after a failed run.
+
+## Related Documentation
+
+- [CLI Commands](cli-commands.md)
+- [Data Import/Export Guide](../user-guides/data-import-export.md)
+- [Admin Import Plan](../plans/nornicdb-admin-import-plan.md)

--- a/docs/operations/cli-commands.md
+++ b/docs/operations/cli-commands.md
@@ -27,7 +27,7 @@ The CLI surface is intentionally small. The full set is:
 - `nornicdb decay suppress` — re-evaluate suppression status.
 - `nornicdb decay stats` — print decay statistics.
 
-For migration, backup, and import operations, use the HTTP/Bolt APIs or the runnable scripts under [`scripts/migration/`](https://github.com/orneryd/nornicdb/tree/main/scripts/migration). The CLI does not have `import`, `export`, `backup`, or `restore` subcommands.
+For migration, backup, and import operations, use the HTTP/Bolt APIs, the runnable scripts under [`scripts/migration/`](https://github.com/orneryd/nornicdb/tree/main/scripts/migration), or the offline admin guide at [admin-tool.md](admin-tool.md). The main `nornicdb` CLI does not have `import`, `export`, `backup`, or `restore` subcommands.
 
 ---
 
@@ -185,7 +185,7 @@ nornicdb version
 
 ## Knowledge-Layer Scoring
 
-Decay behavior, visibility thresholds, and promotion tiers are authored through Cypher DDL (`CREATE DECAY PROFILE`, `CREATE PROMOTION POLICY`). The CLI subcommands above are operational helpers; the *configuration* surface is Cypher. See:
+Decay behavior, visibility thresholds, and promotion tiers are authored through Cypher DDL (`CREATE DECAY PROFILE`, `CREATE PROMOTION POLICY`). The CLI subcommands above are operational helpers; the _configuration_ surface is Cypher. See:
 
 - [Decay Profiles](../user-guides/decay-profiles.md) — defining decay behavior.
 - [Promotion Policies](../user-guides/promotion-policies.md) — boosting scores.
@@ -229,3 +229,4 @@ chown -R $USER:$USER /path/to/data
 - [Operations Guide](README.md) — production deployment and maintenance.
 - [Backup & Restore](backup-restore.md) — data protection strategies.
 - [Monitoring](monitoring.md) — health checks and metrics.
+- [nornicdb-admin Guide](admin-tool.md) — offline bulk import and operator workflows.

--- a/docs/operations/cli-commands.md
+++ b/docs/operations/cli-commands.md
@@ -27,7 +27,7 @@ The CLI surface is intentionally small. The full set is:
 - `nornicdb decay suppress` — re-evaluate suppression status.
 - `nornicdb decay stats` — print decay statistics.
 
-For migration, backup, and import operations, use the HTTP/Bolt APIs, the runnable scripts under [`scripts/migration/`](https://github.com/orneryd/nornicdb/tree/main/scripts/migration), or the offline admin guide at [admin-tool.md](admin-tool.md). The main `nornicdb` CLI does not have `import`, `export`, `backup`, or `restore` subcommands.
+For migration, backup, and import operations, use the HTTP/Bolt APIs, the runnable scripts under [`scripts/migration/`](https://github.com/orneryd/nornicdb/tree/main/scripts/migration), or the offline admin guide at [admin-tool.md](admin-tool.md). The main `nornicdb` server CLI does not have general-purpose `import` or `export` subcommands; those live under `nornicdb-admin`.
 
 ---
 
@@ -229,4 +229,4 @@ chown -R $USER:$USER /path/to/data
 - [Operations Guide](README.md) — production deployment and maintenance.
 - [Backup & Restore](backup-restore.md) — data protection strategies.
 - [Monitoring](monitoring.md) — health checks and metrics.
-- [nornicdb-admin Guide](admin-tool.md) — offline bulk import and operator workflows.
+- [nornicdb-admin Guide](admin-tool.md) — offline bulk import, `--from-path`, and Neo4j-compatible export workflows.

--- a/docs/plans/nornicdb-admin-import-plan.md
+++ b/docs/plans/nornicdb-admin-import-plan.md
@@ -252,6 +252,14 @@ The output of Phase 4 is a data directory that's logically equivalent to one pro
 
 - **Exit code 0:** every row imported, every index built, every constraint satisfied. Report file written.
 
+### Regression scenarios to keep covered
+
+- Missing source folder or file path should fail fast with a CSV/open error before any writes begin.
+- Importing into the same database namespace twice should fail the second time because the target is no longer empty.
+- Importing into a different database namespace on the same underlying engine should succeed and keep the records isolated by namespace.
+- Multi-file sources must treat the first file as the header-bearing file and read subsequent files as data without dropping their first row.
+- After each scenario, verify the loaded database contents through the namespaced storage API, not just through the import report.
+
 ## Phase 6 — Cypher procedure helpers (post-import)
 
 Two small additions to the running server, scoped to make the bulk-load UX cleaner for _online_ loads that still want the deferred-population behavior:

--- a/docs/user-guides/data-import-export.md
+++ b/docs/user-guides/data-import-export.md
@@ -150,7 +150,7 @@ Export Neo4j-compatible CSV files from Neo4j using the tooling you already use f
     --data-dir=./data
    ```
 
-If the folder includes `schema.cypher`, `nornicdb-admin` will apply it automatically unless you override `--schema`.
+If the folder includes `schema.nornic.json` or `schema.cypher`, `nornicdb-admin` will apply it automatically (preferring `schema.nornic.json`) unless you override `--schema`.
 
 See the [admin tool guide](../operations/admin-tool.md) for CSV header examples, `--from-path`, and recovery notes.
 

--- a/docs/user-guides/data-import-export.md
+++ b/docs/user-guides/data-import-export.md
@@ -134,9 +134,7 @@ All official Neo4j drivers work with NornicDB:
 
 1. **Export from Neo4j**:
 
-   ```cypher
-   CALL apoc.export.json.all("export.json", {})
-   ```
+Export Neo4j-compatible CSV files from Neo4j using the tooling you already use for offline import packages.
 
 2. **Start NornicDB**:
 
@@ -145,24 +143,36 @@ All official Neo4j drivers work with NornicDB:
    ```
 
 3. **Import to NornicDB**:
+
    ```bash
-
+   nornicdb-admin database import full mydb \
+    --from-path=./neo4j-export \
+    --data-dir=./data
    ```
-
-# Use the offline admin tool for bulk CSV imports
-
-nornicdb-admin database import full mydb \
- --nodes=Person=people.csv \
- --relationships=KNOWS=relationships.csv \
- --data-dir=./data
 
 ````
 
-See the [admin tool guide](../operations/admin-tool.md) for CSV header examples and recovery notes.
+If the folder includes `schema.cypher`, `nornicdb-admin` will apply it automatically unless you override `--schema`.
+
+See the [admin tool guide](../operations/admin-tool.md) for CSV header examples, `--from-path`, and recovery notes.
 
 ### From NornicDB to Neo4j
 
-Same process in reverse - the formats are identical.
+Use the offline admin export tool to create a Neo4j-compatible package:
+
+```bash
+nornicdb-admin database export neo4j-csv mydb \
+--to-path=./neo4j-export \
+--data-dir=./data
+````
+
+This writes:
+
+- `nodes.csv`
+- `relationships.csv` when the database has relationships
+- `schema.cypher` when the database has exportable constraints or indexes
+
+That package is designed to be re-imported with `nornicdb-admin database import full --from-path=...` and to stay close to Neo4j's offline CSV conventions.
 
 ---
 
@@ -174,7 +184,7 @@ Same process in reverse - the formats are identical.
 # Trigger a snapshot via the authenticated admin HTTP endpoint
 curl -X POST http://localhost:7474/admin/backup \
 -H "Authorization: Bearer $ADMIN_TOKEN"
-````
+```
 
 For volume-level backups (raw `tar` of `/data`) see the [Backup & Restore operations guide](../operations/backup-restore.md).
 
@@ -205,7 +215,7 @@ curl -X POST http://localhost:7474/gdpr/delete \
 - **[Getting Started](../getting-started/README.md)** - Installation guide
 - **[Cypher Queries](cypher-queries.md)** - Query language reference
 - **[API Reference](../api-reference/README.md)** - Complete API docs
-- **[nornicdb-admin](../operations/admin-tool.md)** - Offline bulk import and operator workflows
+- **[nornicdb-admin](../operations/admin-tool.md)** - Offline bulk import, `--from-path`, and Neo4j-compatible export workflows
 
 ---
 

--- a/docs/user-guides/data-import-export.md
+++ b/docs/user-guides/data-import-export.md
@@ -150,8 +150,6 @@ Export Neo4j-compatible CSV files from Neo4j using the tooling you already use f
     --data-dir=./data
    ```
 
-````
-
 If the folder includes `schema.cypher`, `nornicdb-admin` will apply it automatically unless you override `--schema`.
 
 See the [admin tool guide](../operations/admin-tool.md) for CSV header examples, `--from-path`, and recovery notes.
@@ -162,9 +160,9 @@ Use the offline admin export tool to create a Neo4j-compatible package:
 
 ```bash
 nornicdb-admin database export neo4j-csv mydb \
---to-path=./neo4j-export \
---data-dir=./data
-````
+  --to-path=./neo4j-export \
+  --data-dir=./data
+```
 
 This writes:
 
@@ -183,7 +181,7 @@ That package is designed to be re-imported with `nornicdb-admin database import 
 ```bash
 # Trigger a snapshot via the authenticated admin HTTP endpoint
 curl -X POST http://localhost:7474/admin/backup \
--H "Authorization: Bearer $ADMIN_TOKEN"
+  -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
 For volume-level backups (raw `tar` of `/data`) see the [Backup & Restore operations guide](../operations/backup-restore.md).

--- a/docs/user-guides/data-import-export.md
+++ b/docs/user-guides/data-import-export.md
@@ -79,7 +79,7 @@ RETURN labels(n) AS labels, properties(n) AS properties
 
 -- Export with relationships
 MATCH (n)-[r]->(m)
-RETURN 
+RETURN
   labels(n) AS fromLabels,
   properties(n) AS fromProps,
   type(r) AS relType,
@@ -107,14 +107,14 @@ curl -X POST http://localhost:7474/db/nornic/tx/commit \
 
 ### Supported Features
 
-| Feature | Status | Notes |
-|---------|--------|-------|
+| Feature        | Status  | Notes               |
+| -------------- | ------- | ------------------- |
 | Cypher Queries | ✅ Full | All standard Cypher |
-| Bolt Protocol | ✅ Full | v4.4 compatible |
-| HTTP API | ✅ Full | Neo4j REST API |
-| Transactions | ✅ Full | ACID compliant |
-| Indexes | ✅ Full | B-tree and vector |
-| Constraints | ✅ Full | Unique, exists |
+| Bolt Protocol  | ✅ Full | v4.4 compatible     |
+| HTTP API       | ✅ Full | Neo4j REST API      |
+| Transactions   | ✅ Full | ACID compliant      |
+| Indexes        | ✅ Full | B-tree and vector   |
+| Constraints    | ✅ Full | Unique, exists      |
 
 ### Driver Compatibility
 
@@ -133,19 +133,32 @@ All official Neo4j drivers work with NornicDB:
 ### From Neo4j to NornicDB
 
 1. **Export from Neo4j**:
+
    ```cypher
    CALL apoc.export.json.all("export.json", {})
    ```
 
 2. **Start NornicDB**:
+
    ```bash
    docker run -d -p 7474:7474 -p 7687:7687 nornicdb
    ```
 
 3. **Import to NornicDB**:
    ```bash
-   # Use same driver/queries - just change connection URL
+
    ```
+
+# Use the offline admin tool for bulk CSV imports
+
+nornicdb-admin database import full mydb \
+ --nodes=Person=people.csv \
+ --relationships=KNOWS=relationships.csv \
+ --data-dir=./data
+
+````
+
+See the [admin tool guide](../operations/admin-tool.md) for CSV header examples and recovery notes.
 
 ### From NornicDB to Neo4j
 
@@ -160,8 +173,8 @@ Same process in reverse - the formats are identical.
 ```bash
 # Trigger a snapshot via the authenticated admin HTTP endpoint
 curl -X POST http://localhost:7474/admin/backup \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
+-H "Authorization: Bearer $ADMIN_TOKEN"
+````
 
 For volume-level backups (raw `tar` of `/data`) see the [Backup & Restore operations guide](../operations/backup-restore.md).
 
@@ -192,6 +205,7 @@ curl -X POST http://localhost:7474/gdpr/delete \
 - **[Getting Started](../getting-started/README.md)** - Installation guide
 - **[Cypher Queries](cypher-queries.md)** - Query language reference
 - **[API Reference](../api-reference/README.md)** - Complete API docs
+- **[nornicdb-admin](../operations/admin-tool.md)** - Offline bulk import and operator workflows
 
 ---
 

--- a/pkg/adminimport/importer.go
+++ b/pkg/adminimport/importer.go
@@ -230,6 +230,7 @@ func importNodeSource(ctx context.Context, engine storage.Engine, opts Options, 
 		return err
 	}
 	idCols := filterColumns(cols, kindID)
+	namedEmbeddingDims := make(map[string]int)
 	nodes := make([]*storage.Node, 0, opts.ChunkSize)
 	for {
 		select {
@@ -249,7 +250,7 @@ func importNodeSource(ctx context.Context, engine storage.Engine, opts Options, 
 			anonymousSeq = state.anonymousNodeSeq
 			state.anonymousNodeSeq++
 		}
-		node, lookupKey, err := nodeFromRecord(record, cols, idCols, spec.prefix, opts, rowNum, anonymousSeq)
+		node, lookupKey, err := nodeFromRecord(record, filePath, cols, idCols, spec.prefix, opts, rowNum, anonymousSeq, namedEmbeddingDims)
 		if err != nil {
 			return err
 		}
@@ -322,7 +323,7 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 		}
 		edgeSeq := state.edgeSeq
 		state.edgeSeq++
-		edge, skip, err := edgeFromRecord(record, cols, startCols, endCols, typeCols, spec.prefix, opts, state, rowNum, edgeSeq, report)
+		edge, skip, err := edgeFromRecord(record, filePath, cols, startCols, endCols, typeCols, spec.prefix, opts, state, rowNum, edgeSeq, report)
 		if err != nil {
 			return err
 		}
@@ -347,7 +348,7 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 	return nil
 }
 
-func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabels []string, opts Options, line int, anonymousSeq int) (*storage.Node, string, error) {
+func nodeFromRecord(record []string, filePath string, cols []columnSpec, idCols []int, prefixLabels []string, opts Options, line int, anonymousSeq int, namedEmbeddingDims map[string]int) (*storage.Node, string, error) {
 	props := make(map[string]any)
 	named := make(map[string][]float32)
 	labels := append([]string{}, prefixLabels...)
@@ -361,11 +362,11 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 		switch col.Kind {
 		case kindID:
 			if value == "" {
-				return nil, "", csvErr("", line, i+1, fmt.Errorf("missing ID value"))
+				return nil, "", csvErr(filePath, line, i+1, fmt.Errorf("missing ID value"))
 			}
 			canonical, err := canonicalID(value, opts.IDType)
 			if err != nil {
-				return nil, "", csvErr("", line, i+1, err)
+				return nil, "", csvErr(filePath, line, i+1, err)
 			}
 			idValues = append(idValues, canonical)
 			idSpaces = append(idSpaces, col.IDSpace)
@@ -387,23 +388,30 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 			}
 			parsed, err := parsePropertyValue(value, col, opts)
 			if err != nil {
-				return nil, "", csvErr("", line, i+1, err)
+				return nil, "", csvErr(filePath, line, i+1, err)
 			}
 			props[col.Name] = parsed
 		case kindNamedEmbedding:
 			if value == "" {
 				continue
 			}
-			vec, err := parseVector(value, opts.VectorDelimiter, col.VectorDims)
+			dims := col.VectorDims
+			if dims == 0 {
+				dims = namedEmbeddingDims[col.EmbedKey]
+			}
+			vec, err := parseVector(value, opts.VectorDelimiter, dims)
 			if err != nil {
-				return nil, "", csvErr("", line, i+1, err)
+				return nil, "", csvErr(filePath, line, i+1, err)
+			}
+			if dims == 0 {
+				namedEmbeddingDims[col.EmbedKey] = len(vec)
 			}
 			named[col.EmbedKey] = vec
 		case kindIgnore:
 		}
 	}
 	if len(record) > len(cols) && !opts.IgnoreExtraColumns {
-		return nil, "", csvErr("", line, len(cols)+1, fmt.Errorf("extra column without header"))
+		return nil, "", csvErr(filePath, line, len(cols)+1, fmt.Errorf("extra column without header"))
 	}
 	var id storage.NodeID
 	var lookupKey string
@@ -420,15 +428,15 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 	return node, lookupKey, nil
 }
 
-func edgeFromRecord(record []string, cols []columnSpec, startCols, endCols, typeCols []int, prefixType []string, opts Options, state *importState, line int, edgeSeq int, report *Report) (*storage.Edge, bool, error) {
+func edgeFromRecord(record []string, filePath string, cols []columnSpec, startCols, endCols, typeCols []int, prefixType []string, opts Options, state *importState, line int, edgeSeq int, report *Report) (*storage.Edge, bool, error) {
 	props := make(map[string]any)
-	startValues, startSpaces, err := idValuesFromRecord(record, cols, startCols, opts)
+	startValues, startSpaces, startCol, err := idValuesFromRecord(record, cols, startCols, opts)
 	if err != nil {
-		return nil, false, csvErr("", line, 0, err)
+		return nil, false, csvErr(filePath, line, startCol+1, err)
 	}
-	endValues, endSpaces, err := idValuesFromRecord(record, cols, endCols, opts)
+	endValues, endSpaces, endCol, err := idValuesFromRecord(record, cols, endCols, opts)
 	if err != nil {
-		return nil, false, csvErr("", line, 0, err)
+		return nil, false, csvErr(filePath, line, endCol+1, err)
 	}
 	startID, ok := state.idMap[importIDKey(startSpaces, startValues)]
 	if !ok {
@@ -467,7 +475,7 @@ func edgeFromRecord(record []string, cols []columnSpec, startCols, endCols, type
 		}
 		parsed, err := parsePropertyValue(value, col, opts)
 		if err != nil {
-			return nil, false, csvErr("", line, i+1, err)
+			return nil, false, csvErr(filePath, line, i+1, err)
 		}
 		props[col.Name] = parsed
 	}
@@ -482,21 +490,24 @@ func badRelationship(opts Options, report *Report, line int, msg string) error {
 	return &Error{ExitCode: ExitBadRelationship, Message: fmt.Sprintf("bad relationship at row %d: %s", line, msg)}
 }
 
-func idValuesFromRecord(record []string, cols []columnSpec, indexes []int, opts Options) ([]string, []string, error) {
+func idValuesFromRecord(record []string, cols []columnSpec, indexes []int, opts Options) ([]string, []string, int, error) {
 	values := make([]string, 0, len(indexes))
 	spaces := make([]string, 0, len(indexes))
 	for _, idx := range indexes {
 		if idx >= len(record) {
-			return nil, nil, fmt.Errorf("missing ID column")
+			return nil, nil, idx, fmt.Errorf("missing ID column")
+		}
+		if record[idx] == "" {
+			return nil, nil, idx, fmt.Errorf("missing ID value")
 		}
 		value, err := canonicalID(record[idx], opts.IDType)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, idx, err
 		}
 		values = append(values, value)
 		spaces = append(spaces, cols[idx].IDSpace)
 	}
-	return values, spaces, nil
+	return values, spaces, 0, nil
 }
 
 func parseHeader(header []string, node bool) ([]columnSpec, error) {
@@ -534,7 +545,15 @@ func parseColumnSpec(raw string, node bool) (columnSpec, error) {
 		case "TYPE":
 			return columnSpec{Kind: kindType}, nil
 		case "EMBEDDING", "NAMED_EMBEDDING":
-			return columnSpec{Kind: kindNamedEmbedding, EmbedKey: defaultString(arg, "default"), Options: opts}, nil
+			dims := 0
+			if d, ok := opts["dimensions"]; ok {
+				parsed, err := strconv.Atoi(d)
+				if err != nil {
+					return columnSpec{}, unsupported("invalid vector dimensions in header: " + raw)
+				}
+				dims = parsed
+			}
+			return columnSpec{Kind: kindNamedEmbedding, EmbedKey: defaultString(arg, "default"), Options: opts, VectorDims: dims}, nil
 		default:
 			return columnSpec{}, unsupported("unsupported header token: " + raw)
 		}

--- a/pkg/adminimport/importer.go
+++ b/pkg/adminimport/importer.go
@@ -30,8 +30,6 @@ const (
 	ExitUnsupported         = 6
 )
 
-var fixedImportTime = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-
 type Options struct {
 	DatabaseName         string
 	NodeSources          []string
@@ -179,7 +177,9 @@ func (o Options) withDefaults() Options {
 }
 
 type importState struct {
-	idMap map[string]storage.NodeID
+	idMap            map[string]storage.NodeID
+	anonymousNodeSeq int
+	edgeSeq          int
 }
 
 type sourceSpec struct {
@@ -244,7 +244,12 @@ func importNodeSource(ctx context.Context, engine storage.Engine, opts Options, 
 		if err != nil {
 			return csvErr(filePath, rowNum, 0, err)
 		}
-		node, lookupKey, err := nodeFromRecord(record, cols, idCols, spec.prefix, opts, rowNum)
+		anonymousSeq := -1
+		if len(idCols) == 0 {
+			anonymousSeq = state.anonymousNodeSeq
+			state.anonymousNodeSeq++
+		}
+		node, lookupKey, err := nodeFromRecord(record, cols, idCols, spec.prefix, opts, rowNum, anonymousSeq)
 		if err != nil {
 			return err
 		}
@@ -315,7 +320,9 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 		if err != nil {
 			return csvErr(filePath, rowNum, 0, err)
 		}
-		edge, skip, err := edgeFromRecord(record, cols, startCols, endCols, typeCols, spec.prefix, opts, state, rowNum, report)
+		edgeSeq := state.edgeSeq
+		state.edgeSeq++
+		edge, skip, err := edgeFromRecord(record, cols, startCols, endCols, typeCols, spec.prefix, opts, state, rowNum, edgeSeq, report)
 		if err != nil {
 			return err
 		}
@@ -340,7 +347,7 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 	return nil
 }
 
-func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabels []string, opts Options, line int) (*storage.Node, string, error) {
+func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabels []string, opts Options, line int, anonymousSeq int) (*storage.Node, string, error) {
 	props := make(map[string]any)
 	named := make(map[string][]float32)
 	labels := append([]string{}, prefixLabels...)
@@ -351,11 +358,11 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 			continue
 		}
 		value := record[i]
-		if value == "" || (opts.IgnoreEmptyStrings && value == "") {
-			continue
-		}
 		switch col.Kind {
 		case kindID:
+			if value == "" {
+				return nil, "", csvErr("", line, i+1, fmt.Errorf("missing ID value"))
+			}
 			canonical, err := canonicalID(value, opts.IDType)
 			if err != nil {
 				return nil, "", csvErr("", line, i+1, err)
@@ -366,14 +373,27 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 				props[col.Name] = canonical
 			}
 		case kindLabel:
+			if value == "" {
+				continue
+			}
 			labels = append(labels, splitList(value, opts.ArrayDelimiter)...)
 		case kindProperty:
+			if value == "" {
+				if opts.IgnoreEmptyStrings || !preserveEmptyStringProperty(col) {
+					continue
+				}
+				props[col.Name] = ""
+				continue
+			}
 			parsed, err := parsePropertyValue(value, col, opts)
 			if err != nil {
 				return nil, "", csvErr("", line, i+1, err)
 			}
 			props[col.Name] = parsed
 		case kindNamedEmbedding:
+			if value == "" {
+				continue
+			}
 			vec, err := parseVector(value, opts.VectorDelimiter, col.VectorDims)
 			if err != nil {
 				return nil, "", csvErr("", line, i+1, err)
@@ -391,7 +411,7 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 		id = storage.NodeID(strings.Join(idValues, "|"))
 		lookupKey = importIDKey(idSpaces, idValues)
 	} else {
-		id = storage.NodeID(fmt.Sprintf("_anon_%d", line-1))
+		id = storage.NodeID(fmt.Sprintf("_anon_%d", anonymousSeq))
 	}
 	node := &storage.Node{ID: id, Labels: uniqueNonEmpty(labels), Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now}
 	if len(named) > 0 {
@@ -400,7 +420,7 @@ func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabe
 	return node, lookupKey, nil
 }
 
-func edgeFromRecord(record []string, cols []columnSpec, startCols, endCols, typeCols []int, prefixType []string, opts Options, state *importState, line int, report *Report) (*storage.Edge, bool, error) {
+func edgeFromRecord(record []string, cols []columnSpec, startCols, endCols, typeCols []int, prefixType []string, opts Options, state *importState, line int, edgeSeq int, report *Report) (*storage.Edge, bool, error) {
 	props := make(map[string]any)
 	startValues, startSpaces, err := idValuesFromRecord(record, cols, startCols, opts)
 	if err != nil {
@@ -431,19 +451,27 @@ func edgeFromRecord(record []string, cols []columnSpec, startCols, endCols, type
 		return nil, false, unsupported("relationship source requires :TYPE column or --relationships=TYPE= prefix")
 	}
 	for i, col := range cols {
-		if i >= len(record) || record[i] == "" {
+		if i >= len(record) {
 			continue
 		}
 		if col.Kind != kindProperty {
 			continue
 		}
-		parsed, err := parsePropertyValue(record[i], col, opts)
+		value := record[i]
+		if value == "" {
+			if opts.IgnoreEmptyStrings || !preserveEmptyStringProperty(col) {
+				continue
+			}
+			props[col.Name] = ""
+			continue
+		}
+		parsed, err := parsePropertyValue(value, col, opts)
 		if err != nil {
 			return nil, false, csvErr("", line, i+1, err)
 		}
 		props[col.Name] = parsed
 	}
-	return &storage.Edge{ID: storage.EdgeID(fmt.Sprintf("rel_%d", line-1)), StartNode: startID, EndNode: endID, Type: edgeType, Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now, Confidence: 1.0}, false, nil
+	return &storage.Edge{ID: storage.EdgeID(fmt.Sprintf("rel_%d", edgeSeq)), StartNode: startID, EndNode: endID, Type: edgeType, Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now, Confidence: 1.0}, false, nil
 }
 
 func badRelationship(opts Options, report *Report, line int, msg string) error {
@@ -602,7 +630,11 @@ func parseScalar(value, typ string, opts Options) (any, error) {
 		}
 		return v, nil
 	case "boolean":
-		return value == "true", nil
+		v, err := strconv.ParseBool(strings.TrimSpace(value))
+		if err != nil {
+			return nil, err
+		}
+		return v, nil
 	default:
 		return nil, unsupported("unsupported property type: " + typ)
 	}
@@ -658,6 +690,11 @@ type csvSourceReader struct {
 func openCSVSource(files []string, opts Options) (*csvSourceReader, error) {
 	if opts.Quote != '"' {
 		return nil, unsupported("custom --quote is not supported by the Go CSV reader yet")
+	}
+	for _, path := range files {
+		if _, err := os.Stat(path); err != nil {
+			return nil, &Error{ExitCode: ExitCSV, Message: "failed to open CSV file", Err: err}
+		}
 	}
 	return &csvSourceReader{files: files, opts: opts}, nil
 }
@@ -954,6 +991,18 @@ func splitList(value string, delim rune) []string {
 		}
 	}
 	return out
+}
+
+func preserveEmptyStringProperty(col columnSpec) bool {
+	if strings.HasSuffix(col.Type, "[]") || strings.EqualFold(col.Type, "vector") {
+		return false
+	}
+	switch strings.ToLower(defaultString(col.Type, "string")) {
+	case "string", "char":
+		return true
+	default:
+		return false
+	}
 }
 
 func uniqueNonEmpty(values []string) []string {

--- a/pkg/adminimport/importer.go
+++ b/pkg/adminimport/importer.go
@@ -1,0 +1,929 @@
+package adminimport
+
+import (
+	"archive/zip"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/orneryd/nornicdb/pkg/cypher"
+	"github.com/orneryd/nornicdb/pkg/search"
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+const (
+	ExitOK                  = 0
+	ExitCSV                 = 2
+	ExitBadRelationship     = 3
+	ExitDuplicateID         = 4
+	ExitConstraintViolation = 5
+	ExitUnsupported         = 6
+)
+
+var fixedImportTime = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+type Options struct {
+	DatabaseName         string
+	NodeSources          []string
+	RelSources           []string
+	DataDir              string
+	Delimiter            rune
+	ArrayDelimiter       rune
+	VectorDelimiter      rune
+	Quote                rune
+	IDType               string
+	NormalizeTypes       bool
+	IgnoreExtraColumns   bool
+	IgnoreEmptyStrings   bool
+	BadTolerance         int
+	SkipBadRelationships bool
+	SkipDuplicateNodes   bool
+	ReportFile           string
+	SchemaFile           string
+	BuildIndexes         bool
+	ChunkSize            int
+	Now                  time.Time
+	Verbose              bool
+}
+
+type Report struct {
+	DatabaseName          string        `json:"databaseName"`
+	NodesImported         int64         `json:"nodesImported"`
+	RelationshipsImported int64         `json:"relationshipsImported"`
+	BadRelationships      int64         `json:"badRelationships"`
+	DuplicateNodesSkipped int64         `json:"duplicateNodesSkipped"`
+	IndexesBuilt          bool          `json:"indexesBuilt"`
+	StartedAt             time.Time     `json:"startedAt"`
+	CompletedAt           time.Time     `json:"completedAt"`
+	Duration              time.Duration `json:"durationNanos"`
+	Status                string        `json:"status"`
+	Errors                []string      `json:"errors,omitempty"`
+}
+
+type Error struct {
+	ExitCode int
+	Message  string
+	Err      error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err == nil {
+		return e.Message
+	}
+	return e.Message + ": " + e.Err.Error()
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+func ImportFull(ctx context.Context, engine storage.Engine, opts Options) (Report, error) {
+	opts = opts.withDefaults()
+	report := Report{DatabaseName: opts.DatabaseName, StartedAt: time.Now(), Status: "failed"}
+	if opts.DatabaseName == "" {
+		return report, unsupported("database name is required")
+	}
+	if len(opts.NodeSources) == 0 {
+		return report, unsupported("at least one --nodes source is required")
+	}
+	if engine == nil {
+		return report, unsupported("storage engine is required")
+	}
+	if opts.IDType == "actual" {
+		return report, unsupported("--id-type=actual is not supported")
+	}
+
+	target := storage.NewNamespacedEngine(engine, opts.DatabaseName)
+	if err := ensureEmpty(target); err != nil {
+		return report, err
+	}
+
+	state := &importState{idMap: make(map[string]storage.NodeID)}
+	for _, sourceSpec := range opts.NodeSources {
+		if err := importNodeSource(ctx, target, opts, sourceSpec, state, &report); err != nil {
+			report.Errors = append(report.Errors, err.Error())
+			_ = writeReport(opts.ReportFile, report)
+			return report, err
+		}
+	}
+	for _, sourceSpec := range opts.RelSources {
+		if err := importRelationshipSource(ctx, target, opts, sourceSpec, state, &report); err != nil {
+			report.Errors = append(report.Errors, err.Error())
+			_ = writeReport(opts.ReportFile, report)
+			return report, err
+		}
+	}
+	if opts.SchemaFile != "" {
+		if err := applySchema(ctx, target, opts.SchemaFile); err != nil {
+			report.Errors = append(report.Errors, err.Error())
+			_ = writeReport(opts.ReportFile, report)
+			return report, &Error{ExitCode: ExitConstraintViolation, Message: "schema application failed", Err: err}
+		}
+	}
+	if opts.BuildIndexes {
+		svc := search.NewService(target)
+		if opts.DataDir != "" {
+			base := filepath.Join(opts.DataDir, "search", opts.DatabaseName)
+			svc.SetPersistenceEnabled(true)
+			svc.SetFulltextIndexPath(filepath.Join(base, "bm25"))
+			svc.SetVectorIndexPath(filepath.Join(base, "vectors"))
+			svc.SetHNSWIndexPath(filepath.Join(base, "hnsw"))
+		}
+		if err := svc.BuildIndexes(ctx); err != nil {
+			report.Errors = append(report.Errors, err.Error())
+			_ = writeReport(opts.ReportFile, report)
+			return report, err
+		}
+		report.IndexesBuilt = true
+	}
+	report.Status = "success"
+	report.CompletedAt = time.Now()
+	report.Duration = report.CompletedAt.Sub(report.StartedAt)
+	return report, writeReport(opts.ReportFile, report)
+}
+
+func (o Options) withDefaults() Options {
+	if o.Delimiter == 0 {
+		o.Delimiter = ','
+	}
+	if o.ArrayDelimiter == 0 {
+		o.ArrayDelimiter = ';'
+	}
+	if o.VectorDelimiter == 0 {
+		o.VectorDelimiter = ';'
+	}
+	if o.Quote == 0 {
+		o.Quote = '"'
+	}
+	if o.IDType == "" {
+		o.IDType = "string"
+	}
+	if o.ChunkSize <= 0 {
+		o.ChunkSize = 1000
+	}
+	if o.Now.IsZero() {
+		o.Now = time.Now()
+	}
+	return o
+}
+
+type importState struct {
+	idMap map[string]storage.NodeID
+}
+
+type sourceSpec struct {
+	prefix []string
+	files  []string
+}
+
+type headerKind int
+
+const (
+	kindProperty headerKind = iota
+	kindID
+	kindLabel
+	kindIgnore
+	kindStartID
+	kindEndID
+	kindType
+	kindNamedEmbedding
+)
+
+type columnSpec struct {
+	Name       string
+	Kind       headerKind
+	Type       string
+	IDSpace    string
+	VectorDims int
+	EmbedKey   string
+	Options    map[string]string
+}
+
+func importNodeSource(ctx context.Context, engine storage.Engine, opts Options, raw string, state *importState, report *Report) error {
+	spec, err := parseSourceSpec(raw, true)
+	if err != nil {
+		return err
+	}
+	source, err := openCSVSource(spec.files, opts)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	header, err := source.ReadHeader()
+	if err != nil {
+		return csvErr(spec.files[0], 1, 0, err)
+	}
+	cols, err := parseHeader(header, true)
+	if err != nil {
+		return err
+	}
+	idCols := filterColumns(cols, kindID)
+	nodes := make([]*storage.Node, 0, opts.ChunkSize)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		record, filePath, rowNum, err := source.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return csvErr(filePath, rowNum, 0, err)
+		}
+		node, lookupKey, err := nodeFromRecord(record, cols, idCols, spec.prefix, opts, rowNum)
+		if err != nil {
+			return err
+		}
+		if lookupKey != "" {
+			if _, exists := state.idMap[lookupKey]; exists {
+				if opts.SkipDuplicateNodes {
+					report.DuplicateNodesSkipped++
+					continue
+				}
+				return &Error{ExitCode: ExitDuplicateID, Message: fmt.Sprintf("duplicate node ID at row %d", rowNum)}
+			}
+			state.idMap[lookupKey] = node.ID
+		}
+		nodes = append(nodes, node)
+		if len(nodes) >= opts.ChunkSize {
+			if err := engine.BulkCreateNodes(nodes); err != nil {
+				return err
+			}
+			report.NodesImported += int64(len(nodes))
+			nodes = nodes[:0]
+		}
+	}
+	if len(nodes) > 0 {
+		if err := engine.BulkCreateNodes(nodes); err != nil {
+			return err
+		}
+		report.NodesImported += int64(len(nodes))
+	}
+	return nil
+}
+
+func importRelationshipSource(ctx context.Context, engine storage.Engine, opts Options, raw string, state *importState, report *Report) error {
+	spec, err := parseSourceSpec(raw, false)
+	if err != nil {
+		return err
+	}
+	source, err := openCSVSource(spec.files, opts)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	header, err := source.ReadHeader()
+	if err != nil {
+		return csvErr(spec.files[0], 1, 0, err)
+	}
+	cols, err := parseHeader(header, false)
+	if err != nil {
+		return err
+	}
+	startCols := filterColumns(cols, kindStartID)
+	endCols := filterColumns(cols, kindEndID)
+	typeCols := filterColumns(cols, kindType)
+	if len(startCols) == 0 || len(endCols) == 0 {
+		return unsupported("relationship source requires :START_ID and :END_ID columns")
+	}
+	edges := make([]*storage.Edge, 0, opts.ChunkSize)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		record, filePath, rowNum, err := source.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return csvErr(filePath, rowNum, 0, err)
+		}
+		edge, skip, err := edgeFromRecord(record, cols, startCols, endCols, typeCols, spec.prefix, opts, state, rowNum, report)
+		if err != nil {
+			return err
+		}
+		if skip {
+			continue
+		}
+		edges = append(edges, edge)
+		if len(edges) >= opts.ChunkSize {
+			if err := engine.BulkCreateEdges(edges); err != nil {
+				return err
+			}
+			report.RelationshipsImported += int64(len(edges))
+			edges = edges[:0]
+		}
+	}
+	if len(edges) > 0 {
+		if err := engine.BulkCreateEdges(edges); err != nil {
+			return err
+		}
+		report.RelationshipsImported += int64(len(edges))
+	}
+	return nil
+}
+
+func nodeFromRecord(record []string, cols []columnSpec, idCols []int, prefixLabels []string, opts Options, line int) (*storage.Node, string, error) {
+	props := make(map[string]any)
+	named := make(map[string][]float32)
+	labels := append([]string{}, prefixLabels...)
+	var idValues []string
+	var idSpaces []string
+	for i, col := range cols {
+		if i >= len(record) {
+			continue
+		}
+		value := record[i]
+		if value == "" || (opts.IgnoreEmptyStrings && value == "") {
+			continue
+		}
+		switch col.Kind {
+		case kindID:
+			canonical, err := canonicalID(value, opts.IDType)
+			if err != nil {
+				return nil, "", csvErr("", line, i+1, err)
+			}
+			idValues = append(idValues, canonical)
+			idSpaces = append(idSpaces, col.IDSpace)
+			if col.Name != "" {
+				props[col.Name] = canonical
+			}
+		case kindLabel:
+			labels = append(labels, splitList(value, opts.ArrayDelimiter)...)
+		case kindProperty:
+			parsed, err := parsePropertyValue(value, col, opts)
+			if err != nil {
+				return nil, "", csvErr("", line, i+1, err)
+			}
+			props[col.Name] = parsed
+		case kindNamedEmbedding:
+			vec, err := parseVector(value, opts.VectorDelimiter, col.VectorDims)
+			if err != nil {
+				return nil, "", csvErr("", line, i+1, err)
+			}
+			named[col.EmbedKey] = vec
+		case kindIgnore:
+		}
+	}
+	if len(record) > len(cols) && !opts.IgnoreExtraColumns {
+		return nil, "", csvErr("", line, len(cols)+1, fmt.Errorf("extra column without header"))
+	}
+	var id storage.NodeID
+	var lookupKey string
+	if len(idCols) > 0 {
+		id = storage.NodeID(strings.Join(idValues, "|"))
+		lookupKey = importIDKey(idSpaces, idValues)
+	} else {
+		id = storage.NodeID(fmt.Sprintf("_anon_%d", line-1))
+	}
+	node := &storage.Node{ID: id, Labels: uniqueNonEmpty(labels), Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now}
+	if len(named) > 0 {
+		node.NamedEmbeddings = named
+	}
+	return node, lookupKey, nil
+}
+
+func edgeFromRecord(record []string, cols []columnSpec, startCols, endCols, typeCols []int, prefixType []string, opts Options, state *importState, line int, report *Report) (*storage.Edge, bool, error) {
+	props := make(map[string]any)
+	startValues, startSpaces, err := idValuesFromRecord(record, cols, startCols, opts)
+	if err != nil {
+		return nil, false, csvErr("", line, 0, err)
+	}
+	endValues, endSpaces, err := idValuesFromRecord(record, cols, endCols, opts)
+	if err != nil {
+		return nil, false, csvErr("", line, 0, err)
+	}
+	startID, ok := state.idMap[importIDKey(startSpaces, startValues)]
+	if !ok {
+		return nil, opts.SkipBadRelationships, badRelationship(opts, report, line, "missing start node")
+	}
+	endID, ok := state.idMap[importIDKey(endSpaces, endValues)]
+	if !ok {
+		return nil, opts.SkipBadRelationships, badRelationship(opts, report, line, "missing end node")
+	}
+	edgeType := ""
+	if len(prefixType) > 0 {
+		edgeType = prefixType[0]
+	}
+	for _, idx := range typeCols {
+		if idx < len(record) && record[idx] != "" {
+			edgeType = record[idx]
+		}
+	}
+	if edgeType == "" {
+		return nil, false, unsupported("relationship source requires :TYPE column or --relationships=TYPE= prefix")
+	}
+	for i, col := range cols {
+		if i >= len(record) || record[i] == "" {
+			continue
+		}
+		if col.Kind != kindProperty {
+			continue
+		}
+		parsed, err := parsePropertyValue(record[i], col, opts)
+		if err != nil {
+			return nil, false, csvErr("", line, i+1, err)
+		}
+		props[col.Name] = parsed
+	}
+	return &storage.Edge{ID: storage.EdgeID(fmt.Sprintf("rel_%d", line-1)), StartNode: startID, EndNode: endID, Type: edgeType, Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now, Confidence: 1.0}, false, nil
+}
+
+func badRelationship(opts Options, report *Report, line int, msg string) error {
+	report.BadRelationships++
+	if opts.SkipBadRelationships {
+		return nil
+	}
+	return &Error{ExitCode: ExitBadRelationship, Message: fmt.Sprintf("bad relationship at row %d: %s", line, msg)}
+}
+
+func idValuesFromRecord(record []string, cols []columnSpec, indexes []int, opts Options) ([]string, []string, error) {
+	values := make([]string, 0, len(indexes))
+	spaces := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx >= len(record) {
+			return nil, nil, fmt.Errorf("missing ID column")
+		}
+		value, err := canonicalID(record[idx], opts.IDType)
+		if err != nil {
+			return nil, nil, err
+		}
+		values = append(values, value)
+		spaces = append(spaces, cols[idx].IDSpace)
+	}
+	return values, spaces, nil
+}
+
+func parseHeader(header []string, node bool) ([]columnSpec, error) {
+	cols := make([]columnSpec, len(header))
+	for i, raw := range header {
+		col, err := parseColumnSpec(strings.TrimSpace(raw), node)
+		if err != nil {
+			return nil, err
+		}
+		cols[i] = col
+	}
+	return cols, nil
+}
+
+func parseColumnSpec(raw string, node bool) (columnSpec, error) {
+	if raw == "" {
+		return columnSpec{Kind: kindIgnore}, nil
+	}
+	if strings.HasPrefix(raw, ":") {
+		keyword, arg, opts := parseKeyword(raw[1:])
+		switch strings.ToUpper(keyword) {
+		case "ID":
+			if !node {
+				return columnSpec{}, unsupported(":ID is only valid in node headers")
+			}
+			return columnSpec{Kind: kindID, IDSpace: arg}, nil
+		case "LABEL":
+			return columnSpec{Kind: kindLabel}, nil
+		case "IGNORE":
+			return columnSpec{Kind: kindIgnore}, nil
+		case "START_ID":
+			return columnSpec{Kind: kindStartID, IDSpace: arg}, nil
+		case "END_ID":
+			return columnSpec{Kind: kindEndID, IDSpace: arg}, nil
+		case "TYPE":
+			return columnSpec{Kind: kindType}, nil
+		case "EMBEDDING", "NAMED_EMBEDDING":
+			return columnSpec{Kind: kindNamedEmbedding, EmbedKey: defaultString(arg, "default"), Options: opts}, nil
+		default:
+			return columnSpec{}, unsupported("unsupported header token: " + raw)
+		}
+	}
+	name, typ := splitNameType(raw)
+	keyword, arg, opts := parseKeyword(typ)
+	if strings.EqualFold(keyword, "ID") {
+		return columnSpec{Name: name, Kind: kindID, IDSpace: arg}, nil
+	}
+	dims := 0
+	if strings.EqualFold(keyword, "vector") {
+		if d, ok := opts["dimensions"]; ok {
+			parsed, err := strconv.Atoi(d)
+			if err != nil {
+				return columnSpec{}, unsupported("invalid vector dimensions in header: " + raw)
+			}
+			dims = parsed
+		}
+	}
+	return columnSpec{Name: name, Kind: kindProperty, Type: strings.ToLower(keyword), IDSpace: arg, Options: opts, VectorDims: dims}, nil
+}
+
+func splitNameType(raw string) (string, string) {
+	idx := strings.IndexRune(raw, ':')
+	if idx < 0 {
+		return raw, "string"
+	}
+	return raw[:idx], raw[idx+1:]
+}
+
+func parseKeyword(raw string) (string, string, map[string]string) {
+	options := make(map[string]string)
+	base := raw
+	if brace := strings.IndexRune(base, '{'); brace >= 0 {
+		end := strings.LastIndex(base, "}")
+		if end > brace {
+			for _, part := range strings.Split(base[brace+1:end], ",") {
+				key, val, ok := strings.Cut(strings.TrimSpace(part), ":")
+				if ok {
+					options[strings.TrimSpace(key)] = strings.TrimSpace(val)
+				}
+			}
+			base = base[:brace]
+		}
+	}
+	arg := ""
+	if open := strings.IndexRune(base, '('); open >= 0 {
+		if close := strings.LastIndex(base, ")"); close > open {
+			arg = base[open+1 : close]
+			base = base[:open]
+		}
+	}
+	return base, arg, options
+}
+
+func parsePropertyValue(value string, col columnSpec, opts Options) (any, error) {
+	if strings.HasSuffix(col.Type, "[]") {
+		base := strings.TrimSuffix(col.Type, "[]")
+		parts := splitList(value, opts.ArrayDelimiter)
+		out := make([]any, 0, len(parts))
+		for _, part := range parts {
+			parsed, err := parseScalar(part, base, opts)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, parsed)
+		}
+		return out, nil
+	}
+	if col.Type == "vector" {
+		return parseVector(value, opts.VectorDelimiter, col.VectorDims)
+	}
+	return parseScalar(value, col.Type, opts)
+}
+
+func parseScalar(value, typ string, opts Options) (any, error) {
+	switch strings.ToLower(defaultString(typ, "string")) {
+	case "string", "char", "point", "date", "localtime", "time", "localdatetime", "datetime", "duration":
+		return value, nil
+	case "byte", "short", "int", "long":
+		v, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		if opts.NormalizeTypes {
+			return v, nil
+		}
+		return v, nil
+	case "float", "double":
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return nil, err
+		}
+		return v, nil
+	case "boolean":
+		return value == "true", nil
+	default:
+		return nil, unsupported("unsupported property type: " + typ)
+	}
+}
+
+func parseVector(value string, delim rune, dims int) ([]float32, error) {
+	parts := splitList(value, delim)
+	if dims > 0 && len(parts) != dims {
+		return nil, fmt.Errorf("vector dimensions mismatch: expected %d, got %d", dims, len(parts))
+	}
+	out := make([]float32, 0, len(parts))
+	for _, part := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(part), 32)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, float32(v))
+	}
+	return out, nil
+}
+
+func parseSourceSpec(raw string, node bool) (sourceSpec, error) {
+	var prefix []string
+	filesPart := raw
+	if before, after, ok := strings.Cut(raw, "="); ok {
+		prefix = strings.Split(before, ":")
+		filesPart = after
+	}
+	files := splitList(filesPart, ',')
+	if len(files) == 0 || files[0] == "" {
+		return sourceSpec{}, unsupported("empty import source")
+	}
+	for i := range files {
+		files[i] = strings.TrimSpace(files[i])
+	}
+	if !node && len(prefix) > 1 {
+		return sourceSpec{}, unsupported("relationship source accepts at most one type prefix")
+	}
+	return sourceSpec{prefix: uniqueNonEmpty(prefix), files: files}, nil
+}
+
+type csvSourceReader struct {
+	files       []string
+	opts        Options
+	currentFile int
+	reader      *csv.Reader
+	closer      io.Closer
+	rowInFile   int
+	headerRead  bool
+	currentPath string
+}
+
+func openCSVSource(files []string, opts Options) (*csvSourceReader, error) {
+	if opts.Quote != '"' {
+		return nil, unsupported("custom --quote is not supported by the Go CSV reader yet")
+	}
+	return &csvSourceReader{files: files, opts: opts}, nil
+}
+
+func (s *csvSourceReader) Close() error {
+	if s.closer != nil {
+		return s.closer.Close()
+	}
+	return nil
+}
+
+func (s *csvSourceReader) ReadHeader() ([]string, error) {
+	if s.headerRead {
+		return nil, io.EOF
+	}
+	if err := s.openCurrent(); err != nil {
+		return nil, err
+	}
+	header, err := s.reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	s.headerRead = true
+	s.rowInFile = 1
+	return header, nil
+}
+
+func (s *csvSourceReader) Read() ([]string, string, int, error) {
+	if !s.headerRead {
+		return nil, s.currentPath, 0, io.EOF
+	}
+	for {
+		if err := s.openCurrent(); err != nil {
+			return nil, s.currentPath, s.rowInFile + 1, err
+		}
+		record, err := s.reader.Read()
+		if errors.Is(err, io.EOF) {
+			if err := s.advanceFile(); err != nil {
+				return nil, s.currentPath, s.rowInFile + 1, err
+			}
+			continue
+		}
+		if err != nil {
+			return nil, s.currentPath, s.rowInFile + 1, err
+		}
+		s.rowInFile++
+		return record, s.currentPath, s.rowInFile, nil
+	}
+}
+
+func (s *csvSourceReader) openCurrent() error {
+	if s.reader != nil {
+		return nil
+	}
+	if s.currentFile >= len(s.files) {
+		return io.EOF
+	}
+	path := s.files[s.currentFile]
+	reader, closer, err := openOne(path)
+	if err != nil {
+		return err
+	}
+	r := csv.NewReader(reader)
+	r.Comma = s.opts.Delimiter
+	r.LazyQuotes = false
+	r.FieldsPerRecord = -1
+	s.reader = r
+	s.closer = closer
+	s.currentPath = path
+	s.rowInFile = 0
+	return nil
+}
+
+func (s *csvSourceReader) advanceFile() error {
+	if s.closer != nil {
+		_ = s.closer.Close()
+		s.closer = nil
+	}
+	s.reader = nil
+	s.currentFile++
+	if s.currentFile >= len(s.files) {
+		return io.EOF
+	}
+	s.rowInFile = 0
+	return nil
+}
+
+func openOne(path string) (io.Reader, io.Closer, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, &Error{ExitCode: ExitCSV, Message: "failed to open CSV file", Err: err}
+	}
+	if strings.HasSuffix(path, ".gz") {
+		gz, err := gzip.NewReader(f)
+		if err != nil {
+			_ = f.Close()
+			return nil, nil, &Error{ExitCode: ExitCSV, Message: "failed to open gzip CSV file", Err: err}
+		}
+		return gz, closers{gz, f}, nil
+	}
+	if strings.HasSuffix(path, ".zip") {
+		zr, err := zip.OpenReader(path)
+		if err != nil {
+			_ = f.Close()
+			return nil, nil, &Error{ExitCode: ExitCSV, Message: "failed to open zip CSV file", Err: err}
+		}
+		_ = f.Close()
+		if len(zr.File) != 1 {
+			_ = zr.Close()
+			return nil, nil, unsupported("zip CSV sources must contain exactly one file")
+		}
+		rc, err := zr.File[0].Open()
+		if err != nil {
+			_ = zr.Close()
+			return nil, nil, &Error{ExitCode: ExitCSV, Message: "failed to open zipped CSV member", Err: err}
+		}
+		return rc, closers{rc, zr}, nil
+	}
+	return f, f, nil
+}
+
+type closers []io.Closer
+
+func (c closers) Close() error {
+	var firstErr error
+	for _, closer := range c {
+		if err := closer.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func applySchema(ctx context.Context, engine storage.Engine, path string) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	exec := cypher.NewStorageExecutor(engine)
+	for _, stmt := range splitCypherStatements(string(contents)) {
+		if strings.TrimSpace(stmt) == "" {
+			continue
+		}
+		if _, err := exec.Execute(ctx, stmt, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func splitCypherStatements(s string) []string {
+	var out []string
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	var b strings.Builder
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	for _, stmt := range strings.Split(b.String(), ";") {
+		out = append(out, strings.TrimSpace(stmt))
+	}
+	return out
+}
+
+func ensureEmpty(engine storage.Engine) error {
+	nodes, err := engine.NodeCount()
+	if err != nil {
+		return err
+	}
+	edges, err := engine.EdgeCount()
+	if err != nil {
+		return err
+	}
+	if nodes != 0 || edges != 0 {
+		return unsupported("database import full requires an empty target database")
+	}
+	return nil
+}
+
+func writeReport(path string, report Report) error {
+	if path == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+func filterColumns(cols []columnSpec, kind headerKind) []int {
+	var out []int
+	for i, col := range cols {
+		if col.Kind == kind {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func canonicalID(value, idType string) (string, error) {
+	if strings.EqualFold(idType, "integer") {
+		v, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "", err
+		}
+		return strconv.FormatInt(v, 10), nil
+	}
+	return value, nil
+}
+
+func importIDKey(spaces, values []string) string {
+	return strings.Join(spaces, "\x1f") + "\x1e" + strings.Join(values, "\x1f")
+}
+
+func splitList(value string, delim rune) []string {
+	parts := strings.Split(value, string(delim))
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func uniqueNonEmpty(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func defaultString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func csvErr(file string, row, col int, err error) error {
+	where := fmt.Sprintf("row %d", row)
+	if col > 0 {
+		where += fmt.Sprintf(", column %d", col)
+	}
+	if file != "" {
+		where = file + ": " + where
+	}
+	return &Error{ExitCode: ExitCSV, Message: "CSV parse error at " + where, Err: err}
+}
+
+func unsupported(message string) error {
+	return &Error{ExitCode: ExitUnsupported, Message: message}
+}

--- a/pkg/adminimport/importer.go
+++ b/pkg/adminimport/importer.go
@@ -101,13 +101,19 @@ func ImportFull(ctx context.Context, engine storage.Engine, opts Options) (Repor
 	if opts.IDType == "actual" {
 		return report, unsupported("--id-type=actual is not supported")
 	}
+	if err := preflightSources(opts); err != nil {
+		return report, err
+	}
 
 	target := storage.NewNamespacedEngine(engine, opts.DatabaseName)
 	if err := ensureEmpty(target); err != nil {
 		return report, err
 	}
 
-	state := &importState{idMap: make(map[string]storage.NodeID)}
+	state := &importState{
+		idMap:           make(map[string]storage.NodeID),
+		relationshipIDs: make(map[storage.EdgeID]struct{}),
+	}
 	for _, sourceSpec := range opts.NodeSources {
 		if err := importNodeSource(ctx, target, opts, sourceSpec, state, &report); err != nil {
 			report.Errors = append(report.Errors, err.Error())
@@ -178,6 +184,7 @@ func (o Options) withDefaults() Options {
 
 type importState struct {
 	idMap            map[string]storage.NodeID
+	relationshipIDs  map[storage.EdgeID]struct{}
 	anonymousNodeSeq int
 	edgeSeq          int
 }
@@ -304,6 +311,7 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 	startCols := filterColumns(cols, kindStartID)
 	endCols := filterColumns(cols, kindEndID)
 	typeCols := filterColumns(cols, kindType)
+	relIDCols := filterColumns(cols, kindID)
 	if len(startCols) == 0 || len(endCols) == 0 {
 		return unsupported("relationship source requires :START_ID and :END_ID columns")
 	}
@@ -323,7 +331,7 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 		}
 		edgeSeq := state.edgeSeq
 		state.edgeSeq++
-		edge, skip, err := edgeFromRecord(record, filePath, cols, startCols, endCols, typeCols, spec.prefix, opts, state, rowNum, edgeSeq, report)
+		edge, skip, err := edgeFromRecord(record, filePath, cols, startCols, endCols, typeCols, relIDCols, spec.prefix, opts, state, rowNum, edgeSeq, report)
 		if err != nil {
 			return err
 		}
@@ -333,6 +341,9 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 		edges = append(edges, edge)
 		if len(edges) >= opts.ChunkSize {
 			if err := engine.BulkCreateEdges(edges); err != nil {
+				if errors.Is(err, storage.ErrAlreadyExists) {
+					return &Error{ExitCode: ExitDuplicateID, Message: "duplicate relationship ID", Err: err}
+				}
 				return err
 			}
 			report.RelationshipsImported += int64(len(edges))
@@ -341,6 +352,9 @@ func importRelationshipSource(ctx context.Context, engine storage.Engine, opts O
 	}
 	if len(edges) > 0 {
 		if err := engine.BulkCreateEdges(edges); err != nil {
+			if errors.Is(err, storage.ErrAlreadyExists) {
+				return &Error{ExitCode: ExitDuplicateID, Message: "duplicate relationship ID", Err: err}
+			}
 			return err
 		}
 		report.RelationshipsImported += int64(len(edges))
@@ -428,8 +442,9 @@ func nodeFromRecord(record []string, filePath string, cols []columnSpec, idCols 
 	return node, lookupKey, nil
 }
 
-func edgeFromRecord(record []string, filePath string, cols []columnSpec, startCols, endCols, typeCols []int, prefixType []string, opts Options, state *importState, line int, edgeSeq int, report *Report) (*storage.Edge, bool, error) {
+func edgeFromRecord(record []string, filePath string, cols []columnSpec, startCols, endCols, typeCols, relIDCols []int, prefixType []string, opts Options, state *importState, line int, edgeSeq int, report *Report) (*storage.Edge, bool, error) {
 	props := make(map[string]any)
+	edgeID := fmt.Sprintf("rel_%d", edgeSeq)
 	startValues, startSpaces, startCol, err := idValuesFromRecord(record, cols, startCols, opts)
 	if err != nil {
 		return nil, false, csvErr(filePath, line, startCol+1, err)
@@ -440,11 +455,19 @@ func edgeFromRecord(record []string, filePath string, cols []columnSpec, startCo
 	}
 	startID, ok := state.idMap[importIDKey(startSpaces, startValues)]
 	if !ok {
-		return nil, opts.SkipBadRelationships, badRelationship(opts, report, line, "missing start node")
+		skip, relErr := badRelationship(opts, report, line, "missing start node")
+		if relErr != nil {
+			return nil, false, relErr
+		}
+		return nil, skip, nil
 	}
 	endID, ok := state.idMap[importIDKey(endSpaces, endValues)]
 	if !ok {
-		return nil, opts.SkipBadRelationships, badRelationship(opts, report, line, "missing end node")
+		skip, relErr := badRelationship(opts, report, line, "missing end node")
+		if relErr != nil {
+			return nil, false, relErr
+		}
+		return nil, skip, nil
 	}
 	edgeType := ""
 	if len(prefixType) > 0 {
@@ -458,6 +481,18 @@ func edgeFromRecord(record []string, filePath string, cols []columnSpec, startCo
 	if edgeType == "" {
 		return nil, false, unsupported("relationship source requires :TYPE column or --relationships=TYPE= prefix")
 	}
+	if len(relIDCols) > 0 {
+		edgeValues, _, edgeIDCol, idErr := idValuesFromRecord(record, cols, relIDCols, opts)
+		if idErr != nil {
+			return nil, false, csvErr(filePath, line, edgeIDCol+1, idErr)
+		}
+		edgeID = strings.Join(edgeValues, "|")
+	}
+	edgeIDValue := storage.EdgeID(edgeID)
+	if _, exists := state.relationshipIDs[edgeIDValue]; exists {
+		return nil, false, &Error{ExitCode: ExitDuplicateID, Message: fmt.Sprintf("duplicate relationship ID at row %d", line)}
+	}
+	state.relationshipIDs[edgeIDValue] = struct{}{}
 	for i, col := range cols {
 		if i >= len(record) {
 			continue
@@ -479,15 +514,21 @@ func edgeFromRecord(record []string, filePath string, cols []columnSpec, startCo
 		}
 		props[col.Name] = parsed
 	}
-	return &storage.Edge{ID: storage.EdgeID(fmt.Sprintf("rel_%d", edgeSeq)), StartNode: startID, EndNode: endID, Type: edgeType, Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now, Confidence: 1.0}, false, nil
+	return &storage.Edge{ID: edgeIDValue, StartNode: startID, EndNode: endID, Type: edgeType, Properties: props, CreatedAt: opts.Now, UpdatedAt: opts.Now, Confidence: 1.0}, false, nil
 }
 
-func badRelationship(opts Options, report *Report, line int, msg string) error {
+func badRelationship(opts Options, report *Report, line int, msg string) (bool, error) {
 	report.BadRelationships++
-	if opts.SkipBadRelationships {
-		return nil
+	if opts.BadTolerance > 0 && report.BadRelationships <= int64(opts.BadTolerance) {
+		return true, nil
 	}
-	return &Error{ExitCode: ExitBadRelationship, Message: fmt.Sprintf("bad relationship at row %d: %s", line, msg)}
+	if opts.SkipBadRelationships && opts.BadTolerance <= 0 {
+		return true, nil
+	}
+	if opts.BadTolerance > 0 && report.BadRelationships > int64(opts.BadTolerance) {
+		return false, &Error{ExitCode: ExitBadRelationship, Message: fmt.Sprintf("bad relationship tolerance exceeded at row %d (%d > %d): %s", line, report.BadRelationships, opts.BadTolerance, msg)}
+	}
+	return false, &Error{ExitCode: ExitBadRelationship, Message: fmt.Sprintf("bad relationship at row %d: %s", line, msg)}
 }
 
 func idValuesFromRecord(record []string, cols []columnSpec, indexes []int, opts Options) ([]string, []string, int, error) {
@@ -530,9 +571,6 @@ func parseColumnSpec(raw string, node bool) (columnSpec, error) {
 		keyword, arg, opts := parseKeyword(raw[1:])
 		switch strings.ToUpper(keyword) {
 		case "ID":
-			if !node {
-				return columnSpec{}, unsupported(":ID is only valid in node headers")
-			}
 			return columnSpec{Kind: kindID, IDSpace: arg}, nil
 		case "LABEL":
 			return columnSpec{Kind: kindLabel}, nil
@@ -716,6 +754,51 @@ func openCSVSource(files []string, opts Options) (*csvSourceReader, error) {
 		}
 	}
 	return &csvSourceReader{files: files, opts: opts}, nil
+}
+
+func preflightSources(opts Options) error {
+	for _, raw := range opts.NodeSources {
+		spec, err := parseSourceSpec(raw, true)
+		if err != nil {
+			return err
+		}
+		if err := preflightCSVSource(spec.files, opts, true); err != nil {
+			return err
+		}
+	}
+	for _, raw := range opts.RelSources {
+		spec, err := parseSourceSpec(raw, false)
+		if err != nil {
+			return err
+		}
+		if err := preflightCSVSource(spec.files, opts, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func preflightCSVSource(files []string, opts Options, node bool) error {
+	source, err := openCSVSource(files, opts)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	header, err := source.ReadHeader()
+	if err != nil {
+		return csvErr(files[0], 1, 0, err)
+	}
+	cols, err := parseHeader(header, node)
+	if err != nil {
+		return err
+	}
+	if !node {
+		if len(filterColumns(cols, kindStartID)) == 0 || len(filterColumns(cols, kindEndID)) == 0 {
+			return unsupported("relationship source requires :START_ID and :END_ID columns")
+		}
+	}
+	return nil
 }
 
 func (s *csvSourceReader) Close() error {

--- a/pkg/adminimport/importer.go
+++ b/pkg/adminimport/importer.go
@@ -792,6 +792,9 @@ func (c closers) Close() error {
 }
 
 func applySchema(ctx context.Context, engine storage.Engine, path string) error {
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		return applySchemaDefinition(engine, path)
+	}
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -803,6 +806,70 @@ func applySchema(ctx context.Context, engine storage.Engine, path string) error 
 		}
 		if _, err := exec.Execute(ctx, stmt, nil); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func applySchemaDefinition(engine storage.Engine, path string) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var def storage.SchemaDefinition
+	if err := json.Unmarshal(contents, &def); err != nil {
+		return err
+	}
+	schema := engine.GetSchema()
+	if err := schema.ReplaceFromDefinition(&def); err != nil {
+		return err
+	}
+	if err := rebuildSchemaDerivedState(engine, schema); err != nil {
+		return err
+	}
+	for _, constraint := range schema.GetAllConstraints() {
+		if err := storage.ValidateConstraintOnCreationForEngine(engine, constraint); err != nil {
+			return err
+		}
+	}
+	for _, typeConstraint := range schema.GetAllPropertyTypeConstraints() {
+		if err := storage.ValidatePropertyTypeConstraintOnCreationForEngine(engine, typeConstraint); err != nil {
+			return err
+		}
+	}
+	for _, contract := range schema.GetAllConstraintContracts() {
+		if err := storage.ValidateConstraintContractOnCreationForEngine(engine, contract); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rebuildSchemaDerivedState(engine storage.Engine, schema *storage.SchemaManager) error {
+	if err := storage.RefreshUniqueConstraintValuesForEngine(engine, schema); err != nil {
+		return err
+	}
+	nodes, err := engine.AllNodes()
+	if err != nil {
+		return err
+	}
+	for _, node := range nodes {
+		for _, label := range node.Labels {
+			for property, value := range node.Properties {
+				if _, ok := schema.GetPropertyIndex(label, property); ok {
+					if err := schema.PropertyIndexInsert(label, property, node.ID, value); err != nil {
+						return err
+					}
+				}
+			}
+			for _, idx := range schema.GetCompositeIndexesForLabel(label) {
+				if idx == nil {
+					continue
+				}
+				if err := idx.IndexNode(node.ID, node.Properties); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/pkg/adminimport/importer_test.go
+++ b/pkg/adminimport/importer_test.go
@@ -819,3 +819,158 @@ u1,u2,WORKS_WITH,2025
 	require.Error(t, err)
 	require.True(t, errors.Is(err, storage.ErrNotFound))
 }
+
+func TestImporterScenario_MissingSecondSourceAcrossFlagsFailsBeforeWrites(t *testing.T) {
+	dir := t.TempDir()
+	goodPath := filepath.Join(dir, "nodes_good.csv")
+	missingPath := filepath.Join(dir, "nodes_missing.csv")
+	require.NoError(t, os.WriteFile(goodPath, []byte(":ID,name:string\nn1,Alice\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "missingdb",
+		NodeSources:  []string{goodPath, missingPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.ErrorIs(t, importErr.Err, os.ErrNotExist)
+
+	engine := storage.NewNamespacedEngine(base, "missingdb")
+	count, countErr := engine.NodeCount()
+	require.NoError(t, countErr)
+	require.Equal(t, int64(0), count)
+}
+
+func TestImporterBadRelationshipTolerance(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name\nn1,Alice\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(":START_ID,:END_ID,:TYPE\nn1,missing1,KNOWS\nn1,missing2,KNOWS\n"), 0o600))
+
+	_, err := ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName: "tol0",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	report, err := ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName: "tol2",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+		BadTolerance: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), report.BadRelationships)
+
+	_, err = ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName: "tol1",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+		BadTolerance: 1,
+	})
+	require.Error(t, err)
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitBadRelationship, importErr.ExitCode)
+}
+
+func TestImporterRelationshipIDColumnPreservedAndRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name:string\nn1,Alice\nn2,Bob\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(":ID,:START_ID,:END_ID,:TYPE\nrA,n1,n2,KNOWS\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "rels-id",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+
+	engine := storage.NewNamespacedEngine(base, "rels-id")
+	edges, err := engine.AllEdges()
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	require.Equal(t, storage.EdgeID("rA"), edges[0].ID)
+
+	outDir := filepath.Join(t.TempDir(), "export")
+	require.NoError(t, ExportNeo4jCSV(engine, Neo4jCSVExportOptions{OutputDir: outDir}))
+	relsBytes, err := os.ReadFile(filepath.Join(outDir, "relationships.csv"))
+	require.NoError(t, err)
+	require.Contains(t, string(relsBytes), ":ID,:START_ID,:END_ID,:TYPE")
+	require.Contains(t, string(relsBytes), "rA,n1,n2,KNOWS")
+}
+
+func TestImporterReportsDuplicateRelationshipIDsAcrossChunks(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name:string\nn1,Alice\nn2,Bob\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(":ID,:START_ID,:END_ID,:TYPE\nrA,n1,n2,KNOWS\nrA,n1,n2,KNOWS\n"), 0o600))
+
+	_, err := ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName: "rels-dup",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		ChunkSize:    1,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitDuplicateID, importErr.ExitCode)
+	require.Contains(t, importErr.Error(), "duplicate relationship ID")
+}
+
+func TestNeo4jCSVExportSchemaCypher_IncludesRelationshipFulltextAndVectorIndexes(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	source := storage.NewNamespacedEngine(base, "source")
+	_, err := source.CreateNode(&storage.Node{ID: "n1", Labels: []string{"Person"}, Properties: map[string]any{"name": "Alice"}})
+	require.NoError(t, err)
+	_, err = source.CreateNode(&storage.Node{ID: "n2", Labels: []string{"Person"}, Properties: map[string]any{"name": "Bob"}})
+	require.NoError(t, err)
+	require.NoError(t, source.CreateEdge(&storage.Edge{
+		ID:        "e1",
+		StartNode: "n1",
+		EndNode:   "n2",
+		Type:      "RELATES_TO",
+		Properties: map[string]any{
+			"fact":           "a to b",
+			"fact_embedding": []float32{0.1, 0.2, 0.3},
+		},
+	}))
+
+	schema := source.GetSchema()
+	require.NoError(t, schema.AddFulltextRelationshipIndex("rel_fact_ft", []string{"RELATES_TO"}, []string{"fact"}))
+	require.NoError(t, schema.AddVectorIndexForEntity("rel_fact_vec", "RELATES_TO", "fact_embedding", 3, "cosine", storage.ConstraintEntityRelationship))
+
+	outDir := filepath.Join(t.TempDir(), "schema-ddl")
+	require.NoError(t, ExportNeo4jCSV(source, Neo4jCSVExportOptions{OutputDir: outDir}))
+	schemaDDL, err := os.ReadFile(filepath.Join(outDir, Neo4jCSVSchemaFileName))
+	require.NoError(t, err)
+
+	ddl := string(schemaDDL)
+	require.Contains(t, ddl, "CREATE FULLTEXT INDEX `rel_fact_ft` IF NOT EXISTS FOR ()-[r:`RELATES_TO`]-() ON EACH [r.`fact`]")
+	require.Contains(t, ddl, "CREATE VECTOR INDEX `rel_fact_vec` IF NOT EXISTS FOR ()-[r:`RELATES_TO`]-() ON (r.`fact_embedding`)")
+}

--- a/pkg/adminimport/importer_test.go
+++ b/pkg/adminimport/importer_test.go
@@ -7,11 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/orneryd/nornicdb/pkg/knowledgepolicy"
 	"github.com/orneryd/nornicdb/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
+
+var fixedImportTime = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 
 func TestImporterFullLoadsNeo4jCSVWithVectorsEmbeddingsAndRelationships(t *testing.T) {
 	dir := t.TempDir()
@@ -430,6 +433,179 @@ func TestImporterScenario_MissingSourceFolderFails(t *testing.T) {
 	require.ErrorAs(t, err, &importErr)
 	require.Equal(t, ExitCSV, importErr.ExitCode)
 	require.ErrorIs(t, importErr.Err, os.ErrNotExist)
+}
+
+func TestImporterScenario_MissingLaterSourceFailsBeforeWrites(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "nodes_header.csv")
+	missingPath := filepath.Join(dir, "nodes_rows_missing.csv")
+	require.NoError(t, os.WriteFile(headerPath, []byte(":ID,name:string\nn1,Alice\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "missingdb",
+		NodeSources:  []string{headerPath + "," + missingPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.ErrorIs(t, importErr.Err, os.ErrNotExist)
+
+	engine := storage.NewNamespacedEngine(base, "missingdb")
+	count, countErr := engine.NodeCount()
+	require.NoError(t, countErr)
+	require.Equal(t, int64(0), count)
+}
+
+func TestImporterPreservesEmptyStringPropertiesUnlessIgnored(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name:string,nickname:string,age:int\nn1,Alice,,34\nn2,Bob,builder,29\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(":START_ID,:END_ID,:TYPE,note:string,since:int\nn1,n2,KNOWS,,2024\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "keepempty",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+
+	keep := storage.NewNamespacedEngine(base, "keepempty")
+	node, err := keep.GetNode("n1")
+	require.NoError(t, err)
+	require.Equal(t, "", node.Properties["nickname"])
+	edges, err := keep.GetOutgoingEdges("n1")
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	require.Equal(t, "", edges[0].Properties["note"])
+
+	_, err = ImportFull(context.Background(), base, Options{
+		DatabaseName:       "dropempty",
+		NodeSources:        []string{nodesPath},
+		RelSources:         []string{relsPath},
+		IgnoreEmptyStrings: true,
+		BuildIndexes:       false,
+		Now:                fixedImportTime,
+	})
+	require.NoError(t, err)
+
+	drop := storage.NewNamespacedEngine(base, "dropempty")
+	node, err = drop.GetNode("n1")
+	require.NoError(t, err)
+	_, exists := node.Properties["nickname"]
+	require.False(t, exists)
+	edges, err = drop.GetOutgoingEdges("n1")
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	_, exists = edges[0].Properties["note"]
+	require.False(t, exists)
+}
+
+func TestImporterMultiFileAnonymousNodeIDsRemainUnique(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "nodes_header.csv")
+	rowsPath := filepath.Join(dir, "nodes_rows.csv")
+	require.NoError(t, os.WriteFile(headerPath, []byte("name:string\nAlice\n"), 0o600))
+	require.NoError(t, os.WriteFile(rowsPath, []byte("Bob\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	report, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "anon",
+		NodeSources:  []string{headerPath + "," + rowsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), report.NodesImported)
+
+	engine := storage.NewNamespacedEngine(base, "anon")
+	alice, err := engine.GetNode("_anon_0")
+	require.NoError(t, err)
+	require.Equal(t, "Alice", alice.Properties["name"])
+	bob, err := engine.GetNode("_anon_1")
+	require.NoError(t, err)
+	require.Equal(t, "Bob", bob.Properties["name"])
+}
+
+func TestImporterMultiFileRelationshipIDsRemainUnique(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsHeader := filepath.Join(dir, "rels_header.csv")
+	relsRows := filepath.Join(dir, "rels_rows.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name:string\nn1,Alice\nn2,Bob\nn3,Carol\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsHeader, []byte(":START_ID,:END_ID,:TYPE\nn1,n2,KNOWS\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsRows, []byte("n2,n3,KNOWS\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	report, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "rels",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsHeader + "," + relsRows},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), report.RelationshipsImported)
+
+	engine := storage.NewNamespacedEngine(base, "rels")
+	edges, err := engine.AllEdges()
+	require.NoError(t, err)
+	require.Len(t, edges, 2)
+	require.NotEqual(t, edges[0].ID, edges[1].ID)
+}
+
+func TestImporterBooleanParsingIsCaseInsensitiveAndRejectsInvalidValues(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,active:boolean\nn1,TRUE\nn2,False\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "bools",
+		NodeSources:  []string{nodesPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+
+	engine := storage.NewNamespacedEngine(base, "bools")
+	n1, err := engine.GetNode("n1")
+	require.NoError(t, err)
+	require.Equal(t, true, n1.Properties["active"])
+	n2, err := engine.GetNode("n2")
+	require.NoError(t, err)
+	require.Equal(t, false, n2.Properties["active"])
+
+	invalidPath := filepath.Join(dir, "invalid_bool.csv")
+	require.NoError(t, os.WriteFile(invalidPath, []byte(":ID,active:boolean\nn1,notabool\n"), 0o600))
+	_, err = ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName: "badbool",
+		NodeSources:  []string{invalidPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
 }
 
 func TestImporterScenario_TargetingAndExistingDataIsolation(t *testing.T) {

--- a/pkg/adminimport/importer_test.go
+++ b/pkg/adminimport/importer_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/orneryd/nornicdb/pkg/knowledgepolicy"
 	"github.com/orneryd/nornicdb/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -99,6 +101,229 @@ n1,Bob
 	require.NoError(t, err)
 	require.NotNil(t, node)
 	require.Equal(t, "Alice", node.Properties["name"])
+}
+
+func TestDiscoverNeo4jCSVSourcesFromDirectory(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "relationships.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(`:ID,name,:LABEL
+n1,Alice,Person
+`), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(`:START_ID,:END_ID,:TYPE,since:int
+n1,n2,KNOWS,2024
+`), 0o600))
+
+	nodeSources, relSources, err := DiscoverNeo4jCSVSources(dir, Options{})
+	require.NoError(t, err)
+	require.Equal(t, []string{nodesPath}, nodeSources)
+	require.Equal(t, []string{relsPath}, relSources)
+}
+
+func TestNeo4jCSVExportRoundTripsThroughImporter(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	source := storage.NewNamespacedEngine(base, "source")
+	_, err := source.CreateNode(&storage.Node{
+		ID:     "u1",
+		Labels: []string{"Person", "User"},
+		Properties: map[string]any{
+			"name": "Alice",
+			"age":  int64(34),
+			"tags": []any{"agent", "graph"},
+			"vec":  []float32{0.1, 0.2, 0.3},
+		},
+		NamedEmbeddings: map[string][]float32{"default": {0.4, 0.5, 0.6}},
+	})
+	require.NoError(t, err)
+	_, err = source.CreateNode(&storage.Node{
+		ID:     "u2",
+		Labels: []string{"Person"},
+		Properties: map[string]any{
+			"name": "Bob",
+			"age":  int64(29),
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, source.CreateEdge(&storage.Edge{
+		ID:        "r1",
+		StartNode: "u1",
+		EndNode:   "u2",
+		Type:      "KNOWS",
+		Properties: map[string]any{
+			"since": int64(2024),
+		},
+	}))
+	require.NoError(t, source.GetSchema().AddUniqueConstraint("person_name_unique", "Person", "name"))
+	require.NoError(t, source.GetSchema().AddPropertyIndex("person_age_idx", "Person", []string{"age"}))
+
+	outDir := filepath.Join(t.TempDir(), "neo4j-csv")
+	require.NoError(t, ExportNeo4jCSV(source, Neo4jCSVExportOptions{OutputDir: outDir}))
+	schemaBytes, err := os.ReadFile(filepath.Join(outDir, Neo4jCSVSchemaFileName))
+	require.NoError(t, err)
+	require.Contains(t, string(schemaBytes), "CREATE CONSTRAINT `person_name_unique` IF NOT EXISTS")
+	require.True(t, strings.Contains(string(schemaBytes), "CREATE INDEX `person_age_idx` IF NOT EXISTS") || strings.Contains(string(schemaBytes), "CREATE INDEX person_age_idx IF NOT EXISTS"))
+	_, err = os.Stat(filepath.Join(outDir, Neo4jCSVNornicSchemaFileName))
+	require.NoError(t, err)
+
+	nodeSources, relSources, err := DiscoverNeo4jCSVSources(outDir, Options{})
+	require.NoError(t, err)
+
+	destBase := storage.NewMemoryEngine()
+	report, err := ImportFull(context.Background(), destBase, Options{
+		DatabaseName: "dest",
+		NodeSources:  nodeSources,
+		RelSources:   relSources,
+		SchemaFile:   filepath.Join(outDir, Neo4jCSVSchemaFileName),
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), report.NodesImported)
+	require.Equal(t, int64(1), report.RelationshipsImported)
+
+	dest := storage.NewNamespacedEngine(destBase, "dest")
+	alice, err := dest.GetNode("u1")
+	require.NoError(t, err)
+	require.Equal(t, "Alice", alice.Properties["name"])
+	require.Equal(t, int64(34), alice.Properties["age"])
+	require.Equal(t, []any{"agent", "graph"}, alice.Properties["tags"])
+	require.Equal(t, []float32{0.1, 0.2, 0.3}, alice.Properties["vec"])
+	require.Equal(t, []float32{0.4, 0.5, 0.6}, alice.NamedEmbeddings["default"])
+	require.ElementsMatch(t, []string{"Person", "User"}, alice.Labels)
+
+	edges, err := dest.GetOutgoingEdges("u1")
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	require.Equal(t, "KNOWS", edges[0].Type)
+	require.Equal(t, int64(2024), edges[0].Properties["since"])
+	constraints := dest.GetSchema().GetConstraintsForLabels([]string{"Person"})
+	require.Len(t, constraints, 1)
+	require.Equal(t, "person_name_unique", constraints[0].Name)
+	indexes := dest.GetSchema().GetIndexes()
+	require.NotEmpty(t, indexes)
+}
+
+func TestNeo4jCSVExportRoundTripsFullSchemaDefinition(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	source := storage.NewNamespacedEngine(base, "source")
+	_, err := source.CreateNode(&storage.Node{
+		ID:     "u1",
+		Labels: []string{"Person"},
+		Properties: map[string]any{
+			"name":      "Alice",
+			"age":       int64(34),
+			"email":     "alice@example.com",
+			"country":   "US",
+			"city":      "NYC",
+			"status":    "active",
+			"embedding": []float32{0.1, 0.2, 0.3},
+		},
+	})
+	require.NoError(t, err)
+	_, err = source.CreateNode(&storage.Node{
+		ID:     "u2",
+		Labels: []string{"Person"},
+		Properties: map[string]any{
+			"name":    "Bob",
+			"age":     int64(29),
+			"email":   "bob@example.com",
+			"country": "US",
+			"city":    "LA",
+			"status":  "active",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, source.CreateEdge(&storage.Edge{
+		ID:        "r1",
+		StartNode: "u1",
+		EndNode:   "u2",
+		Type:      "KNOWS",
+		Properties: map[string]any{
+			"note":  "met at graph conf",
+			"since": int64(2024),
+		},
+	}))
+
+	schema := source.GetSchema()
+	require.NoError(t, schema.AddUniqueConstraint("person_email_unique", "Person", "email"))
+	require.NoError(t, schema.AddPropertyTypeConstraint("person_age_type", "Person", "age", storage.PropertyTypeInteger))
+	require.NoError(t, schema.AddPropertyIndex("person_name_idx", "Person", []string{"name"}))
+	require.NoError(t, schema.AddCompositeIndex("person_location_idx", "Person", []string{"country", "city"}))
+	require.NoError(t, schema.AddFulltextIndex("person_search_idx", []string{"Person"}, []string{"name"}))
+	require.NoError(t, schema.AddFulltextRelationshipIndex("knows_note_idx", []string{"KNOWS"}, []string{"note"}))
+	require.NoError(t, schema.AddVectorIndex("person_embedding_idx", "Person", "embedding", 3, "cosine"))
+	require.NoError(t, schema.AddRangeIndex("person_age_range", "Person", "age"))
+	require.NoError(t, schema.AddConstraintContractBundle(storage.ConstraintContract{
+		Name:              "person_name_contract",
+		TargetEntityType:  string(storage.ConstraintEntityNode),
+		TargetLabelOrType: "Person",
+		Definition:        "CREATE CONSTRAINT CONTRACT person_name_contract FOR (n:Person) REQUIRE n.name IS NOT NULL",
+		Entries: []storage.ConstraintContractEntry{{
+			Kind:       storage.ConstraintContractKindBooleanNode,
+			Expression: "n.status IN ['active']",
+		}},
+	}, nil, nil, false))
+	require.NoError(t, schema.CreateDecayProfileBundle(knowledgepolicy.DecayProfileBundle{
+		Name:                "person_decay_profile",
+		HalfLifeSeconds:     86400,
+		VisibilityThreshold: 0.25,
+		ScoreFloor:          0.10,
+		Function:            knowledgepolicy.DecayFunctionExponential,
+		Scope:               knowledgepolicy.ScopeNode,
+		DecayEnabled:        true,
+		ScoreFrom:           knowledgepolicy.ScoreFromCreated,
+		Enabled:             true,
+	}))
+	threshold := 0.25
+	require.NoError(t, schema.CreateDecayProfileBinding(knowledgepolicy.DecayProfileBinding{
+		Name:                "person_decay_binding",
+		TargetLabels:        []string{"Person"},
+		ProfileRef:          "person_decay_profile",
+		VisibilityThreshold: &threshold,
+		Order:               1,
+	}))
+	require.NoError(t, schema.CreatePromotionProfile(knowledgepolicy.PromotionProfileDef{
+		Name:       "person_boost_profile",
+		Scope:      knowledgepolicy.ScopeNode,
+		Multiplier: 1.5,
+		ScoreFloor: 0.20,
+		ScoreCap:   1.0,
+		Enabled:    true,
+	}))
+	require.NoError(t, schema.CreatePromotionPolicy(knowledgepolicy.PromotionPolicyDef{
+		Name:         "person_boost_policy",
+		TargetLabels: []string{"Person"},
+		Enabled:      true,
+		WhenClauses: []knowledgepolicy.PromotionPolicyWhenClause{{
+			Predicate:  "n.age >= 30",
+			ProfileRef: "person_boost_profile",
+			Order:      1,
+		}},
+	}))
+
+	outDir := filepath.Join(t.TempDir(), "neo4j-csv-full-schema")
+	require.NoError(t, ExportNeo4jCSV(source, Neo4jCSVExportOptions{OutputDir: outDir}))
+	_, err = os.Stat(filepath.Join(outDir, Neo4jCSVSchemaFileName))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(outDir, Neo4jCSVNornicSchemaFileName))
+	require.NoError(t, err)
+
+	nodeSources, relSources, err := DiscoverNeo4jCSVSources(outDir, Options{})
+	require.NoError(t, err)
+
+	destBase := storage.NewMemoryEngine()
+	_, err = ImportFull(context.Background(), destBase, Options{
+		DatabaseName: "dest",
+		NodeSources:  nodeSources,
+		RelSources:   relSources,
+		SchemaFile:   filepath.Join(outDir, Neo4jCSVNornicSchemaFileName),
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+
+	dest := storage.NewNamespacedEngine(destBase, "dest")
+	require.Equal(t, source.GetSchema().ExportDefinition(), dest.GetSchema().ExportDefinition())
 }
 
 func TestImporterReportsDuplicateIDs(t *testing.T) {

--- a/pkg/adminimport/importer_test.go
+++ b/pkg/adminimport/importer_test.go
@@ -608,6 +608,103 @@ func TestImporterBooleanParsingIsCaseInsensitiveAndRejectsInvalidValues(t *testi
 	require.Equal(t, ExitCSV, importErr.ExitCode)
 }
 
+func TestImporterRelationshipEndpointIDsAreRequired(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name:string\nn1,Alice\nn2,Bob\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(":START_ID,:END_ID,:TYPE\n,n2,KNOWS\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName:         "missingrelid",
+		NodeSources:          []string{nodesPath},
+		RelSources:           []string{relsPath},
+		SkipBadRelationships: true,
+		BuildIndexes:         false,
+		Now:                  fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.Contains(t, importErr.Error(), relsPath)
+	require.Contains(t, importErr.Error(), "missing ID value")
+}
+
+func TestImporterNodeParseErrorsIncludeFilePath(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "invalid_nodes.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,active:boolean\nn1,notabool\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "nodeparse",
+		NodeSources:  []string{nodesPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.Contains(t, importErr.Error(), nodesPath)
+}
+
+func TestImporterRelationshipParseErrorsIncludeFilePath(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "invalid_rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,name:string\nn1,Alice\nn2,Bob\n"), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(":START_ID,:END_ID,:TYPE,since:int\nn1,n2,KNOWS,notanint\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "relparse",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.Contains(t, importErr.Error(), relsPath)
+}
+
+func TestImporterNamedEmbeddingDimensionsAreInferredAndValidated(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(":ID,:EMBEDDING(image)\nn1,0.1;0.2\nn2,0.3;0.4;0.5\n"), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "embeddims",
+		NodeSources:  []string{nodesPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.Contains(t, importErr.Error(), nodesPath)
+	require.Contains(t, importErr.Error(), "vector dimensions mismatch")
+}
+
 func TestImporterScenario_TargetingAndExistingDataIsolation(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/adminimport/importer_test.go
+++ b/pkg/adminimport/importer_test.go
@@ -15,6 +15,7 @@ func TestImporterFullLoadsNeo4jCSVWithVectorsEmbeddingsAndRelationships(t *testi
 	dir := t.TempDir()
 	nodesPath := filepath.Join(dir, "nodes.csv")
 	relsPath := filepath.Join(dir, "rels.csv")
+	schemaPath := filepath.Join(dir, "schema.cypher")
 
 	require.NoError(t, os.WriteFile(nodesPath, []byte(`id:ID(User),name:string,age:int,active:boolean,tags:string[],"embedding:vector{coordinateType:float,dimensions:3}",:EMBEDDING(default),:LABEL,:IGNORE
 u1,Alice,34,true,"agent;graph","0.1;0.2;0.3","0.4;0.5;0.6",Person;User,ignored
@@ -23,13 +24,17 @@ u2,Bob,29,false,"graph","0.7;0.8;0.9","1.0;1.1;1.2",Person,ignored
 	require.NoError(t, os.WriteFile(relsPath, []byte(`:START_ID(User),:END_ID(User),:TYPE,since:int
 u1,u2,KNOWS,2024
 `), 0o600))
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`CREATE CONSTRAINT person_name_unique IF NOT EXISTS FOR (n:Person) REQUIRE n.name IS UNIQUE;
+`), 0o600))
 
 	base := storage.NewMemoryEngine()
 	report, err := ImportFull(context.Background(), base, Options{
 		DatabaseName: "mydb",
 		NodeSources:  []string{"Imported=" + nodesPath},
 		RelSources:   []string{relsPath},
-		BuildIndexes: false,
+		SchemaFile:   schemaPath,
+		DataDir:      dir,
+		BuildIndexes: true,
 		ChunkSize:    2,
 		Now:          fixedImportTime,
 		ReportFile:   filepath.Join(dir, "report.json"),
@@ -57,9 +62,43 @@ u1,u2,KNOWS,2024
 	require.Equal(t, storage.NodeID("u2"), edges[0].EndNode)
 	require.Equal(t, "KNOWS", edges[0].Type)
 	require.Equal(t, int64(2024), edges[0].Properties["since"])
+	require.True(t, report.IndexesBuilt)
+
+	constraints := engine.GetSchema().GetConstraintsForLabels([]string{"Person"})
+	require.Len(t, constraints, 1)
+	require.Equal(t, "person_name_unique", constraints[0].Name)
+	require.Equal(t, storage.ConstraintUnique, constraints[0].Type)
+	require.Equal(t, []string{"name"}, constraints[0].Properties)
 
 	_, err = os.Stat(filepath.Join(dir, "report.json"))
 	require.NoError(t, err)
+}
+
+func TestImporterSkipsDuplicateNodesWhenRequested(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(`:ID,name
+n1,Alice
+n1,Bob
+`), 0o600))
+
+	base := storage.NewMemoryEngine()
+	report, err := ImportFull(context.Background(), base, Options{
+		DatabaseName:       "mydb",
+		NodeSources:        []string{nodesPath},
+		BuildIndexes:       false,
+		SkipDuplicateNodes: true,
+		Now:                fixedImportTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), report.NodesImported)
+	require.Equal(t, int64(1), report.DuplicateNodesSkipped)
+
+	engine := storage.NewNamespacedEngine(base, "mydb")
+	node, err := engine.GetNode("n1")
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	require.Equal(t, "Alice", node.Properties["name"])
 }
 
 func TestImporterReportsDuplicateIDs(t *testing.T) {

--- a/pkg/adminimport/importer_test.go
+++ b/pkg/adminimport/importer_test.go
@@ -1,0 +1,284 @@
+package adminimport
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImporterFullLoadsNeo4jCSVWithVectorsEmbeddingsAndRelationships(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+
+	require.NoError(t, os.WriteFile(nodesPath, []byte(`id:ID(User),name:string,age:int,active:boolean,tags:string[],"embedding:vector{coordinateType:float,dimensions:3}",:EMBEDDING(default),:LABEL,:IGNORE
+u1,Alice,34,true,"agent;graph","0.1;0.2;0.3","0.4;0.5;0.6",Person;User,ignored
+u2,Bob,29,false,"graph","0.7;0.8;0.9","1.0;1.1;1.2",Person,ignored
+`), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(`:START_ID(User),:END_ID(User),:TYPE,since:int
+u1,u2,KNOWS,2024
+`), 0o600))
+
+	base := storage.NewMemoryEngine()
+	report, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "mydb",
+		NodeSources:  []string{"Imported=" + nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		ChunkSize:    2,
+		Now:          fixedImportTime,
+		ReportFile:   filepath.Join(dir, "report.json"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), report.NodesImported)
+	require.Equal(t, int64(1), report.RelationshipsImported)
+
+	engine := storage.NewNamespacedEngine(base, "mydb")
+	alice, err := engine.GetNode("u1")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Imported", "Person", "User"}, alice.Labels)
+	require.Equal(t, "Alice", alice.Properties["name"])
+	require.Equal(t, int64(34), alice.Properties["age"])
+	require.Equal(t, true, alice.Properties["active"])
+	require.Equal(t, []any{"agent", "graph"}, alice.Properties["tags"])
+	require.Equal(t, []float32{0.1, 0.2, 0.3}, alice.Properties["embedding"])
+	require.Equal(t, []float32{0.4, 0.5, 0.6}, alice.NamedEmbeddings["default"])
+	require.Equal(t, "u1", alice.Properties["id"])
+
+	edges, err := engine.GetOutgoingEdges("u1")
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	require.Equal(t, storage.NodeID("u1"), edges[0].StartNode)
+	require.Equal(t, storage.NodeID("u2"), edges[0].EndNode)
+	require.Equal(t, "KNOWS", edges[0].Type)
+	require.Equal(t, int64(2024), edges[0].Properties["since"])
+
+	_, err = os.Stat(filepath.Join(dir, "report.json"))
+	require.NoError(t, err)
+}
+
+func TestImporterReportsDuplicateIDs(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(`:ID,name
+n1,Alice
+n1,Bob
+`), 0o600))
+
+	_, err := ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName: "mydb",
+		NodeSources:  []string{nodesPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitDuplicateID, importErr.ExitCode)
+}
+
+func TestImporterCompositeIDRelationships(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(`tenant:ID(Scope),local:ID(Scope),name
+a,1,Alice
+a,2,Bob
+`), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(`:START_ID(Scope),:START_ID(Scope),:END_ID(Scope),:END_ID(Scope),:TYPE
+a,1,a,2,KNOWS
+`), 0o600))
+
+	base := storage.NewMemoryEngine()
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "mydb",
+		NodeSources:  []string{nodesPath},
+		RelSources:   []string{relsPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+
+	engine := storage.NewNamespacedEngine(base, "mydb")
+	edges, err := engine.AllEdges()
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	require.Equal(t, storage.NodeID("a|1"), edges[0].StartNode)
+	require.Equal(t, storage.NodeID("a|2"), edges[0].EndNode)
+}
+
+func TestImporterBadRelationshipReferenceHonorsSkipFlag(t *testing.T) {
+	dir := t.TempDir()
+	nodesPath := filepath.Join(dir, "nodes.csv")
+	relsPath := filepath.Join(dir, "rels.csv")
+	require.NoError(t, os.WriteFile(nodesPath, []byte(`:ID,name
+n1,Alice
+`), 0o600))
+	require.NoError(t, os.WriteFile(relsPath, []byte(`:START_ID,:END_ID,:TYPE
+n1,missing,KNOWS
+`), 0o600))
+
+	_, err := ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName:         "mydb",
+		NodeSources:          []string{nodesPath},
+		RelSources:           []string{relsPath},
+		BuildIndexes:         false,
+		Now:                  fixedImportTime,
+		SkipBadRelationships: false,
+	})
+	require.Error(t, err)
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitBadRelationship, importErr.ExitCode)
+
+	report, err := ImportFull(context.Background(), storage.NewMemoryEngine(), Options{
+		DatabaseName:         "mydb",
+		NodeSources:          []string{nodesPath},
+		RelSources:           []string{relsPath},
+		BuildIndexes:         false,
+		Now:                  fixedImportTime,
+		SkipBadRelationships: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), report.BadRelationships)
+	require.Equal(t, int64(0), report.RelationshipsImported)
+}
+
+func TestImporterScenario_MissingSourceFolderFails(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	missingPath := filepath.Join(t.TempDir(), "missing", "nodes.csv")
+	_, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "missingdb",
+		NodeSources:  []string{missingPath},
+		BuildIndexes: false,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+
+	var importErr *Error
+	require.ErrorAs(t, err, &importErr)
+	require.Equal(t, ExitCSV, importErr.ExitCode)
+	require.ErrorIs(t, importErr.Err, os.ErrNotExist)
+}
+
+func TestImporterScenario_TargetingAndExistingDataIsolation(t *testing.T) {
+	dir := t.TempDir()
+
+	alphaNodesHeader := filepath.Join(dir, "alpha_nodes_header.csv")
+	alphaNodesRows := filepath.Join(dir, "alpha_nodes_rows.csv")
+	alphaRels := filepath.Join(dir, "alpha_rels.csv")
+	require.NoError(t, os.WriteFile(alphaNodesHeader, []byte(`id:ID(User),name:string,role:string,:LABEL
+`), 0o600))
+	require.NoError(t, os.WriteFile(alphaNodesRows, []byte(`u1,Alice,admin,Person;User
+u2,Bob,editor,Person
+`), 0o600))
+	require.NoError(t, os.WriteFile(alphaRels, []byte(`:START_ID(User),:END_ID(User),:TYPE,since:int
+u1,u2,KNOWS,2024
+`), 0o600))
+
+	betaNodesHeader := filepath.Join(dir, "beta_nodes_header.csv")
+	betaNodesRows := filepath.Join(dir, "beta_nodes_rows.csv")
+	betaRels := filepath.Join(dir, "beta_rels.csv")
+	require.NoError(t, os.WriteFile(betaNodesHeader, []byte(`id:ID(User),name:string,role:string,:LABEL
+`), 0o600))
+	require.NoError(t, os.WriteFile(betaNodesRows, []byte(`u1,Carol,owner,Person;User
+u2,Dan,reader,Person
+`), 0o600))
+	require.NoError(t, os.WriteFile(betaRels, []byte(`:START_ID(User),:END_ID(User),:TYPE,since:int
+u1,u2,WORKS_WITH,2025
+`), 0o600))
+
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { _ = base.Close() })
+
+	alphaReport, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "alpha",
+		NodeSources:  []string{"Imported=" + alphaNodesHeader + "," + alphaNodesRows},
+		RelSources:   []string{alphaRels},
+		BuildIndexes: false,
+		ChunkSize:    1,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), alphaReport.NodesImported)
+	require.Equal(t, int64(1), alphaReport.RelationshipsImported)
+
+	alpha := storage.NewNamespacedEngine(base, "alpha")
+	alphaAlice, err := alpha.GetNode("u1")
+	require.NoError(t, err)
+	require.Equal(t, "Alice", alphaAlice.Properties["name"])
+	require.Equal(t, "admin", alphaAlice.Properties["role"])
+	require.ElementsMatch(t, []string{"Imported", "Person", "User"}, alphaAlice.Labels)
+
+	alphaEdges, err := alpha.GetOutgoingEdges("u1")
+	require.NoError(t, err)
+	require.Len(t, alphaEdges, 1)
+	require.Equal(t, storage.NodeID("u1"), alphaEdges[0].StartNode)
+	require.Equal(t, storage.NodeID("u2"), alphaEdges[0].EndNode)
+	require.Equal(t, "KNOWS", alphaEdges[0].Type)
+	require.Equal(t, int64(2024), alphaEdges[0].Properties["since"])
+
+	_, err = ImportFull(context.Background(), base, Options{
+		DatabaseName: "alpha",
+		NodeSources:  []string{"Imported=" + alphaNodesHeader + "," + alphaNodesRows},
+		RelSources:   []string{alphaRels},
+		BuildIndexes: false,
+		ChunkSize:    1,
+		Now:          fixedImportTime,
+	})
+	require.Error(t, err)
+	var targetErr *Error
+	require.ErrorAs(t, err, &targetErr)
+	require.Equal(t, ExitUnsupported, targetErr.ExitCode)
+	require.Contains(t, targetErr.Message, "empty target database")
+
+	betaReport, err := ImportFull(context.Background(), base, Options{
+		DatabaseName: "beta",
+		NodeSources:  []string{"Imported=" + betaNodesHeader + "," + betaNodesRows},
+		RelSources:   []string{betaRels},
+		BuildIndexes: false,
+		ChunkSize:    1,
+		Now:          fixedImportTime,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), betaReport.NodesImported)
+	require.Equal(t, int64(1), betaReport.RelationshipsImported)
+
+	beta := storage.NewNamespacedEngine(base, "beta")
+	betaCarol, err := beta.GetNode("u1")
+	require.NoError(t, err)
+	require.Equal(t, "Carol", betaCarol.Properties["name"])
+	require.Equal(t, "owner", betaCarol.Properties["role"])
+	require.ElementsMatch(t, []string{"Imported", "Person", "User"}, betaCarol.Labels)
+
+	betaEdges, err := beta.GetOutgoingEdges("u1")
+	require.NoError(t, err)
+	require.Len(t, betaEdges, 1)
+	require.Equal(t, storage.NodeID("u1"), betaEdges[0].StartNode)
+	require.Equal(t, storage.NodeID("u2"), betaEdges[0].EndNode)
+	require.Equal(t, "WORKS_WITH", betaEdges[0].Type)
+	require.Equal(t, int64(2025), betaEdges[0].Properties["since"])
+
+	alphaAlice, err = alpha.GetNode("u1")
+	require.NoError(t, err)
+	require.Equal(t, "Alice", alphaAlice.Properties["name"])
+	require.Equal(t, "admin", alphaAlice.Properties["role"])
+
+	alphaCount, err := alpha.NodeCount()
+	require.NoError(t, err)
+	require.Equal(t, int64(2), alphaCount)
+	betaCount, err := beta.NodeCount()
+	require.NoError(t, err)
+	require.Equal(t, int64(2), betaCount)
+
+	_, err = beta.GetNode("missing")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, storage.ErrNotFound))
+}

--- a/pkg/adminimport/neo4j_csv.go
+++ b/pkg/adminimport/neo4j_csv.go
@@ -174,13 +174,13 @@ func exportNodesCSV(path string, nodes []*storage.Node, opts Neo4jCSVExportOptio
 
 func exportRelationshipsCSV(path string, edges []*storage.Edge, opts Neo4jCSVExportOptions) error {
 	columns := inferEdgeColumns(edges)
-	header := []string{":START_ID", ":END_ID", ":TYPE"}
+	header := []string{":ID", ":START_ID", ":END_ID", ":TYPE"}
 	for _, col := range columns {
 		header = append(header, col.Header)
 	}
 	rows := make([][]string, 0, len(edges))
 	for _, edge := range edges {
-		row := []string{string(edge.StartNode), string(edge.EndNode), edge.Type}
+		row := []string{string(edge.ID), string(edge.StartNode), string(edge.EndNode), edge.Type}
 		for _, col := range columns {
 			row = append(row, formatPropertyValue(edge.Properties[col.Property], col, opts))
 		}
@@ -646,6 +646,7 @@ func renderIndexStatement(index any) (string, bool) {
 	case "FULLTEXT":
 		properties := stringSliceValue(m["properties"])
 		labels := stringSliceValue(m["labels"])
+		relationshipTypes := stringSliceValue(m["relationshipTypes"])
 		if len(properties) == 0 {
 			return "", false
 		}
@@ -655,6 +656,13 @@ func renderIndexStatement(index any) (string, bool) {
 				parts = append(parts, quoteCypherIdent(item))
 			}
 			return fmt.Sprintf("CREATE FULLTEXT INDEX %s IF NOT EXISTS FOR (n:%s) ON EACH [%s]", quoteCypherIdent(name), strings.Join(parts, "|"), strings.Join(cypherPropertyRefs("n", properties), ", ")), true
+		}
+		if len(relationshipTypes) > 0 {
+			parts := make([]string, 0, len(relationshipTypes))
+			for _, item := range relationshipTypes {
+				parts = append(parts, quoteCypherIdent(item))
+			}
+			return fmt.Sprintf("CREATE FULLTEXT INDEX %s IF NOT EXISTS FOR ()-[r:%s]-() ON EACH [%s]", quoteCypherIdent(name), strings.Join(parts, "|"), strings.Join(cypherPropertyRefs("r", properties), ", ")), true
 		}
 		return "", false
 	case "VECTOR":
@@ -669,12 +677,19 @@ func renderIndexStatement(index any) (string, bool) {
 		if property == "" || label == "" || dimensions == 0 {
 			return "", false
 		}
+		entityType, _ := m["entityType"].(string)
+		entity := storage.ConstraintEntityNode
+		variable := "n"
+		if entityType == string(storage.ConstraintEntityRelationship) {
+			entity = storage.ConstraintEntityRelationship
+			variable = "r"
+		}
 		options := fmt.Sprintf("OPTIONS {indexConfig: {`vector.dimensions`: %d", dimensions)
 		if similarity != "" {
 			options += fmt.Sprintf(", `vector.similarity_function`: '%s'", strings.ToLower(similarity))
 		}
 		options += "}}"
-		return fmt.Sprintf("CREATE VECTOR INDEX %s IF NOT EXISTS FOR %s ON (%s) %s", quoteCypherIdent(name), cypherPattern(storage.ConstraintEntityNode, label), strings.Join(cypherPropertyRefs("n", []string{property}), ", "), options), true
+		return fmt.Sprintf("CREATE VECTOR INDEX %s IF NOT EXISTS FOR %s ON (%s) %s", quoteCypherIdent(name), cypherPattern(entity, label), strings.Join(cypherPropertyRefs(variable, []string{property}), ", "), options), true
 	default:
 		return "", false
 	}

--- a/pkg/adminimport/neo4j_csv.go
+++ b/pkg/adminimport/neo4j_csv.go
@@ -1,0 +1,770 @@
+package adminimport
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+type Neo4jCSVExportOptions struct {
+	OutputDir       string
+	Delimiter       rune
+	ArrayDelimiter  rune
+	VectorDelimiter rune
+	Quote           rune
+}
+
+const Neo4jCSVSchemaFileName = "schema.cypher"
+const Neo4jCSVNornicSchemaFileName = "schema.nornic.json"
+
+type inferredColumn struct {
+	Header     string
+	Property   string
+	Kind       string
+	ScalarType string
+	VectorDims int
+	EmbedKey   string
+}
+
+func DiscoverNeo4jCSVSources(dir string, opts Options) (nodeSources []string, relSources []string, err error) {
+	entries := make([]string, 0)
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if isCSVLikePath(path) {
+			entries = append(entries, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, &Error{ExitCode: ExitCSV, Message: "failed to scan Neo4j CSV directory", Err: err}
+	}
+	sort.Strings(entries)
+	for _, path := range entries {
+		kind, classifyErr := classifyNeo4jCSVFile(path, opts)
+		if classifyErr != nil {
+			return nil, nil, classifyErr
+		}
+		switch kind {
+		case "node":
+			nodeSources = append(nodeSources, path)
+		case "relationship":
+			relSources = append(relSources, path)
+		}
+	}
+	if len(nodeSources) == 0 && len(relSources) == 0 {
+		return nil, nil, unsupported("no Neo4j-compatible CSV files found in source directory")
+	}
+	if len(nodeSources) == 0 {
+		return nil, nil, unsupported("source directory does not contain any node CSV files")
+	}
+	return nodeSources, relSources, nil
+}
+
+func ExportNeo4jCSV(engine storage.ExportableEngine, opts Neo4jCSVExportOptions) error {
+	if opts.OutputDir == "" {
+		return unsupported("output directory is required")
+	}
+	if opts.Delimiter == 0 {
+		opts.Delimiter = ','
+	}
+	if opts.ArrayDelimiter == 0 {
+		opts.ArrayDelimiter = ';'
+	}
+	if opts.VectorDelimiter == 0 {
+		opts.VectorDelimiter = ';'
+	}
+	if opts.Quote == 0 {
+		opts.Quote = '"'
+	}
+	if opts.Quote != '"' {
+		return unsupported("custom quote characters are not supported for Neo4j CSV export")
+	}
+	if err := os.MkdirAll(opts.OutputDir, 0o755); err != nil {
+		return err
+	}
+
+	nodes, err := engine.AllNodes()
+	if err != nil {
+		return err
+	}
+	edges, err := engine.AllEdges()
+	if err != nil {
+		return err
+	}
+
+	if err := exportNodesCSV(filepath.Join(opts.OutputDir, "nodes.csv"), nodes, opts); err != nil {
+		return err
+	}
+	if len(edges) > 0 {
+		if err := exportRelationshipsCSV(filepath.Join(opts.OutputDir, "relationships.csv"), edges, opts); err != nil {
+			return err
+		}
+	}
+	if err := exportNornicSchemaDefinition(filepath.Join(opts.OutputDir, Neo4jCSVNornicSchemaFileName), engine.GetSchema()); err != nil {
+		return err
+	}
+	if err := exportSchemaCypher(filepath.Join(opts.OutputDir, Neo4jCSVSchemaFileName), engine.GetSchema()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func DefaultNeo4jCSVSchemaPath(dir string) string {
+	return filepath.Join(dir, Neo4jCSVSchemaFileName)
+}
+
+func DefaultNeo4jCSVNornicSchemaPath(dir string) string {
+	return filepath.Join(dir, Neo4jCSVNornicSchemaFileName)
+}
+
+func classifyNeo4jCSVFile(path string, opts Options) (string, error) {
+	source, err := openCSVSource([]string{path}, opts.withDefaults())
+	if err != nil {
+		return "", err
+	}
+	defer source.Close()
+	header, err := source.ReadHeader()
+	if err != nil {
+		return "", &Error{ExitCode: ExitCSV, Message: "failed to read CSV header", Err: err}
+	}
+	cols, err := parseHeader(header, false)
+	if err == nil {
+		hasStart := len(filterColumns(cols, kindStartID)) > 0
+		hasEnd := len(filterColumns(cols, kindEndID)) > 0
+		if hasStart && hasEnd {
+			return "relationship", nil
+		}
+	}
+	if _, err := parseHeader(header, true); err == nil {
+		return "node", nil
+	}
+	return "", unsupported("unsupported CSV header in Neo4j source directory: " + path)
+}
+
+func exportNodesCSV(path string, nodes []*storage.Node, opts Neo4jCSVExportOptions) error {
+	columns := inferNodeColumns(nodes)
+	header := []string{":ID", ":LABEL"}
+	for _, col := range columns {
+		header = append(header, col.Header)
+	}
+	rows := make([][]string, 0, len(nodes))
+	for _, node := range nodes {
+		row := []string{string(node.ID), strings.Join(node.Labels, string(opts.ArrayDelimiter))}
+		for _, col := range columns {
+			row = append(row, formatNodeColumnValue(node, col, opts))
+		}
+		rows = append(rows, row)
+	}
+	return writeCSV(path, header, rows, opts.Delimiter)
+}
+
+func exportRelationshipsCSV(path string, edges []*storage.Edge, opts Neo4jCSVExportOptions) error {
+	columns := inferEdgeColumns(edges)
+	header := []string{":START_ID", ":END_ID", ":TYPE"}
+	for _, col := range columns {
+		header = append(header, col.Header)
+	}
+	rows := make([][]string, 0, len(edges))
+	for _, edge := range edges {
+		row := []string{string(edge.StartNode), string(edge.EndNode), edge.Type}
+		for _, col := range columns {
+			row = append(row, formatPropertyValue(edge.Properties[col.Property], col, opts))
+		}
+		rows = append(rows, row)
+	}
+	return writeCSV(path, header, rows, opts.Delimiter)
+}
+
+func inferNodeColumns(nodes []*storage.Node) []inferredColumn {
+	props := make(map[string]inferredColumn)
+	for _, node := range nodes {
+		for key, value := range node.Properties {
+			if key == "id" {
+				continue
+			}
+			props[key] = mergeColumn(props[key], key, value)
+		}
+		for key, vector := range node.NamedEmbeddings {
+			props[":EMBEDDING("+key+")"] = inferredColumn{
+				Header:     ":EMBEDDING(" + key + ")",
+				Kind:       "embedding",
+				EmbedKey:   key,
+				VectorDims: len(vector),
+			}
+		}
+	}
+	return sortColumns(props)
+}
+
+func inferEdgeColumns(edges []*storage.Edge) []inferredColumn {
+	props := make(map[string]inferredColumn)
+	for _, edge := range edges {
+		for key, value := range edge.Properties {
+			props[key] = mergeColumn(props[key], key, value)
+		}
+	}
+	return sortColumns(props)
+}
+
+func mergeColumn(existing inferredColumn, key string, value any) inferredColumn {
+	if existing.Header == "" {
+		existing.Property = key
+	}
+	kind, scalarType, dims := inferValueShape(value)
+	if existing.Kind == "" {
+		existing.Kind = kind
+		existing.ScalarType = scalarType
+		existing.VectorDims = dims
+	} else if existing.Kind != kind || existing.ScalarType != scalarType {
+		existing.Kind = "property"
+		existing.ScalarType = "string"
+		existing.VectorDims = 0
+	} else if dims > existing.VectorDims {
+		existing.VectorDims = dims
+	}
+	switch existing.Kind {
+	case "vector":
+		existing.Header = fmt.Sprintf("%s:vector{coordinateType:float,dimensions:%d}", key, max(1, existing.VectorDims))
+	case "array":
+		existing.Header = fmt.Sprintf("%s:%s[]", key, defaultString(existing.ScalarType, "string"))
+	default:
+		existing.Header = fmt.Sprintf("%s:%s", key, defaultString(existing.ScalarType, "string"))
+	}
+	return existing
+}
+
+func inferValueShape(value any) (kind string, scalarType string, dims int) {
+	switch v := value.(type) {
+	case []float32:
+		return "vector", "vector", len(v)
+	case []float64:
+		return "vector", "vector", len(v)
+	case []any:
+		if len(v) == 0 {
+			return "array", "string", 0
+		}
+		if allFloatLike(v) {
+			return "vector", "vector", len(v)
+		}
+		_, scalarType, _ = inferValueShape(v[0])
+		if scalarType == "vector" {
+			scalarType = "string"
+		}
+		return "array", scalarType, 0
+	case []string:
+		return "array", "string", 0
+	case []bool:
+		return "array", "boolean", 0
+	case []int:
+		return "array", "long", 0
+	case []int64:
+		return "array", "long", 0
+	case string:
+		return "property", "string", 0
+	case bool:
+		return "property", "boolean", 0
+	case int, int8, int16, int32, int64:
+		return "property", "long", 0
+	case uint, uint8, uint16, uint32, uint64:
+		return "property", "long", 0
+	case float32, float64:
+		return "property", "double", 0
+	case time.Time:
+		return "property", "datetime", 0
+	default:
+		rv := reflect.ValueOf(value)
+		if rv.IsValid() && rv.Kind() == reflect.Slice {
+			if rv.Len() == 0 {
+				return "array", "string", 0
+			}
+			if allFloatLikeReflect(rv) {
+				return "vector", "vector", rv.Len()
+			}
+			first := rv.Index(0).Interface()
+			_, inferredScalar, _ := inferValueShape(first)
+			if inferredScalar == "vector" {
+				inferredScalar = "string"
+			}
+			return "array", inferredScalar, 0
+		}
+		return "property", "string", 0
+	}
+}
+
+func sortColumns(cols map[string]inferredColumn) []inferredColumn {
+	keys := make([]string, 0, len(cols))
+	for key := range cols {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]inferredColumn, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, cols[key])
+	}
+	return out
+}
+
+func formatNodeColumnValue(node *storage.Node, col inferredColumn, opts Neo4jCSVExportOptions) string {
+	if col.Kind == "embedding" {
+		return formatVector(node.NamedEmbeddings[col.EmbedKey], opts.VectorDelimiter)
+	}
+	return formatPropertyValue(node.Properties[col.Property], col, opts)
+}
+
+func formatPropertyValue(value any, col inferredColumn, opts Neo4jCSVExportOptions) string {
+	if value == nil {
+		return ""
+	}
+	switch col.Kind {
+	case "vector":
+		switch v := value.(type) {
+		case []float32:
+			return formatVector(v, opts.VectorDelimiter)
+		case []float64:
+			parts := make([]string, 0, len(v))
+			for _, item := range v {
+				parts = append(parts, strconv.FormatFloat(item, 'f', -1, 64))
+			}
+			return strings.Join(parts, string(opts.VectorDelimiter))
+		case []any:
+			parts := make([]string, 0, len(v))
+			for _, item := range v {
+				parts = append(parts, formatScalar(item, "double"))
+			}
+			return strings.Join(parts, string(opts.VectorDelimiter))
+		default:
+			return fmt.Sprint(value)
+		}
+	case "array":
+		switch v := value.(type) {
+		case []any:
+			parts := make([]string, 0, len(v))
+			for _, item := range v {
+				parts = append(parts, formatScalar(item, col.ScalarType))
+			}
+			return strings.Join(parts, string(opts.ArrayDelimiter))
+		case []string:
+			return strings.Join(v, string(opts.ArrayDelimiter))
+		case []bool:
+			parts := make([]string, 0, len(v))
+			for _, item := range v {
+				parts = append(parts, formatScalar(item, col.ScalarType))
+			}
+			return strings.Join(parts, string(opts.ArrayDelimiter))
+		case []int:
+			parts := make([]string, 0, len(v))
+			for _, item := range v {
+				parts = append(parts, formatScalar(item, col.ScalarType))
+			}
+			return strings.Join(parts, string(opts.ArrayDelimiter))
+		case []int64:
+			parts := make([]string, 0, len(v))
+			for _, item := range v {
+				parts = append(parts, formatScalar(item, col.ScalarType))
+			}
+			return strings.Join(parts, string(opts.ArrayDelimiter))
+		default:
+			rv := reflect.ValueOf(value)
+			if rv.IsValid() && rv.Kind() == reflect.Slice {
+				parts := make([]string, 0, rv.Len())
+				for i := 0; i < rv.Len(); i++ {
+					parts = append(parts, formatScalar(rv.Index(i).Interface(), col.ScalarType))
+				}
+				return strings.Join(parts, string(opts.ArrayDelimiter))
+			}
+			return fmt.Sprint(value)
+		}
+	default:
+		return formatScalar(value, col.ScalarType)
+	}
+}
+
+func formatScalar(value any, scalarType string) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 64)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case time.Time:
+		if scalarType == "datetime" {
+			return v.UTC().Format(time.RFC3339Nano)
+		}
+		return v.String()
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func formatVector(vector []float32, delim rune) string {
+	parts := make([]string, 0, len(vector))
+	for _, item := range vector {
+		parts = append(parts, strconv.FormatFloat(float64(item), 'f', -1, 64))
+	}
+	return strings.Join(parts, string(delim))
+}
+
+func allFloatLike(values []any) bool {
+	for _, value := range values {
+		switch value.(type) {
+		case float32, float64:
+		default:
+			return false
+		}
+	}
+	return len(values) > 0
+}
+
+func allFloatLikeReflect(values reflect.Value) bool {
+	if !values.IsValid() || values.Kind() != reflect.Slice || values.Len() == 0 {
+		return false
+	}
+	for i := 0; i < values.Len(); i++ {
+		switch values.Index(i).Kind() {
+		case reflect.Float32, reflect.Float64:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func writeCSV(path string, header []string, rows [][]string, delimiter rune) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := csv.NewWriter(file)
+	writer.Comma = delimiter
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
+}
+
+func exportNornicSchemaDefinition(path string, schema *storage.SchemaManager) error {
+	if schema == nil {
+		return nil
+	}
+	def := schema.ExportDefinition()
+	if !hasSchemaDefinitionContent(def) {
+		return nil
+	}
+	data, err := json.MarshalIndent(def, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func hasSchemaDefinitionContent(def *storage.SchemaDefinition) bool {
+	if def == nil {
+		return false
+	}
+	return len(def.Constraints) > 0 ||
+		len(def.ConstraintContracts) > 0 ||
+		len(def.PropertyTypeConstraints) > 0 ||
+		len(def.PropertyIndexes) > 0 ||
+		len(def.CompositeIndexes) > 0 ||
+		len(def.FulltextIndexes) > 0 ||
+		len(def.VectorIndexes) > 0 ||
+		len(def.RangeIndexes) > 0 ||
+		len(def.DecayProfileBundles) > 0 ||
+		len(def.DecayProfileBindings) > 0 ||
+		len(def.PromotionProfiles) > 0 ||
+		len(def.PromotionPolicies) > 0
+}
+
+func exportSchemaCypher(path string, schema *storage.SchemaManager) error {
+	if schema == nil {
+		return nil
+	}
+	statements := make([]string, 0)
+	for _, constraint := range schema.GetAllConstraints() {
+		if stmt, ok := renderConstraintStatement(constraint); ok {
+			statements = append(statements, stmt)
+		}
+	}
+	for _, typeConstraint := range schema.GetAllPropertyTypeConstraints() {
+		if stmt, ok := renderPropertyTypeConstraintStatement(typeConstraint); ok {
+			statements = append(statements, stmt)
+		}
+	}
+	for _, index := range schema.GetIndexes() {
+		if stmt, ok := renderIndexStatement(index); ok {
+			statements = append(statements, stmt)
+		}
+	}
+	if len(statements) == 0 {
+		return nil
+	}
+	sort.Strings(statements)
+	contents := strings.Join(statements, ";\n") + ";\n"
+	return os.WriteFile(path, []byte(contents), 0o600)
+}
+
+func renderConstraintStatement(c storage.Constraint) (string, bool) {
+	entity := c.EffectiveEntityType()
+	props := cypherPropertyRefs(entityVariable(entity), c.Properties)
+	var pattern string
+	var requirement string
+	switch c.Type {
+	case storage.ConstraintUnique:
+		if len(props) != 1 {
+			return "", false
+		}
+		pattern = cypherPattern(entity, c.Label)
+		requirement = props[0] + " IS UNIQUE"
+	case storage.ConstraintNodeKey:
+		pattern = cypherPattern(entity, c.Label)
+		requirement = "(" + strings.Join(props, ", ") + ") IS NODE KEY"
+	case storage.ConstraintExists:
+		if len(props) != 1 {
+			return "", false
+		}
+		pattern = cypherPattern(entity, c.Label)
+		requirement = props[0] + " IS NOT NULL"
+	case storage.ConstraintRelationshipKey:
+		pattern = cypherPattern(entity, c.Label)
+		requirement = "(" + strings.Join(props, ", ") + ") IS RELATIONSHIP KEY"
+	case storage.ConstraintTemporal:
+		pattern = cypherPattern(entity, c.Label)
+		requirement = "(" + strings.Join(props, ", ") + ") IS TEMPORAL NO OVERLAP"
+	case storage.ConstraintDomain:
+		if len(props) != 1 {
+			return "", false
+		}
+		pattern = cypherPattern(entity, c.Label)
+		requirement = props[0] + " IN [" + strings.Join(formatConstraintValues(c.AllowedValues), ", ") + "]"
+	case storage.ConstraintCardinality:
+		if entity != storage.ConstraintEntityRelationship {
+			return "", false
+		}
+		pattern = cypherRelationshipPattern(c.Label, c.Direction, "", "")
+		requirement = fmt.Sprintf("MAX COUNT %d", c.MaxCount)
+	case storage.ConstraintPolicy:
+		if entity != storage.ConstraintEntityRelationship {
+			return "", false
+		}
+		pattern = cypherRelationshipPattern(c.Label, "OUTGOING", c.SourceLabel, c.TargetLabel)
+		requirement = c.PolicyMode
+	default:
+		return "", false
+	}
+	return fmt.Sprintf("CREATE CONSTRAINT %s IF NOT EXISTS FOR %s REQUIRE %s", quoteCypherIdent(c.Name), pattern, requirement), true
+}
+
+func renderPropertyTypeConstraintStatement(c storage.PropertyTypeConstraint) (string, bool) {
+	entity := c.EffectiveEntityType()
+	pattern := cypherPattern(entity, c.Label)
+	ref := entityVariable(entity) + "." + quoteCypherIdent(c.Property)
+	return fmt.Sprintf("CREATE CONSTRAINT %s IF NOT EXISTS FOR %s REQUIRE %s IS :: %s", quoteCypherIdent(c.Name), pattern, ref, c.ExpectedType), true
+}
+
+func renderIndexStatement(index any) (string, bool) {
+	m, ok := index.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	name, _ := m["name"].(string)
+	typ, _ := m["type"].(string)
+	label, _ := m["label"].(string)
+	switch typ {
+	case "PROPERTY", "COMPOSITE":
+		properties := stringSliceValue(m["properties"])
+		if len(properties) == 0 {
+			return "", false
+		}
+		return fmt.Sprintf("CREATE INDEX %s IF NOT EXISTS FOR %s ON (%s)", quoteCypherIdent(name), cypherPattern(storage.ConstraintEntityNode, label), strings.Join(cypherPropertyRefs("n", properties), ", ")), true
+	case "RANGE":
+		if owning, _ := m["owningConstraint"].(string); owning != "" {
+			return "", false
+		}
+		entityType, _ := m["entityType"].(string)
+		properties := stringSliceValue(m["properties"])
+		if len(properties) == 0 {
+			if property, _ := m["property"].(string); property != "" {
+				properties = []string{property}
+			}
+		}
+		if len(properties) == 0 {
+			return "", false
+		}
+		entity := storage.ConstraintEntityNode
+		if entityType == string(storage.ConstraintEntityRelationship) {
+			entity = storage.ConstraintEntityRelationship
+		}
+		return fmt.Sprintf("CREATE INDEX %s IF NOT EXISTS FOR %s ON (%s)", quoteCypherIdent(name), cypherPattern(entity, label), strings.Join(cypherPropertyRefs(entityVariable(entity), properties), ", ")), true
+	case "FULLTEXT":
+		properties := stringSliceValue(m["properties"])
+		labels := stringSliceValue(m["labels"])
+		if len(properties) == 0 {
+			return "", false
+		}
+		if len(labels) > 0 {
+			parts := make([]string, 0, len(labels))
+			for _, item := range labels {
+				parts = append(parts, quoteCypherIdent(item))
+			}
+			return fmt.Sprintf("CREATE FULLTEXT INDEX %s IF NOT EXISTS FOR (n:%s) ON EACH [%s]", quoteCypherIdent(name), strings.Join(parts, "|"), strings.Join(cypherPropertyRefs("n", properties), ", ")), true
+		}
+		return "", false
+	case "VECTOR":
+		property, _ := m["property"].(string)
+		dimensions, _ := m["dimensions"].(int)
+		if dimensions == 0 {
+			if value, ok := m["dimensions"].(float64); ok {
+				dimensions = int(value)
+			}
+		}
+		similarity, _ := m["similarityFunc"].(string)
+		if property == "" || label == "" || dimensions == 0 {
+			return "", false
+		}
+		options := fmt.Sprintf("OPTIONS {indexConfig: {`vector.dimensions`: %d", dimensions)
+		if similarity != "" {
+			options += fmt.Sprintf(", `vector.similarity_function`: '%s'", strings.ToLower(similarity))
+		}
+		options += "}}"
+		return fmt.Sprintf("CREATE VECTOR INDEX %s IF NOT EXISTS FOR %s ON (%s) %s", quoteCypherIdent(name), cypherPattern(storage.ConstraintEntityNode, label), strings.Join(cypherPropertyRefs("n", []string{property}), ", "), options), true
+	default:
+		return "", false
+	}
+}
+
+func cypherPattern(entity storage.ConstraintEntityType, label string) string {
+	if entity == storage.ConstraintEntityRelationship {
+		return fmt.Sprintf("()-[r:%s]-()", quoteCypherIdent(label))
+	}
+	return fmt.Sprintf("(n:%s)", quoteCypherIdent(label))
+}
+
+func cypherRelationshipPattern(label, direction, sourceLabel, targetLabel string) string {
+	left := "()"
+	right := "()"
+	if sourceLabel != "" {
+		left = fmt.Sprintf("(:%s)", quoteCypherIdent(sourceLabel))
+	}
+	if targetLabel != "" {
+		right = fmt.Sprintf("(:%s)", quoteCypherIdent(targetLabel))
+	}
+	switch strings.ToUpper(direction) {
+	case "INCOMING":
+		return fmt.Sprintf("%s<-[r:%s]-%s", left, quoteCypherIdent(label), right)
+	default:
+		return fmt.Sprintf("%s-[r:%s]->%s", left, quoteCypherIdent(label), right)
+	}
+}
+
+func entityVariable(entity storage.ConstraintEntityType) string {
+	if entity == storage.ConstraintEntityRelationship {
+		return "r"
+	}
+	return "n"
+}
+
+func cypherPropertyRefs(variable string, properties []string) []string {
+	refs := make([]string, 0, len(properties))
+	for _, property := range properties {
+		refs = append(refs, variable+"."+quoteCypherIdent(property))
+	}
+	return refs
+}
+
+func quoteCypherIdent(value string) string {
+	return "`" + strings.ReplaceAll(value, "`", "``") + "`"
+}
+
+func formatConstraintValues(values []interface{}) []string {
+	formatted := make([]string, 0, len(values))
+	for _, value := range values {
+		switch v := value.(type) {
+		case string:
+			formatted = append(formatted, "'"+strings.ReplaceAll(v, "'", "\\'")+"'")
+		case bool:
+			formatted = append(formatted, formatScalar(v, "boolean"))
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			formatted = append(formatted, formatScalar(v, "double"))
+		default:
+			formatted = append(formatted, "'"+strings.ReplaceAll(fmt.Sprint(v), "'", "\\'")+"'")
+		}
+	}
+	return formatted
+}
+
+func stringSliceValue(value interface{}) []string {
+	slice, ok := value.([]string)
+	if ok {
+		return slice
+	}
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			result = append(result, text)
+		}
+	}
+	return result
+}
+
+func isCSVLikePath(path string) bool {
+	return strings.HasSuffix(path, ".csv") || strings.HasSuffix(path, ".csv.gz") || strings.HasSuffix(path, ".zip")
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/pkg/adminimport/neo4j_csv.go
+++ b/pkg/adminimport/neo4j_csv.go
@@ -470,7 +470,7 @@ func allFloatLikeReflect(values reflect.Value) bool {
 }
 
 func writeCSV(path string, header []string, rows [][]string, delimiter rune) error {
-	file, err := os.Create(path)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/adminimport/neo4j_csv.go
+++ b/pkg/adminimport/neo4j_csv.go
@@ -194,7 +194,9 @@ func inferNodeColumns(nodes []*storage.Node) []inferredColumn {
 	for _, node := range nodes {
 		for key, value := range node.Properties {
 			if key == "id" {
-				continue
+				if s, ok := value.(string); ok && s == string(node.ID) {
+					continue
+				}
 			}
 			props[key] = mergeColumn(props[key], key, value)
 		}

--- a/pkg/cypher/call_compat.go
+++ b/pkg/cypher/call_compat.go
@@ -483,7 +483,7 @@ func (e *StorageExecutor) callDbIndexVectorCreateNodeIndex(ctx context.Context, 
 
 	// Create vector index using schema manager
 	schema := e.storage.GetSchema()
-	err := schema.AddVectorIndex(indexName, label, property, dimension, similarity)
+	err := schema.AddVectorIndexForEntity(indexName, label, property, dimension, similarity, storage.ConstraintEntityNode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create vector index: %w", err)
 	}
@@ -534,7 +534,7 @@ func (e *StorageExecutor) callDbIndexVectorCreateRelationshipIndex(ctx context.C
 	// Create vector index on relationships using schema manager
 	schema := e.storage.GetSchema()
 	// Use relationship type as "label" for index naming
-	err = schema.AddVectorIndex(indexName, relType, property, dimension, similarity)
+	err = schema.AddVectorIndexForEntity(indexName, relType, property, dimension, similarity, storage.ConstraintEntityRelationship)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create relationship vector index: %w", err)
 	}

--- a/pkg/cypher/executor_match_vector_cosine_fastpath.go
+++ b/pkg/cypher/executor_match_vector_cosine_fastpath.go
@@ -95,7 +95,7 @@ func (e *StorageExecutor) tryFastPathMatchVectorCosine(ctx context.Context, cyph
 		return &ExecuteResult{Columns: columns, Rows: [][]interface{}{}, Stats: &QueryStats{}}, true
 	}
 
-	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), label, vectorProp)
+	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), label, vectorProp, storage.ConstraintEntityNode)
 	if !hasIndex {
 		return nil, false
 	}
@@ -252,7 +252,7 @@ func (e *StorageExecutor) tryFastPathMatchWithVectorCosineProjection(ctx context
 		return &ExecuteResult{Columns: columns, Rows: [][]interface{}{}, Stats: &QueryStats{}}, true
 	}
 
-	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), label, vectorProp)
+	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), label, vectorProp, storage.ConstraintEntityNode)
 	if !hasIndex {
 		return nil, false
 	}
@@ -373,7 +373,7 @@ func (e *StorageExecutor) tryFastPathMatchRelationshipVectorCosine(ctx context.C
 		return &ExecuteResult{Columns: columns, Rows: [][]interface{}{}, Stats: &QueryStats{}}, true
 	}
 
-	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), pattern.relType, vectorProp)
+	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), pattern.relType, vectorProp, storage.ConstraintEntityRelationship)
 	if !hasIndex {
 		return nil, false
 	}
@@ -522,7 +522,7 @@ func (e *StorageExecutor) tryFastPathMatchWithRelationshipVectorCosineProjection
 		return &ExecuteResult{Columns: columns, Rows: [][]interface{}{}, Stats: &QueryStats{}}, true
 	}
 
-	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), pattern.relType, vectorProp)
+	indexName, hasIndex := findCosineVectorIndexName(e.storage.GetSchema(), pattern.relType, vectorProp, storage.ConstraintEntityRelationship)
 	if !hasIndex {
 		return nil, false
 	}
@@ -842,9 +842,12 @@ func parseFastPathLimit(ctx context.Context, limitPart string) (int, bool) {
 	return limit, true
 }
 
-func findCosineVectorIndexName(schema *storage.SchemaManager, label string, property string) (string, bool) {
+func findCosineVectorIndexName(schema *storage.SchemaManager, label string, property string, entityType storage.ConstraintEntityType) (string, bool) {
 	if schema == nil {
 		return "", false
+	}
+	if entityType == "" {
+		entityType = storage.ConstraintEntityNode
 	}
 	indexes := schema.GetIndexes()
 	matches := make([]string, 0, 2)
@@ -863,6 +866,13 @@ func findCosineVectorIndexName(schema *storage.SchemaManager, label string, prop
 		}
 		idxProp, _ := idx["property"].(string)
 		if !strings.EqualFold(strings.TrimSpace(idxProp), strings.TrimSpace(property)) {
+			continue
+		}
+		idxEntityType, _ := idx["entityType"].(string)
+		if idxEntityType == "" {
+			idxEntityType = string(storage.ConstraintEntityNode)
+		}
+		if !strings.EqualFold(strings.TrimSpace(idxEntityType), string(entityType)) {
 			continue
 		}
 

--- a/pkg/cypher/executor_match_vector_cosine_fastpath.go
+++ b/pkg/cypher/executor_match_vector_cosine_fastpath.go
@@ -600,11 +600,6 @@ func (e *StorageExecutor) fetchCosineNodeScores(ctx context.Context, indexName s
 	if !ok || len(queryVector) == 0 {
 		return nil, false
 	}
-	if !orderDesc {
-		for i := range queryVector {
-			queryVector[i] = -queryVector[i]
-		}
-	}
 
 	var targetLabel, targetProperty string
 	similarityFunc := "cosine"
@@ -624,6 +619,9 @@ func (e *StorageExecutor) fetchCosineNodeScores(ctx context.Context, indexName s
 	}
 	if wantDims <= 0 {
 		wantDims = search.DefaultVectorDimensions
+	}
+	if !orderDesc {
+		return e.fetchCosineNodeScoresExact(ctx, targetLabel, targetProperty, similarityFunc, limit, queryVector, orderDesc, wantDims)
 	}
 	if e.searchService != nil && !e.searchService.VectorEnabled() {
 		return []vectorNodeScore{}, true
@@ -654,12 +652,120 @@ func (e *StorageExecutor) fetchCosineNodeScores(ctx context.Context, indexName s
 			continue
 		}
 		score := hit.Score
-		if !orderDesc {
-			score = -score
+		if strings.EqualFold(similarityFunc, "cosine") {
+			score = clampCosineFastPathScore(score)
 		}
 		out = append(out, vectorNodeScore{node: node, score: score})
 	}
 	return out, true
+}
+
+func (e *StorageExecutor) fetchCosineNodeScoresExact(ctx context.Context, label string, property string, similarity string, limit int, queryVector []float32, orderDesc bool, wantDims int) ([]vectorNodeScore, bool) {
+	if limit <= 0 {
+		return []vectorNodeScore{}, true
+	}
+	if wantDims > 0 && len(queryVector) != wantDims {
+		return []vectorNodeScore{}, true
+	}
+	nodes, err := e.storage.GetNodesByLabel(label)
+	if err != nil {
+		return nil, false
+	}
+	out := make([]vectorNodeScore, 0, min(limit, len(nodes)))
+	for _, node := range nodes {
+		select {
+		case <-ctx.Done():
+			return nil, false
+		default:
+		}
+		score, ok := scoreNodeVectorForFastPath(node, property, similarity, queryVector)
+		if !ok {
+			continue
+		}
+		out = append(out, vectorNodeScore{node: node, score: score})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].score == out[j].score {
+			return string(out[i].node.ID) < string(out[j].node.ID)
+		}
+		if orderDesc {
+			return out[i].score > out[j].score
+		}
+		return out[i].score < out[j].score
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, true
+}
+
+func scoreNodeVectorForFastPath(node *storage.Node, property string, similarity string, queryVector []float32) (float64, bool) {
+	if node == nil {
+		return 0, false
+	}
+	vectorName := property
+	if vectorName == "" {
+		vectorName = "default"
+	}
+
+	bestScore := -2.0
+	if node.NamedEmbeddings != nil {
+		if embedding, ok := node.NamedEmbeddings[vectorName]; ok {
+			if score, ok := scoreVectorForFastPath(queryVector, embedding, similarity); ok {
+				bestScore = score
+			}
+		}
+		if bestScore < -1.0 && property == "" {
+			for _, embedding := range node.NamedEmbeddings {
+				if score, ok := scoreVectorForFastPath(queryVector, embedding, similarity); ok && score > bestScore {
+					bestScore = score
+				}
+			}
+		}
+	}
+
+	if bestScore < -1.0 && property != "" && node.Properties != nil {
+		if score, ok := scoreVectorForFastPath(queryVector, toFloat32Slice(node.Properties[property]), similarity); ok {
+			bestScore = score
+		}
+	}
+
+	if bestScore < -1.0 {
+		for _, embedding := range node.ChunkEmbeddings {
+			if score, ok := scoreVectorForFastPath(queryVector, embedding, similarity); ok && score > bestScore {
+				bestScore = score
+			}
+		}
+	}
+
+	if bestScore < -1.0 {
+		return 0, false
+	}
+	return bestScore, true
+}
+
+func scoreVectorForFastPath(queryVector []float32, embedding []float32, similarity string) (float64, bool) {
+	if len(embedding) == 0 || len(embedding) != len(queryVector) {
+		return 0, false
+	}
+	switch strings.ToLower(strings.TrimSpace(similarity)) {
+	case "euclidean":
+		return vector.EuclideanSimilarity(queryVector, embedding), true
+	case "dot":
+		return vector.DotProduct(queryVector, embedding), true
+	default:
+		return clampCosineFastPathScore(vector.CosineSimilarity(queryVector, embedding)), true
+	}
+}
+
+func clampCosineFastPathScore(score float64) float64 {
+	if score > 1.0 {
+		return 1.0
+	}
+	if score < -1.0 {
+		return -1.0
+	}
+	return score
 }
 
 func (e *StorageExecutor) fetchCosineRelationshipScores(ctx context.Context, indexName string, limit int, queryExpr string, orderDesc bool) ([]vectorEdgeScore, bool) {
@@ -699,7 +805,7 @@ func (e *StorageExecutor) fetchCosineRelationshipScores(ctx context.Context, ind
 		case "dot":
 			score = vector.DotProduct(vec, embedding)
 		default:
-			score = vector.CosineSimilarity(vec, embedding)
+			score = clampCosineFastPathScore(vector.CosineSimilarity(vec, embedding))
 		}
 		out = append(out, vectorEdgeScore{edge: edge, score: score})
 	}

--- a/pkg/cypher/executor_match_vector_cosine_fastpath_test.go
+++ b/pkg/cypher/executor_match_vector_cosine_fastpath_test.go
@@ -236,3 +236,17 @@ LIMIT $k`
 
 	require.Equal(t, 0, counting.allNodesCalls)
 }
+
+func TestFindCosineVectorIndexName_DisambiguatesByEntityType(t *testing.T) {
+	schema := storage.NewSchemaManager()
+	require.NoError(t, schema.AddVectorIndexForEntity("a_rel_idx", "Thing", "emb", 3, "cosine", storage.ConstraintEntityRelationship))
+	require.NoError(t, schema.AddVectorIndexForEntity("z_node_idx", "Thing", "emb", 3, "cosine", storage.ConstraintEntityNode))
+
+	nodeIndex, ok := findCosineVectorIndexName(schema, "Thing", "emb", storage.ConstraintEntityNode)
+	require.True(t, ok)
+	require.Equal(t, "z_node_idx", nodeIndex)
+
+	relIndex, ok := findCosineVectorIndexName(schema, "Thing", "emb", storage.ConstraintEntityRelationship)
+	require.True(t, ok)
+	require.Equal(t, "a_rel_idx", relIndex)
+}

--- a/pkg/cypher/schema.go
+++ b/pkg/cypher/schema.go
@@ -2462,7 +2462,11 @@ func (e *StorageExecutor) executeCreateVectorIndex(ctx context.Context, cypher s
 	// space is only registered when vector search is enabled — otherwise
 	// the operator explicitly turned vector indexing off and we must not
 	// allocate or warm any vector backend on their behalf.
-	if err := e.storage.GetSchema().AddVectorIndex(indexName, label, property, dimensions, similarityFunc); err != nil {
+	entityType := storage.ConstraintEntityNode
+	if parsed.isRelationship {
+		entityType = storage.ConstraintEntityRelationship
+	}
+	if err := e.storage.GetSchema().AddVectorIndexForEntity(indexName, label, property, dimensions, similarityFunc, entityType); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nornicdb/embed_query_chunk_test.go
+++ b/pkg/nornicdb/embed_query_chunk_test.go
@@ -170,27 +170,29 @@ func TestDB_EmbedQuery_LongQuery_UsesFirstChunkForCompatibility(t *testing.T) {
 }
 
 func TestDB_EmbedQueryChunks_LongQuery_ReturnsChunkEmbeddings(t *testing.T) {
-	emb := &chunkingTestEmbedder{dims: 4}
+	emb := &deterministicChunkEmbedder{
+		dims: 4,
+		chunks: []string{
+			"first chunk",
+			"second chunk",
+		},
+	}
 	db := &DB{embedQueue: &EmbedQueue{embedder: emb}}
 
-	longQuery := loadLargeDocQuery(t)
-	chunks, embs, err := db.EmbedQueryChunks(context.Background(), longQuery)
+	chunks, embs, err := db.EmbedQueryChunks(context.Background(), "long query")
 	require.NoError(t, err)
-	require.Greater(t, len(chunks), 1)
+	require.Equal(t, []string{"first chunk", "second chunk"}, chunks)
 	require.Len(t, embs, len(chunks))
 	for _, vec := range embs {
 		require.Len(t, vec, 4)
 	}
 
 	emb.mu.Lock()
-	embedCalls := emb.embedCalls
-	batchCalls := emb.embedBatchCall
-	maxTokens := emb.maxTokens
+	batchCalls := append([][]string(nil), emb.batchCalls...)
 	emb.mu.Unlock()
 
-	require.Equal(t, 0, embedCalls, "expected long query path to avoid single-text embedding")
-	require.Equal(t, 1, batchCalls, "expected long query path to batch-embed chunks once")
-	require.LessOrEqual(t, maxTokens, 512, "expected all embedded chunks to be <= 512 tokens")
+	require.Len(t, batchCalls, 1, "expected multi-chunk query path to batch-embed chunks once")
+	require.Equal(t, chunks, batchCalls[0])
 }
 
 func TestDB_EmbedQueryForDB_NoResolver_ReturnsSameAsEmbedQuery(t *testing.T) {

--- a/pkg/storage/composite_engine.go
+++ b/pkg/storage/composite_engine.go
@@ -1058,9 +1058,12 @@ func (c *CompositeEngine) GetSchema() *SchemaManager {
 						}
 					case "FULLTEXT":
 						labels := anyToStringSlice(idxMap["labels"])
+						relationshipTypes := anyToStringSlice(idxMap["relationshipTypes"])
 						properties := anyToStringSlice(idxMap["properties"])
 						if len(labels) > 0 && len(properties) > 0 {
 							_ = mergedSchema.AddFulltextIndex(idxName, labels, properties)
+						} else if len(relationshipTypes) > 0 && len(properties) > 0 {
+							_ = mergedSchema.AddFulltextRelationshipIndex(idxName, relationshipTypes, properties)
 						}
 					case "VECTOR":
 						if label, ok := idxMap["label"].(string); ok {
@@ -1075,7 +1078,11 @@ func (c *CompositeEngine) GetSchema() *SchemaManager {
 								if sim, ok := idxMap["similarityFunc"].(string); ok {
 									similarityFunc = sim
 								}
-								_ = mergedSchema.AddVectorIndex(idxName, label, property, dimensions, similarityFunc)
+								entityType := ConstraintEntityNode
+								if etRaw, ok := idxMap["entityType"].(string); ok && strings.EqualFold(etRaw, string(ConstraintEntityRelationship)) {
+									entityType = ConstraintEntityRelationship
+								}
+								_ = mergedSchema.AddVectorIndexForEntity(idxName, label, property, dimensions, similarityFunc, entityType)
 							}
 						}
 					case "RANGE":

--- a/pkg/storage/constraint_contracts_engine_test.go
+++ b/pkg/storage/constraint_contracts_engine_test.go
@@ -49,6 +49,35 @@ func TestEvaluateNodeConstraintContractExpressionEngine_PropertyIn_False(t *test
 	require.False(t, got)
 }
 
+func TestEvaluateNodeConstraintContractExpressionEngine_PropertyComparison(t *testing.T) {
+	engine := constraintContractsEngineFixture(t)
+	node := &Node{
+		ID:     "test:n1",
+		Labels: []string{"Person"},
+		Properties: map[string]any{
+			"name":  "Alice",
+			"score": int64(75),
+		},
+	}
+
+	for _, c := range []struct {
+		expr string
+		want bool
+	}{
+		{"n.score > 50", true},
+		{"n.score < 50", false},
+		{"n.score >= 75", true},
+		{"n.score <= 50", false},
+		{"n.name = 'Alice'", true},
+		{"n.name <> ''", true},
+		{"n.name <> 'Alice'", false},
+	} {
+		got, err := evaluateNodeConstraintContractExpressionEngine(engine, node, c.expr)
+		require.NoError(t, err, "expr=%q", c.expr)
+		require.Equal(t, c.want, got, "expr=%q", c.expr)
+	}
+}
+
 func TestEvaluateNodeConstraintContractExpressionEngine_CountPattern(t *testing.T) {
 	engine := constraintContractsEngineFixture(t)
 	// Set up alice with 3 outgoing OWNS edges.

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -504,6 +504,7 @@ type VectorIndex struct {
 	Property       string
 	Dimensions     int
 	SimilarityFunc string // "cosine", "euclidean", "dot"
+	EntityType     ConstraintEntityType
 }
 
 // RangeIndex represents an index for range queries on a single property.
@@ -1225,11 +1226,19 @@ func (sm *SchemaManager) AddFulltextRelationshipIndex(name string, relTypes, pro
 
 // AddVectorIndex adds a vector index.
 func (sm *SchemaManager) AddVectorIndex(name, label, property string, dimensions int, similarityFunc string) error {
+	return sm.AddVectorIndexForEntity(name, label, property, dimensions, similarityFunc, ConstraintEntityNode)
+}
+
+// AddVectorIndexForEntity adds a vector index scoped to a node label or relationship type.
+func (sm *SchemaManager) AddVectorIndexForEntity(name, label, property string, dimensions int, similarityFunc string, entityType ConstraintEntityType) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	if _, exists := sm.vectorIndexes[name]; exists {
 		return nil // Already exists
+	}
+	if entityType == "" {
+		entityType = ConstraintEntityNode
 	}
 
 	sm.vectorIndexes[name] = &VectorIndex{
@@ -1238,6 +1247,7 @@ func (sm *SchemaManager) AddVectorIndex(name, label, property string, dimensions
 		Property:       property,
 		Dimensions:     dimensions,
 		SimilarityFunc: similarityFunc,
+		EntityType:     entityType,
 	}
 
 	if sm.persist != nil {
@@ -1770,10 +1780,11 @@ func (sm *SchemaManager) GetIndexes() []interface{} {
 
 	for _, idx := range sm.fulltextIndexes {
 		indexes = append(indexes, map[string]interface{}{
-			"name":       idx.Name,
-			"type":       "FULLTEXT",
-			"labels":     idx.Labels,
-			"properties": idx.Properties,
+			"name":              idx.Name,
+			"type":              "FULLTEXT",
+			"labels":            idx.Labels,
+			"relationshipTypes": idx.RelationshipTypes,
+			"properties":        idx.Properties,
 		})
 	}
 
@@ -1785,6 +1796,7 @@ func (sm *SchemaManager) GetIndexes() []interface{} {
 			"property":       idx.Property,
 			"dimensions":     idx.Dimensions,
 			"similarityFunc": idx.SimilarityFunc,
+			"entityType":     string(defaultConstraintEntityType(idx.EntityType)),
 		})
 	}
 
@@ -1812,6 +1824,13 @@ func (sm *SchemaManager) GetIndexes() []interface{} {
 	}
 
 	return indexes
+}
+
+func defaultConstraintEntityType(entityType ConstraintEntityType) ConstraintEntityType {
+	if entityType == "" {
+		return ConstraintEntityNode
+	}
+	return entityType
 }
 
 // GetVectorIndex returns a vector index by name.

--- a/pkg/storage/schema_persistence.go
+++ b/pkg/storage/schema_persistence.go
@@ -208,6 +208,7 @@ func (sm *SchemaManager) exportDefinitionLocked() *SchemaDefinition {
 				Property:       idx.Property,
 				Dimensions:     idx.Dimensions,
 				SimilarityFunc: idx.SimilarityFunc,
+				EntityType:     defaultConstraintEntityType(idx.EntityType),
 			})
 		}
 		sort.Slice(def.VectorIndexes, func(i, j int) bool {
@@ -442,6 +443,7 @@ func (sm *SchemaManager) replaceFromDefinitionLocked(def *SchemaDefinition) erro
 			Property:       idx.Property,
 			Dimensions:     idx.Dimensions,
 			SimilarityFunc: idx.SimilarityFunc,
+			EntityType:     defaultConstraintEntityType(idx.EntityType),
 		}
 	}
 


### PR DESCRIPTION
#171

## Summary

This PR improves Neo4j-compatibility and operational correctness for `nornicdb-admin` import/export, and fixes a cosine fast-path index-selection bug.

### Admin import/export updates
- Add/verify official `nornicdb-admin` bulk import docs and operational scenarios.
- Preflight source files before writes for clearer fail-fast behavior.
- Preserve relationship `:ID` values during import/export (`relationships.csv` now includes `:ID` round-trip).
- Enforce duplicate relationship ID detection with deterministic `ExitDuplicateID` behavior.
- Improve CLI exit-code propagation by mapping typed admin-import errors instead of collapsing to generic exit code `1`.
- Export schema DDL for relationship fulltext/vector index forms.
- Preserve real node property `id` on Neo4j CSV export (only skipped when it exactly matches internal `node.ID`).

### Cypher/vector correctness updates
- Persist and carry vector index `entityType` metadata (`NODE` vs `RELATIONSHIP`) through schema paths.
- Make cosine fast-path index lookup entity-type aware to avoid wrong index selection when label/property overlap.
- Add regression tests for entity-type disambiguation and relationship-ID duplicate handling.

## Example Usage

Basic import:

```bash
nornicdb-admin database import full mydb \
  --nodes=Person=people.csv \
  --relationships=KNOWS=relationships.csv \
  --data-dir=./data \
  --schema=./schema.cypher \
  --report-file=./import-report.json
  ```
Multi-file source import:
```
nornicdb-admin database import full mydb \
  --nodes=Person=people-header.csv,people-part-2.csv \
  --relationships=WORKS_AT=works-at-header.csv,works-at-part-2.csv
```
Separate databases in the same storage directory:
```
nornicdb-admin database import full alpha --nodes=Person=alpha.csv --data-dir=./data
nornicdb-admin database import full beta --nodes=Person=beta.csv --data-dir=./data
```

Notes
`--from-path` schema auto-discovery now documented as: prefer `schema.nornic.json`, fallback to `schema.cypher` (unless `--schema` is provided).
Re-importing into the same namespace is rejected because the database is no longer empty.
Duplicate relationship IDs now fail with typed duplicate-ID semantics instead of ambiguous generic failures.
