### PR TITLE
fix(config,cypher): honor async YAML settings

### DIFF
--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -386,11 +386,11 @@ Current behavior:
 ```yaml
 # === Async Write Settings ===
 # These control the async write-behind cache for better throughput
-async_writes:
-  enabled: true # Enable async writes (default: true)
-  flush_interval: 50ms # How often to flush pending writes
-  max_node_cache_size: 50000 # Max nodes to buffer before forcing flush
-  max_edge_cache_size: 100000 # Max edges to buffer before forcing flush
+database:
+  async_writes_enabled: true # Enable async writes (default: true)
+  async_flush_interval: 50ms # How often to flush pending writes
+  async_max_node_cache_size: 50000 # Max nodes to buffer before forcing flush
+  async_max_edge_cache_size: 100000 # Max edges to buffer before forcing flush
 ```
 
 ### Environment Variables
@@ -407,28 +407,28 @@ async_writes:
 **For High Throughput (bulk operations):**
 
 ```yaml
-async_writes:
-  enabled: true
-  flush_interval: 200ms # Larger = better throughput
-  max_node_cache_size: 100000 # Increase for bulk inserts
-  max_edge_cache_size: 200000
+database:
+  async_writes_enabled: true
+  async_flush_interval: 200ms # Larger = better throughput
+  async_max_node_cache_size: 100000 # Increase for bulk inserts
+  async_max_edge_cache_size: 200000
 ```
 
 **For Lower Staleness Window (still eventual consistency):**
 
 ```yaml
-async_writes:
-  enabled: true
-  flush_interval: 10ms # Smaller = more consistent
-  max_node_cache_size: 1000 # Smaller = less memory risk
-  max_edge_cache_size: 2000
+database:
+  async_writes_enabled: true
+  async_flush_interval: 10ms # Smaller = more consistent
+  async_max_node_cache_size: 1000 # Smaller = less memory risk
+  async_max_edge_cache_size: 2000
 ```
 
 **For Maximum Durability:**
 
 ```yaml
-async_writes:
-  enabled: false # Disable async writes
+database:
+  async_writes_enabled: false # Disable async writes
 ```
 
 With `enabled: true`, do not assume every mutation becomes eventual. The setting enables the async write-behind engine and lets eligible queries use it; durable transactional mutations still return `200 OK` and include `receipt` metadata.
@@ -977,9 +977,9 @@ NornicDB validates configuration on startup and will:
 
 | Setting                | Impact                               | Recommendation            |
 | ---------------------- | ------------------------------------ | ------------------------- |
-| `enabled: true`        | 3-10x write throughput improvement   | Enable for most workloads |
-| `flush_interval: 50ms` | Balance of consistency vs throughput | Default works well        |
-| `cache_size: 50000`    | Memory usage vs bulk performance     | Adjust based on RAM       |
+| `async_writes_enabled: true`        | 3-10x write throughput improvement   | Enable for most workloads |
+| `async_flush_interval: 50ms` | Balance of consistency vs throughput | Default works well        |
+| `async_max_node_cache_size: 50000`    | Memory usage vs bulk performance     | Adjust based on RAM       |
 
 ### Search Similarity
 
@@ -995,13 +995,13 @@ NornicDB validates configuration on startup and will:
 
 **High memory usage:**
 
-- Reduce `max_node_cache_size` and `max_edge_cache_size`
+- Reduce `async_max_node_cache_size` and `async_max_edge_cache_size`
 - Monitor during bulk operations
 - Consider disabling async writes for memory-constrained environments
 
 **Stale data reads:**
 
-- Reduce `flush_interval` for more frequent writes
+- Reduce `async_flush_interval` for more frequent writes
 - Disable async writes if strong consistency is required
 - Monitor WAL size and compaction
 
@@ -1031,11 +1031,11 @@ curl http://localhost:7474/metrics | grep search
 ### Development Environment
 
 ```yaml
-async_writes:
-  enabled: true
-  flush_interval: 10ms # Fast feedback
-  max_node_cache_size: 1000
-  max_edge_cache_size: 2000
+database:
+  async_writes_enabled: true
+  async_flush_interval: 10ms # Fast feedback
+  async_max_node_cache_size: 1000
+  async_max_edge_cache_size: 2000
 
 search:
   min_similarity: 0.3 # More results for testing
@@ -1044,11 +1044,11 @@ search:
 ### Production High-Throughput
 
 ```yaml
-async_writes:
-  enabled: true
-  flush_interval: 100ms # Better throughput
-  max_node_cache_size: 100000
-  max_edge_cache_size: 200000
+database:
+  async_writes_enabled: true
+  async_flush_interval: 100ms # Better throughput
+  async_max_node_cache_size: 100000
+  async_max_edge_cache_size: 200000
 
 search:
   min_similarity: 0.7 # Higher precision
@@ -1057,11 +1057,11 @@ search:
 ### Memory-Constrained
 
 ```yaml
-async_writes:
-  enabled: false # Disable to save memory
+database:
+  async_writes_enabled: false # Disable to save memory
   # or small cache sizes:
-  # max_node_cache_size: 500
-  # max_edge_cache_size: 1000
+  # async_max_node_cache_size: 500
+  # async_max_edge_cache_size: 1000
 
 search:
   min_similarity: 0.8 # Reduce result processing

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -431,7 +431,7 @@ database:
   async_writes_enabled: false # Disable async writes
 ```
 
-With `enabled: true`, do not assume every mutation becomes eventual. The setting enables the async write-behind engine and lets eligible queries use it; durable transactional mutations still return `200 OK` and include `receipt` metadata.
+With `async_writes_enabled: true`, do not assume every mutation becomes eventual. The setting enables the async write-behind engine and lets eligible queries use it; durable transactional mutations still return `200 OK` and include `receipt` metadata.
 
 ### Memory Management
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1402,16 +1402,26 @@ type YAMLConfig struct {
 		EncryptionAuditSignKey            string `yaml:"encryption_audit_sign_key"`
 		EncryptionRotationEnabled         *bool  `yaml:"encryption_rotation_enabled"`
 		EncryptionRotationInterval        string `yaml:"encryption_rotation_interval"`
-		BadgerNodeCacheMaxEntries         int    `yaml:"badger_node_cache_max_entries"`
-		BadgerEdgeTypeCacheMaxTypes       int    `yaml:"badger_edge_type_cache_max_types"`
-		MVCCRetentionMaxVersions          int    `yaml:"mvcc_retention_max_versions"`
-		MVCCRetentionTTL                  string `yaml:"mvcc_retention_ttl"`
-		IDFreelistTTL                     string `yaml:"id_freelist_ttl"`
-		MVCCLifecycleEnabled              *bool  `yaml:"mvcc_lifecycle_enabled"`
-		MVCCLifecycleCycleInterval        string `yaml:"mvcc_lifecycle_interval"`
-		MVCCLifecycleMaxSnapshotAge       string `yaml:"mvcc_lifecycle_max_snapshot_age"`
-		MVCCLifecycleMaxChainCap          int    `yaml:"mvcc_lifecycle_max_chain_cap"`
-		PersistSearchIndexes              bool   `yaml:"persist_search_indexes"`
+		AsyncWritesEnabled                *bool  `yaml:"async_writes_enabled"`
+		AsyncFlushInterval                string `yaml:"async_flush_interval"`
+		AsyncMaxNodeCacheSize             *int   `yaml:"async_max_node_cache_size"`
+		AsyncMaxEdgeCacheSize             *int   `yaml:"async_max_edge_cache_size"`
+		AsyncWrites                       struct {
+			Enabled          *bool  `yaml:"enabled"`
+			FlushInterval    string `yaml:"flush_interval"`
+			MaxNodeCacheSize *int   `yaml:"max_node_cache_size"`
+			MaxEdgeCacheSize *int   `yaml:"max_edge_cache_size"`
+		} `yaml:"async_writes"`
+		BadgerNodeCacheMaxEntries   int    `yaml:"badger_node_cache_max_entries"`
+		BadgerEdgeTypeCacheMaxTypes int    `yaml:"badger_edge_type_cache_max_types"`
+		MVCCRetentionMaxVersions    int    `yaml:"mvcc_retention_max_versions"`
+		MVCCRetentionTTL            string `yaml:"mvcc_retention_ttl"`
+		IDFreelistTTL               string `yaml:"id_freelist_ttl"`
+		MVCCLifecycleEnabled        *bool  `yaml:"mvcc_lifecycle_enabled"`
+		MVCCLifecycleCycleInterval  string `yaml:"mvcc_lifecycle_interval"`
+		MVCCLifecycleMaxSnapshotAge string `yaml:"mvcc_lifecycle_max_snapshot_age"`
+		MVCCLifecycleMaxChainCap    int    `yaml:"mvcc_lifecycle_max_chain_cap"`
+		PersistSearchIndexes        bool   `yaml:"persist_search_indexes"`
 	} `yaml:"database"`
 
 	// Storage alias for database
@@ -2027,10 +2037,8 @@ func applyEnvVars(config *Config) error {
 	}
 
 	// Async write settings
-	if getEnv("NORNICDB_ASYNC_WRITES_ENABLED", "true") == "false" {
-		config.Database.AsyncWritesEnabled = false
-	} else {
-		config.Database.AsyncWritesEnabled = true
+	if v, ok := envutil.LookupBoolLoose("NORNICDB_ASYNC_WRITES_ENABLED"); ok {
+		config.Database.AsyncWritesEnabled = v
 	}
 	if v := getEnvDuration("NORNICDB_ASYNC_FLUSH_INTERVAL", 0); v > 0 {
 		config.Database.AsyncFlushInterval = v
@@ -3022,6 +3030,30 @@ func LoadFromFile(configPath string) (*Config, error) {
 		if d, err := time.ParseDuration(strings.TrimSpace(yamlCfg.Database.EncryptionRotationInterval)); err == nil {
 			config.Database.EncryptionRotationInterval = d
 		}
+	}
+	if yamlCfg.Database.AsyncWritesEnabled != nil {
+		config.Database.AsyncWritesEnabled = *yamlCfg.Database.AsyncWritesEnabled
+	} else if yamlCfg.Database.AsyncWrites.Enabled != nil {
+		config.Database.AsyncWritesEnabled = *yamlCfg.Database.AsyncWrites.Enabled
+	}
+	asyncFlushInterval := strings.TrimSpace(yamlCfg.Database.AsyncFlushInterval)
+	if asyncFlushInterval == "" {
+		asyncFlushInterval = strings.TrimSpace(yamlCfg.Database.AsyncWrites.FlushInterval)
+	}
+	if asyncFlushInterval != "" {
+		if d, err := time.ParseDuration(asyncFlushInterval); err == nil {
+			config.Database.AsyncFlushInterval = d
+		}
+	}
+	if yamlCfg.Database.AsyncMaxNodeCacheSize != nil {
+		config.Database.AsyncMaxNodeCacheSize = *yamlCfg.Database.AsyncMaxNodeCacheSize
+	} else if yamlCfg.Database.AsyncWrites.MaxNodeCacheSize != nil {
+		config.Database.AsyncMaxNodeCacheSize = *yamlCfg.Database.AsyncWrites.MaxNodeCacheSize
+	}
+	if yamlCfg.Database.AsyncMaxEdgeCacheSize != nil {
+		config.Database.AsyncMaxEdgeCacheSize = *yamlCfg.Database.AsyncMaxEdgeCacheSize
+	} else if yamlCfg.Database.AsyncWrites.MaxEdgeCacheSize != nil {
+		config.Database.AsyncMaxEdgeCacheSize = *yamlCfg.Database.AsyncWrites.MaxEdgeCacheSize
 	}
 	if yamlCfg.Database.BadgerNodeCacheMaxEntries > 0 {
 		config.Database.BadgerNodeCacheMaxEntries = yamlCfg.Database.BadgerNodeCacheMaxEntries

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3046,13 +3046,25 @@ func LoadFromFile(configPath string) (*Config, error) {
 		}
 	}
 	if yamlCfg.Database.AsyncMaxNodeCacheSize != nil {
+		if *yamlCfg.Database.AsyncMaxNodeCacheSize < 0 {
+			return nil, fmt.Errorf("invalid async_max_node_cache_size: %d", *yamlCfg.Database.AsyncMaxNodeCacheSize)
+		}
 		config.Database.AsyncMaxNodeCacheSize = *yamlCfg.Database.AsyncMaxNodeCacheSize
 	} else if yamlCfg.Database.AsyncWrites.MaxNodeCacheSize != nil {
+		if *yamlCfg.Database.AsyncWrites.MaxNodeCacheSize < 0 {
+			return nil, fmt.Errorf("invalid async_writes.max_node_cache_size: %d", *yamlCfg.Database.AsyncWrites.MaxNodeCacheSize)
+		}
 		config.Database.AsyncMaxNodeCacheSize = *yamlCfg.Database.AsyncWrites.MaxNodeCacheSize
 	}
 	if yamlCfg.Database.AsyncMaxEdgeCacheSize != nil {
+		if *yamlCfg.Database.AsyncMaxEdgeCacheSize < 0 {
+			return nil, fmt.Errorf("invalid async_max_edge_cache_size: %d", *yamlCfg.Database.AsyncMaxEdgeCacheSize)
+		}
 		config.Database.AsyncMaxEdgeCacheSize = *yamlCfg.Database.AsyncMaxEdgeCacheSize
 	} else if yamlCfg.Database.AsyncWrites.MaxEdgeCacheSize != nil {
+		if *yamlCfg.Database.AsyncWrites.MaxEdgeCacheSize < 0 {
+			return nil, fmt.Errorf("invalid async_writes.max_edge_cache_size: %d", *yamlCfg.Database.AsyncWrites.MaxEdgeCacheSize)
+		}
 		config.Database.AsyncMaxEdgeCacheSize = *yamlCfg.Database.AsyncWrites.MaxEdgeCacheSize
 	}
 	if yamlCfg.Database.BadgerNodeCacheMaxEntries > 0 {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -884,6 +884,77 @@ func TestLoadFromFile_MVCCLifecycle(t *testing.T) {
 	require.Equal(t, 9*time.Second, cfg.EmbeddingWorker.TriggerDebounceDelay)
 }
 
+func TestLoadFromFile_AsyncWriteSettingsFlatYAML(t *testing.T) {
+	clearEnvVars(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+database:
+  async_writes_enabled: false
+  async_flush_interval: "75ms"
+  async_max_node_cache_size: 123
+  async_max_edge_cache_size: 456
+`), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := LoadFromFile(path)
+	require.NoError(t, err)
+	require.False(t, cfg.Database.AsyncWritesEnabled)
+	require.Equal(t, 75*time.Millisecond, cfg.Database.AsyncFlushInterval)
+	require.Equal(t, 123, cfg.Database.AsyncMaxNodeCacheSize)
+	require.Equal(t, 456, cfg.Database.AsyncMaxEdgeCacheSize)
+}
+
+func TestLoadFromFile_AsyncWriteSettingsNestedYAMLLegacyShape(t *testing.T) {
+	clearEnvVars(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+database:
+  async_writes:
+    enabled: false
+    flush_interval: "150ms"
+    max_node_cache_size: 321
+    max_edge_cache_size: 654
+`), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := LoadFromFile(path)
+	require.NoError(t, err)
+	require.False(t, cfg.Database.AsyncWritesEnabled)
+	require.Equal(t, 150*time.Millisecond, cfg.Database.AsyncFlushInterval)
+	require.Equal(t, 321, cfg.Database.AsyncMaxNodeCacheSize)
+	require.Equal(t, 654, cfg.Database.AsyncMaxEdgeCacheSize)
+}
+
+func TestLoadFromFile_AsyncWriteSettingsEnvPrecedence(t *testing.T) {
+	clearEnvVars(t)
+	t.Setenv("NORNICDB_ASYNC_WRITES_ENABLED", "true")
+	t.Setenv("NORNICDB_ASYNC_FLUSH_INTERVAL", "25ms")
+	t.Setenv("NORNICDB_ASYNC_MAX_NODE_CACHE_SIZE", "777")
+	t.Setenv("NORNICDB_ASYNC_MAX_EDGE_CACHE_SIZE", "888")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+database:
+  async_writes_enabled: false
+  async_flush_interval: "75ms"
+  async_max_node_cache_size: 123
+  async_max_edge_cache_size: 456
+`), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := LoadFromFile(path)
+	require.NoError(t, err)
+	require.True(t, cfg.Database.AsyncWritesEnabled)
+	require.Equal(t, 25*time.Millisecond, cfg.Database.AsyncFlushInterval)
+	require.Equal(t, 777, cfg.Database.AsyncMaxNodeCacheSize)
+	require.Equal(t, 888, cfg.Database.AsyncMaxEdgeCacheSize)
+}
+
 func TestLoadFromFile_ComprehensiveSectionsAndEnvPrecedence(t *testing.T) {
 	clearEnvVars(t)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -955,6 +955,60 @@ database:
 	require.Equal(t, 888, cfg.Database.AsyncMaxEdgeCacheSize)
 }
 
+func TestLoadFromFile_AsyncWriteSettingsRejectsNegativeFlatCacheSizes(t *testing.T) {
+	clearEnvVars(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+database:
+  async_max_node_cache_size: -1
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = LoadFromFile(path)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid async_max_node_cache_size")
+
+	err = os.WriteFile(path, []byte(`
+database:
+  async_max_edge_cache_size: -2
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = LoadFromFile(path)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid async_max_edge_cache_size")
+}
+
+func TestLoadFromFile_AsyncWriteSettingsRejectsNegativeNestedCacheSizes(t *testing.T) {
+	clearEnvVars(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+database:
+  async_writes:
+    max_node_cache_size: -3
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = LoadFromFile(path)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid async_writes.max_node_cache_size")
+
+	err = os.WriteFile(path, []byte(`
+database:
+  async_writes:
+    max_edge_cache_size: -4
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = LoadFromFile(path)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid async_writes.max_edge_cache_size")
+}
+
 func TestLoadFromFile_ComprehensiveSectionsAndEnvPrecedence(t *testing.T) {
 	clearEnvVars(t)
 

--- a/pkg/cypher/comparison.go
+++ b/pkg/cypher/comparison.go
@@ -90,6 +90,23 @@ func (e *StorageExecutor) nodeMatchesProps(node *storage.Node, props map[string]
 	return true
 }
 
+// edgeMatchesProps checks if an edge's properties match the expected values.
+func (e *StorageExecutor) edgeMatchesProps(edge *storage.Edge, props map[string]interface{}) bool {
+	if props == nil {
+		return true
+	}
+	for key, expected := range props {
+		actual, exists := edge.Properties[key]
+		if !exists {
+			return false
+		}
+		if !e.compareEqual(actual, expected) {
+			return false
+		}
+	}
+	return true
+}
+
 // compareEqual handles equality comparison with type coercion.
 //
 // # Parameters

--- a/pkg/cypher/relationship_property_filter_test.go
+++ b/pkg/cypher/relationship_property_filter_test.go
@@ -237,6 +237,30 @@ func TestCategoryRelationshipTraversal(t *testing.T) {
 	})
 }
 
+func TestRelationshipInlinePropertyFilterOnRelationship(t *testing.T) {
+	baseStore := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(baseStore, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, "CREATE (:A {id:'a1'}), (:A {id:'a2'}), (:B {id:'b1'}), (:B {id:'b2'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "MATCH (a:A {id:'a1'}), (b:B {id:'b1'}) CREATE (a)-[:REL {prop:'x'}]->(b)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "MATCH (a:A {id:'a2'}), (b:B {id:'b2'}) CREATE (a)-[:REL {prop:'y'}]->(b)", nil)
+	require.NoError(t, err)
+
+	inlineRes, err := exec.Execute(ctx, "MATCH ()-[r:REL {prop: $v}]->() RETURN count(r) AS c", map[string]interface{}{"v": "x"})
+	require.NoError(t, err)
+	require.Len(t, inlineRes.Rows, 1)
+	require.Equal(t, int64(1), inlineRes.Rows[0][0], "inline relationship property filter should match one relationship")
+
+	whereRes, err := exec.Execute(ctx, "MATCH ()-[r:REL]->() WHERE r.prop = $v RETURN count(r) AS c", map[string]interface{}{"v": "x"})
+	require.NoError(t, err)
+	require.Len(t, whereRes.Rows, 1)
+	require.Equal(t, int64(1), whereRes.Rows[0][0], "WHERE relationship property filter should match one relationship")
+}
+
 // TestSpecialCharacterPropertyValues tests various special characters in property values
 func TestSpecialCharacterPropertyValues(t *testing.T) {
 	baseStore := newTestMemoryEngine(t)

--- a/pkg/cypher/traversal.go
+++ b/pkg/cypher/traversal.go
@@ -38,6 +38,7 @@ type TraversalContext struct {
 	endNode          *storage.Node
 	relTypes         []string // Allowed relationship types (empty = any)
 	relTypeSet       map[string]struct{}
+	relProperties    map[string]interface{}
 	direction        string // "outgoing", "incoming", "both"
 	minHops          int
 	maxHops          int
@@ -216,7 +217,8 @@ func (e *StorageExecutor) executeMatchWithRelationshipsWithPath(ctx context.Cont
 	if whereClause == "" && pathVariable == "" && !matches.IsChained && len(returnItems) == 1 &&
 		matches.StartNode.variable == "" && len(matches.StartNode.labels) == 0 && len(matches.StartNode.properties) == 0 &&
 		matches.EndNode.variable == "" && len(matches.EndNode.labels) == 0 && len(matches.EndNode.properties) == 0 &&
-		matches.Relationship.MinHops == 1 && matches.Relationship.MaxHops == 1 {
+		matches.Relationship.MinHops == 1 && matches.Relationship.MaxHops == 1 &&
+		len(matches.Relationship.Properties) == 0 {
 		if count, ok, err := e.tryFastRelationshipCount(matches, returnItems[0]); ok {
 			if err != nil {
 				return nil, err
@@ -1443,6 +1445,7 @@ func (e *StorageExecutor) traverseGraphSequential(ctx context.Context, match *Tr
 			startNode:        startNode,
 			relTypes:         match.Relationship.Types,
 			relTypeSet:       buildRelTypeSet(match.Relationship.Types),
+			relProperties:    match.Relationship.Properties,
 			direction:        match.Relationship.Direction,
 			minHops:          match.Relationship.MinHops,
 			maxHops:          match.Relationship.MaxHops,
@@ -1509,6 +1512,7 @@ func (e *StorageExecutor) traverseGraphParallel(ctx context.Context, match *Trav
 					startNode:        startNode,
 					relTypes:         match.Relationship.Types,
 					relTypeSet:       buildRelTypeSet(match.Relationship.Types),
+					relProperties:    match.Relationship.Properties,
 					direction:        match.Relationship.Direction,
 					minHops:          match.Relationship.MinHops,
 					maxHops:          match.Relationship.MaxHops,
@@ -1651,6 +1655,7 @@ func (e *StorageExecutor) traverseFromNode(traversalCtx context.Context, startNo
 		startNode:        startNode,
 		relTypes:         match.Relationship.Types,
 		relTypeSet:       buildRelTypeSet(match.Relationship.Types),
+		relProperties:    match.Relationship.Properties,
 		direction:        match.Relationship.Direction,
 		minHops:          match.Relationship.MinHops,
 		maxHops:          match.Relationship.MaxHops,
@@ -1746,6 +1751,9 @@ func (e *StorageExecutor) findPaths(
 					continue
 				}
 			}
+		}
+		if len(ctx.relProperties) > 0 && !e.edgeMatchesProps(edge, ctx.relProperties) {
+			continue
 		}
 
 		// Get next node


### PR DESCRIPTION
resolves #215 
## Summary

This PR fixes two silent behavior gaps:

1. **Config docs vs binary behavior (async writes):**
   YAML async write settings were documented but not loaded from file, and env processing could override YAML `false` back to `true` when `NORNICDB_ASYNC_WRITES_ENABLED` was unset.

2. **Inline relationship property filtering in MATCH traversal:**
   Patterns like `MATCH ()-[r:REL {prop: $v}]->()` could silently return no rows because traversal filtered by type/direction but not relationship properties.

### Config loading
- Added YAML parsing for async write settings in `database`:
  - `async_writes_enabled`
  - `async_flush_interval`
  - `async_max_node_cache_size`
  - `async_max_edge_cache_size`
- Added backward-compatible support for legacy nested shape:
  - `database.async_writes.enabled`
  - `database.async_writes.flush_interval`
  - `database.async_writes.max_node_cache_size`
  - `database.async_writes.max_edge_cache_size`
- Fixed env override behavior:
  - `NORNICDB_ASYNC_WRITES_ENABLED` now only overrides when explicitly set.
  - Unset env no longer forces `AsyncWritesEnabled=true`.

### Traversal / Cypher matching
- Added edge property matcher and wired it into traversal DFS edge expansion.
- Inline relationship property filters are now enforced during path search.
- Disabled relationship count fast path when inline relationship properties are present to preserve semantics.

### Docs
- Unified `docs/operations/configuration.md` async examples to canonical flat YAML keys under `database.async_*`.
- Updated tuning/troubleshooting references to the same key names.

## Tests

Added regression tests:

### `pkg/config`
- `TestLoadFromFile_AsyncWriteSettingsFlatYAML`
- `TestLoadFromFile_AsyncWriteSettingsNestedYAMLLegacyShape`
- `TestLoadFromFile_AsyncWriteSettingsEnvPrecedence`

### `pkg/cypher`
- `TestRelationshipInlinePropertyFilterOnRelationship`

- Operators can now reliably disable async writes via YAML as documented.
- Prevents silent config drift that can surface as write-backlog and memory pressure incidents under heavy load.
- Relationship inline property patterns now behave as documented/expected and match WHERE-form semantics.