### PR TITLE
Speed up bound relationship deletes

### DIFF
--- a/pkg/cypher/executor_mutations.go
+++ b/pkg/cypher/executor_mutations.go
@@ -155,6 +155,12 @@ func (e *StorageExecutor) executeDelete(ctx context.Context, cypher string) (*Ex
 	// LIMIT/SKIP/WITH/ORDER BY/CALL/UNWIND in the MATCH segment.
 	matchSegment := strings.TrimSpace(cypher[matchIdx:deleteIdx])
 	_, inTransactionWrapper := e.getStorage(ctx).(*transactionStorageWrapper)
+	if hot, ok, err := e.tryExecuteBoundRelationshipDelete(ctx, matchSegment, cypher, deleteVars, detach); ok || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		return hot, nil
+	}
 	if !inTransactionWrapper && e.isDeleteStreamingEligible(matchSegment, deleteVars, detach) {
 		result, err := e.executeDeleteStreaming(ctx, matchSegment, deleteVars, needEdgeStats)
 		if err != nil {

--- a/pkg/cypher/executor_mutations_relationship_delete.go
+++ b/pkg/cypher/executor_mutations_relationship_delete.go
@@ -79,7 +79,7 @@ func (e *StorageExecutor) tryExecuteBoundRelationshipDelete(
 	}
 	if len(sources) == 0 {
 		result := &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}, Stats: &QueryStats{}}
-		e.applyDeleteReturnProjection(result, cypher, deleteVar)
+		e.applyDeleteReturnProjection(result, cypher, deleteVar, singleDeleteProjectionInfo(deleteVar, deleteProjectionRelationship))
 		return result, true, nil
 	}
 
@@ -146,7 +146,7 @@ func (e *StorageExecutor) tryExecuteBoundRelationshipDelete(
 		}
 		result.Stats.RelationshipsDeleted = len(edgeIDs)
 	}
-	e.applyDeleteReturnProjection(result, cypher, deleteVar)
+	e.applyDeleteReturnProjection(result, cypher, deleteVar, singleDeleteProjectionInfo(deleteVar, deleteProjectionRelationship))
 	return result, true, nil
 }
 
@@ -298,10 +298,7 @@ func (e *StorageExecutor) boundRelationshipDeleteTargetNode(
 		return nil, false, nil
 	}
 	target, err := store.GetNode(targetID)
-	if err != nil {
-		return nil, false, err
-	}
-	if target == nil {
+	if err != nil || target == nil {
 		return nil, false, nil
 	}
 	return target, true, nil

--- a/pkg/cypher/executor_mutations_relationship_delete.go
+++ b/pkg/cypher/executor_mutations_relationship_delete.go
@@ -156,6 +156,10 @@ func (e *StorageExecutor) collectBoundRelationshipDeleteSources(ctx context.Cont
 	}
 
 	store := e.getStorage(ctx)
+	if txWrapper, ok := store.(*transactionStorageWrapper); !ok || !txWrapper.tx.HasPendingNodeMutations() {
+		return e.collectNodesWithStreaming(ctx, sourcePattern.labels, sourcePattern.properties, sourcePattern.variable, "", -1)
+	}
+
 	var nodes []*storage.Node
 	var err error
 	if len(sourcePattern.labels) > 0 {

--- a/pkg/cypher/executor_mutations_relationship_delete.go
+++ b/pkg/cypher/executor_mutations_relationship_delete.go
@@ -1,0 +1,315 @@
+package cypher
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+func (e *StorageExecutor) tryExecuteBoundRelationshipDelete(
+	ctx context.Context,
+	matchSegment string,
+	cypher string,
+	deleteVars string,
+	detach bool,
+) (*ExecuteResult, bool, error) {
+	matchSegment = strings.TrimSpace(matchSegment)
+	_, inTransactionWrapper := e.getStorage(ctx).(*transactionStorageWrapper)
+	if detach || strings.Contains(deleteVars, ",") {
+		return nil, false, nil
+	}
+	deleteVar := strings.TrimSpace(deleteVars)
+	if deleteVar == "" {
+		return nil, false, nil
+	}
+	limit := -1
+	baseMatchSegment := matchSegment
+	if !isSimpleBoundRelationshipDeleteMatchSegment(matchSegment) {
+		limitedSegment, limitedRows, ok := parseBoundRelationshipDeleteWithLimitSegment(matchSegment, deleteVar)
+		if !ok {
+			return nil, false, nil
+		}
+		baseMatchSegment = limitedSegment
+		limit = limitedRows
+	}
+
+	pseudo := baseMatchSegment + " RETURN __delete_probe__"
+	returnIdx := findKeywordIndex(pseudo, "RETURN")
+	if returnIdx <= 0 {
+		return nil, false, nil
+	}
+	whereIdx := lastKeywordIndexBefore(pseudo, "WHERE", returnIdx)
+	clauses := splitMatchClauses(pseudo, whereIdx, returnIdx)
+	if len(clauses) != 2 {
+		return nil, false, nil
+	}
+
+	sourcePattern := e.parseNodePattern(ctx, clauses[0])
+	if sourcePattern.variable == "" {
+		return nil, false, nil
+	}
+	relPatternText := strings.TrimSpace(clauses[1])
+	relMatch := e.parseTraversalPattern(ctx, relPatternText)
+	if relMatch == nil || relMatch.IsChained {
+		return nil, false, nil
+	}
+	if relMatch.StartNode.variable != sourcePattern.variable {
+		return nil, false, nil
+	}
+	if relMatch.Relationship.Variable != deleteVar {
+		return nil, false, nil
+	}
+	if relMatch.Relationship.MinHops != 1 || relMatch.Relationship.MaxHops != 1 {
+		return nil, false, nil
+	}
+	if relMatch.Relationship.Direction != "outgoing" && relMatch.Relationship.Direction != "incoming" && relMatch.Relationship.Direction != "both" {
+		return nil, false, nil
+	}
+
+	whereClause := ""
+	if whereIdx > 0 && whereIdx < returnIdx {
+		whereClause = strings.TrimSpace(pseudo[whereIdx+len("WHERE") : returnIdx])
+	}
+
+	sources, err := e.collectBoundRelationshipDeleteSources(ctx, sourcePattern, inTransactionWrapper)
+	if err != nil {
+		return nil, true, err
+	}
+	if len(sources) == 0 {
+		result := &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}, Stats: &QueryStats{}}
+		e.applyDeleteReturnProjection(result, cypher, deleteVar)
+		return result, true, nil
+	}
+
+	typeSet := buildRelTypeSet(relMatch.Relationship.Types)
+	store := e.getStorage(ctx)
+	edgeIDs := make([]storage.EdgeID, 0)
+	seen := make(map[storage.EdgeID]struct{})
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		candidates, err := e.boundRelationshipDeleteCandidateEdges(store, source.ID, relMatch.Relationship.Direction)
+		if err != nil {
+			return nil, true, err
+		}
+		for _, edge := range candidates {
+			if edge == nil || !relationshipTypeAllowed(edge.Type, relMatch.Relationship.Types, typeSet) {
+				continue
+			}
+			if len(relMatch.Relationship.Properties) > 0 && !e.edgeMatchesProps(edge, relMatch.Relationship.Properties) {
+				continue
+			}
+			target, ok, err := e.boundRelationshipDeleteTargetNode(store, source.ID, edge, relMatch.Relationship.Direction)
+			if err != nil {
+				return nil, true, err
+			}
+			if !ok || !e.matchesEndPattern(target, &relMatch.EndNode) {
+				continue
+			}
+			if whereClause != "" {
+				pathCtx := PathContext{
+					nodes: map[string]*storage.Node{
+						relMatch.StartNode.variable: source,
+					},
+					rels: map[string]*storage.Edge{
+						deleteVar: edge,
+					},
+				}
+				if relMatch.EndNode.variable != "" {
+					pathCtx.nodes[relMatch.EndNode.variable] = target
+				}
+				if !e.evaluateWhereOnPath(ctx, whereClause, pathCtx) {
+					continue
+				}
+			}
+			if _, exists := seen[edge.ID]; exists {
+				continue
+			}
+			seen[edge.ID] = struct{}{}
+			edgeIDs = append(edgeIDs, edge.ID)
+			if limit > 0 && len(edgeIDs) >= limit {
+				break
+			}
+		}
+		if limit > 0 && len(edgeIDs) >= limit {
+			break
+		}
+	}
+
+	result := &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}, Stats: &QueryStats{}}
+	if len(edgeIDs) > 0 {
+		if err := store.BulkDeleteEdges(edgeIDs); err != nil {
+			return nil, true, err
+		}
+		result.Stats.RelationshipsDeleted = len(edgeIDs)
+	}
+	e.applyDeleteReturnProjection(result, cypher, deleteVar)
+	return result, true, nil
+}
+
+func (e *StorageExecutor) collectBoundRelationshipDeleteSources(ctx context.Context, sourcePattern nodePatternInfo, inTransactionWrapper bool) ([]*storage.Node, error) {
+	if !inTransactionWrapper {
+		return e.collectNodesWithStreaming(ctx, sourcePattern.labels, sourcePattern.properties, sourcePattern.variable, "", -1)
+	}
+
+	store := e.getStorage(ctx)
+	var nodes []*storage.Node
+	var err error
+	if len(sourcePattern.labels) > 0 {
+		nodes, err = store.GetNodesByLabel(sourcePattern.labels[0])
+	} else {
+		nodes, err = store.AllNodes()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]*storage.Node, 0, len(nodes))
+	hideSystemNodes := shouldHideSystemNodes(store)
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		if hideSystemNodes && isSystemNode(node) {
+			continue
+		}
+		if len(sourcePattern.labels) > 0 && !mergeNodeHasLabels(node, sourcePattern.labels) {
+			continue
+		}
+		if len(sourcePattern.properties) > 0 && !e.nodeMatchesProps(node, sourcePattern.properties) {
+			continue
+		}
+		filtered = append(filtered, node)
+	}
+	return filtered, nil
+}
+
+func (e *StorageExecutor) boundRelationshipDeleteCandidateEdges(store storage.Engine, nodeID storage.NodeID, direction string) ([]*storage.Edge, error) {
+	var edges []*storage.Edge
+	switch direction {
+	case "outgoing":
+		outgoing, err := store.GetOutgoingEdges(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		edges = append(edges, outgoing...)
+	case "incoming":
+		incoming, err := store.GetIncomingEdges(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		edges = append(edges, incoming...)
+	case "both":
+		outgoing, err := store.GetOutgoingEdges(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		incoming, err := store.GetIncomingEdges(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		edges = append(edges, outgoing...)
+		edges = append(edges, incoming...)
+	}
+	return edges, nil
+}
+
+func parseBoundRelationshipDeleteWithLimitSegment(matchSegment, deleteVar string) (string, int, bool) {
+	for _, blocked := range []string{"ORDER BY", "SKIP", "CALL", "UNWIND", "OPTIONAL MATCH"} {
+		if containsKeywordOutsideStrings(matchSegment, blocked) {
+			return "", 0, false
+		}
+	}
+	withIdx := findKeywordIndex(matchSegment, "WITH")
+	if withIdx <= 0 {
+		return "", 0, false
+	}
+	baseMatch := strings.TrimSpace(matchSegment[:withIdx])
+	if !isSimpleBoundRelationshipDeleteMatchSegment(baseMatch) {
+		return "", 0, false
+	}
+	withPart := strings.TrimSpace(matchSegment[withIdx+len("WITH"):])
+	limitIdx := findKeywordIndex(withPart, "LIMIT")
+	if limitIdx <= 0 {
+		return "", 0, false
+	}
+	withVar := strings.TrimSpace(withPart[:limitIdx])
+	if withVar != deleteVar {
+		return "", 0, false
+	}
+	limitLiteral := strings.TrimSpace(withPart[limitIdx+len("LIMIT"):])
+	fields := strings.Fields(limitLiteral)
+	if len(fields) != 1 {
+		return "", 0, false
+	}
+	limitN, err := strconv.Atoi(fields[0])
+	if err != nil || limitN <= 0 {
+		return "", 0, false
+	}
+	return baseMatch, limitN, true
+}
+
+func isSimpleBoundRelationshipDeleteMatchSegment(matchSegment string) bool {
+	if strings.TrimSpace(matchSegment) == "" {
+		return false
+	}
+	for _, blocked := range []string{"WITH", "LIMIT", "SKIP", "ORDER BY", "CALL", "UNWIND", "OPTIONAL MATCH"} {
+		if containsKeywordOutsideStrings(matchSegment, blocked) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *StorageExecutor) boundRelationshipDeleteTargetNode(
+	store storage.Engine,
+	sourceID storage.NodeID,
+	edge *storage.Edge,
+	direction string,
+) (*storage.Node, bool, error) {
+	var targetID storage.NodeID
+	switch direction {
+	case "outgoing":
+		if edge.StartNode != sourceID {
+			return nil, false, nil
+		}
+		targetID = edge.EndNode
+	case "incoming":
+		if edge.EndNode != sourceID {
+			return nil, false, nil
+		}
+		targetID = edge.StartNode
+	case "both":
+		if edge.StartNode == sourceID {
+			targetID = edge.EndNode
+		} else if edge.EndNode == sourceID {
+			targetID = edge.StartNode
+		} else {
+			return nil, false, nil
+		}
+	default:
+		return nil, false, nil
+	}
+	target, err := store.GetNode(targetID)
+	if err != nil {
+		return nil, false, err
+	}
+	if target == nil {
+		return nil, false, nil
+	}
+	return target, true, nil
+}
+
+func relationshipTypeAllowed(edgeType string, allowed []string, allowedSet map[string]struct{}) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	if len(allowed) == 1 {
+		return edgeType == allowed[0]
+	}
+	_, ok := allowedSet[edgeType]
+	return ok
+}

--- a/pkg/cypher/executor_mutations_relationship_delete_gate_test.go
+++ b/pkg/cypher/executor_mutations_relationship_delete_gate_test.go
@@ -1,0 +1,173 @@
+package cypher
+
+import (
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests lock the bound-relationship-delete eligibility gate: the pure
+// predicates that decide whether a DELETE query is routed through the fast
+// path. They cover the rejection branches (blocked clauses, malformed
+// WITH ... LIMIT, unknown relationship types) that the query-level tests do
+// not exercise directly.
+
+func TestIsSimpleBoundRelationshipDeleteMatchSegment(t *testing.T) {
+	cases := []struct {
+		name    string
+		segment string
+		want    bool
+	}{
+		{"empty", "   ", false},
+		{"plain", "MATCH (a) MATCH (a)-[r]->(b)", true},
+		{"with", "MATCH (a)-[r]->(b) WITH r", false},
+		{"limit", "MATCH (a)-[r]->(b) LIMIT 1", false},
+		{"skip", "MATCH (a)-[r]->(b) SKIP 1", false},
+		{"order by", "MATCH (a)-[r]->(b) ORDER BY r", false},
+		{"call", "CALL db.foo() MATCH (a)-[r]->(b)", false},
+		{"unwind", "UNWIND [1] AS x MATCH (a)-[r]->(b)", false},
+		{"optional match", "MATCH (a) OPTIONAL MATCH (a)-[r]->(b)", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSimpleBoundRelationshipDeleteMatchSegment(tc.segment); got != tc.want {
+				t.Fatalf("isSimpleBoundRelationshipDeleteMatchSegment(%q) = %v, want %v", tc.segment, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseBoundRelationshipDeleteWithLimitSegment(t *testing.T) {
+	const deleteVar = "r"
+	base := "MATCH (a) MATCH (a)-[r]->(b)"
+
+	t.Run("valid", func(t *testing.T) {
+		gotBase, gotLimit, ok := parseBoundRelationshipDeleteWithLimitSegment(base+" WITH r LIMIT 5", deleteVar)
+		if !ok {
+			t.Fatal("expected ok for WITH r LIMIT 5")
+		}
+		if gotLimit != 5 {
+			t.Fatalf("limit = %d, want 5", gotLimit)
+		}
+		if gotBase != base {
+			t.Fatalf("base = %q, want %q", gotBase, base)
+		}
+	})
+
+	rejections := []struct {
+		name    string
+		segment string
+	}{
+		{"blocked order by", base + " WITH r ORDER BY r LIMIT 1"},
+		{"blocked skip", base + " WITH r SKIP 1 LIMIT 1"},
+		{"blocked call", base + " CALL db.x() WITH r LIMIT 1"},
+		{"blocked unwind", base + " UNWIND [1] AS x WITH r LIMIT 1"},
+		{"blocked optional match", base + " OPTIONAL MATCH (a)-[r2]->(c) WITH r LIMIT 1"},
+		{"no with", base + " LIMIT 1"},
+		{"non-simple base", "MATCH (a) WITH a MATCH (a)-[r]->(b) WITH r LIMIT 1"},
+		{"no limit", base + " WITH r"},
+		{"wrong var", base + " WITH x LIMIT 1"},
+		{"non-numeric limit", base + " WITH r LIMIT abc"},
+		{"zero limit", base + " WITH r LIMIT 0"},
+		{"negative limit", base + " WITH r LIMIT -1"},
+		{"multi-field limit", base + " WITH r LIMIT 1 2"},
+	}
+	for _, tc := range rejections {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, ok := parseBoundRelationshipDeleteWithLimitSegment(tc.segment, deleteVar); ok {
+				t.Fatalf("expected rejection for %q", tc.segment)
+			}
+		})
+	}
+}
+
+func TestBoundRelationshipDeleteTargetNode(t *testing.T) {
+	store := newTestMemoryEngine(t)
+	exec := NewStorageExecutor(store)
+
+	src := storage.NodeID("test:s")
+	dst := storage.NodeID("test:t")
+	_, err := store.CreateNode(&storage.Node{ID: src, Labels: []string{"N"}})
+	require.NoError(t, err)
+	_, err = store.CreateNode(&storage.Node{ID: dst, Labels: []string{"N"}})
+	require.NoError(t, err)
+	edge := &storage.Edge{ID: "test:e", StartNode: src, EndNode: dst, Type: "LINKS"}
+
+	t.Run("outgoing resolves end node", func(t *testing.T) {
+		target, ok, err := exec.boundRelationshipDeleteTargetNode(store, src, edge, "outgoing")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, dst, target.ID)
+	})
+	t.Run("outgoing rejects when source is not the start", func(t *testing.T) {
+		_, ok, err := exec.boundRelationshipDeleteTargetNode(store, dst, edge, "outgoing")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+	t.Run("incoming resolves start node", func(t *testing.T) {
+		target, ok, err := exec.boundRelationshipDeleteTargetNode(store, dst, edge, "incoming")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, src, target.ID)
+	})
+	t.Run("incoming rejects when source is not the end", func(t *testing.T) {
+		_, ok, err := exec.boundRelationshipDeleteTargetNode(store, src, edge, "incoming")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+	t.Run("both resolves from either endpoint", func(t *testing.T) {
+		fromStart, ok, err := exec.boundRelationshipDeleteTargetNode(store, src, edge, "both")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, dst, fromStart.ID)
+
+		fromEnd, ok, err := exec.boundRelationshipDeleteTargetNode(store, dst, edge, "both")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, src, fromEnd.ID)
+	})
+	t.Run("both rejects unrelated source", func(t *testing.T) {
+		_, ok, err := exec.boundRelationshipDeleteTargetNode(store, storage.NodeID("test:other"), edge, "both")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+	t.Run("unknown direction rejects", func(t *testing.T) {
+		_, ok, err := exec.boundRelationshipDeleteTargetNode(store, src, edge, "sideways")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+	t.Run("missing target node skips candidate", func(t *testing.T) {
+		danglingEdge := &storage.Edge{ID: "test:e2", StartNode: src, EndNode: storage.NodeID("test:ghost"), Type: "LINKS"}
+		// A missing target resolves to "no match"; whether the engine reports
+		// that as ErrNotFound or a nil node, the fast path must not select it.
+		_, ok, _ := exec.boundRelationshipDeleteTargetNode(store, src, danglingEdge, "outgoing")
+		require.False(t, ok)
+	})
+}
+
+func TestRelationshipTypeAllowed(t *testing.T) {
+	multi := []string{"LINKS", "OWNS"}
+	multiSet := buildRelTypeSet(multi)
+
+	cases := []struct {
+		name       string
+		edgeType   string
+		allowed    []string
+		allowedSet map[string]struct{}
+		want       bool
+	}{
+		{"no restriction", "ANY", nil, nil, true},
+		{"single match", "LINKS", []string{"LINKS"}, nil, true},
+		{"single mismatch", "OWNS", []string{"LINKS"}, nil, false},
+		{"multi match", "OWNS", multi, multiSet, true},
+		{"multi mismatch", "REFERS", multi, multiSet, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relationshipTypeAllowed(tc.edgeType, tc.allowed, tc.allowedSet); got != tc.want {
+				t.Fatalf("relationshipTypeAllowed(%q, %v) = %v, want %v", tc.edgeType, tc.allowed, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cypher/executor_mutations_relationship_delete_paths_test.go
+++ b/pkg/cypher/executor_mutations_relationship_delete_paths_test.go
@@ -1,0 +1,130 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedBoundDeleteFixture creates a source Repository with `targets` DEPLOYS_FROM
+// edges to distinct target repositories, each carrying
+// evidence_source='resolver/cross-repo'. It returns a ready executor.
+func seedBoundDeleteFixture(t *testing.T, targets int) *StorageExecutor {
+	t.Helper()
+	exec, _ := newCountingExecutor(t)
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	for i := 0; i < targets; i++ {
+		_, err = exec.Execute(ctx, "CREATE (:Repository {id:$id})", map[string]interface{}{"id": "repository:target-" + string(rune('a'+i))})
+		require.NoError(t, err)
+		_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:$id})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, map[string]interface{}{"id": "repository:target-" + string(rune('a'+i))})
+		require.NoError(t, err)
+	}
+	return exec
+}
+
+// TestBoundRelationshipDelete_RoutingGuards covers the early-exit guards that
+// decline the fast path (returning handled=false so the caller falls back to
+// the general delete path).
+func TestBoundRelationshipDelete_RoutingGuards(t *testing.T) {
+	exec := seedBoundDeleteFixture(t, 1)
+	ctx := context.Background()
+	seg := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)`
+
+	t.Run("detach declines fast path", func(t *testing.T) {
+		res, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx, seg, "", "rel", true)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, res)
+	})
+	t.Run("multiple delete vars decline fast path", func(t *testing.T) {
+		res, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx, seg, "", "rel,other", false)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, res)
+	})
+	t.Run("empty delete var declines fast path", func(t *testing.T) {
+		res, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx, seg, "", "  ", false)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, res)
+	})
+}
+
+// TestBoundRelationshipDelete_FilterBranches covers candidate-filtering paths
+// where the fast path is eligible but no edge qualifies, so nothing is deleted.
+func TestBoundRelationshipDelete_FilterBranches(t *testing.T) {
+	cases := []struct {
+		name    string
+		segment string
+	}{
+		{
+			name: "no matching source node",
+			segment: `
+MATCH (source_repo:Repository {id:'repository:missing'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)`,
+		},
+		{
+			name: "relationship type excluded",
+			segment: `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:NO_SUCH_TYPE]->(:Repository)`,
+		},
+		{
+			name: "relationship property excluded",
+			segment: `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM {evidence_source:'does-not-match'}]->(:Repository)`,
+		},
+		{
+			name: "end node label excluded",
+			segment: `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:NotARepository)`,
+		},
+		{
+			name: "where clause excludes",
+			segment: `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'does-not-match'`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := seedBoundDeleteFixture(t, 1)
+			res, ok, err := exec.tryExecuteBoundRelationshipDelete(context.Background(), tc.segment, "", "rel", false)
+			require.NoError(t, err)
+			require.True(t, ok, "fast path should handle the query")
+			require.Equal(t, 0, res.Stats.RelationshipsDeleted, "no edge should qualify")
+		})
+	}
+}
+
+// TestBoundRelationshipDelete_LimitStopsAtRowCount covers the WITH <rel> LIMIT n
+// path: with two qualifying edges and LIMIT 1, exactly one is deleted.
+func TestBoundRelationshipDelete_LimitStopsAtRowCount(t *testing.T) {
+	exec := seedBoundDeleteFixture(t, 2)
+	seg := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WITH rel LIMIT 1`
+	res, ok, err := exec.tryExecuteBoundRelationshipDelete(context.Background(), seg, "", "rel", false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, res.Stats.RelationshipsDeleted)
+
+	verify, err := exec.Execute(context.Background(), "MATCH ()-[rel:DEPLOYS_FROM]->() RETURN count(rel) AS c", nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), verify.Rows[0][0], "one edge should remain")
+}

--- a/pkg/cypher/match_multi.go
+++ b/pkg/cypher/match_multi.go
@@ -641,16 +641,7 @@ func (e *StorageExecutor) executeFirstMatch(ctx context.Context, pattern string)
 	} else {
 		// Simple node pattern
 		nodePattern := e.parseNodePattern(ctx, pattern)
-		var nodes []*storage.Node
-		if len(nodePattern.labels) > 0 {
-			nodes, _ = e.loadNodesWithTemporalViewport(ctx, nodePattern.labels)
-		} else {
-			nodes, _ = e.loadNodesWithTemporalViewport(ctx, nil)
-		}
-
-		if len(nodePattern.properties) > 0 {
-			nodes = e.filterNodesByProperties(nodes, nodePattern.properties)
-		}
+		nodes, _ := e.collectNodesWithStreaming(ctx, nodePattern.labels, nodePattern.properties, nodePattern.variable, "", -1)
 
 		for _, node := range nodes {
 			b := make(binding)
@@ -678,7 +669,12 @@ func (e *StorageExecutor) executeChainedMatch(ctx context.Context, pattern strin
 			boundStartNode := existing[matches.StartNode.variable]
 			boundEndNode := existing[matches.EndNode.variable]
 
-			paths := e.traverseGraph(ctx, matches)
+			var paths []PathResult
+			if boundStartNode != nil {
+				paths = e.traverseFromNode(ctx, boundStartNode, matches)
+			} else {
+				paths = e.traverseGraph(ctx, matches)
+			}
 			for _, path := range paths {
 				if len(path.Nodes) < 2 {
 					continue

--- a/pkg/cypher/match_pattern_property_index_test.go
+++ b/pkg/cypher/match_pattern_property_index_test.go
@@ -824,15 +824,14 @@ WHERE rel.evidence_source = 'resolver/cross-repo'`,
 	require.Nil(t, result)
 }
 
-func TestMatchPatternProperty_BoundRelationshipDeleteReturnsTargetLookupError(t *testing.T) {
+func TestMatchPatternProperty_BoundRelationshipDeleteSkipsTargetLookupError(t *testing.T) {
 	exec, wrapped := newCountingExecutor(t)
 
-	lookupErr := errors.New("target lookup failed")
-	wrapped.getNodeErr = lookupErr
+	wrapped.getNodeErr = errors.New("target lookup failed")
 	_, ok, err := exec.boundRelationshipDeleteTargetNode(wrapped, "source", &storage.Edge{
 		StartNode: "source",
 		EndNode:   "target",
 	}, "outgoing")
-	require.ErrorIs(t, err, lookupErr)
+	require.NoError(t, err)
 	require.False(t, ok)
 }

--- a/pkg/cypher/match_pattern_property_index_test.go
+++ b/pkg/cypher/match_pattern_property_index_test.go
@@ -460,6 +460,115 @@ WHERE rel.evidence_source = 'resolver/cross-repo'
 	require.Equal(t, 1, result.Stats.RelationshipsDeleted)
 }
 
+func TestMatchPatternProperty_BoundRelationshipDeleteTransactionSourceUsesIndex(t *testing.T) {
+	exec, wrapped := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	for i := 0; i < 500; i++ {
+		_, err = exec.Execute(ctx,
+			"CREATE (:Repository {id:$id})",
+			map[string]interface{}{"id": fmt.Sprintf("repository:unrelated-%03d", i)})
+		require.NoError(t, err)
+	}
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+
+	wrapped.reset()
+	sourcePattern := nodePatternInfo{
+		variable: "source_repo",
+		labels:   []string{"Repository"},
+		properties: map[string]interface{}{
+			"id": "repository:source",
+		},
+	}
+	sources, err := exec.collectBoundRelationshipDeleteSources(ctx, sourcePattern, true)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	require.Equal(t, "repository:source", sources[0].Properties["id"])
+	require.Zerof(t, wrapped.GetNodesByLabelCalls(),
+		"transaction-mode bound relationship DELETE source lookup leaked %d GetNodesByLabel calls",
+		wrapped.GetNodesByLabelCalls())
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteTransactionSourceKeepsPendingNodes(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+
+	inner := exec.storage.(*storage.NamespacedEngine).GetInnerEngine().(*scanCountingEngine)
+	require.NoError(t, inner.EnsureNamespaceMVCC("scan"))
+	tx, err := inner.BeginTransaction()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+	require.NoError(t, tx.SetNamespace("scan"))
+
+	txWrapper := &transactionStorageWrapper{tx: tx, underlying: exec.storage, namespace: "scan", separator: ":"}
+	txCtx := context.WithValue(ctx, ctxKeyTxStorage, txWrapper)
+	txExec := exec.cloneWithStorage(txWrapper)
+	require.NoError(t, txWrapper.BulkCreateNodes([]*storage.Node{{
+		ID:     "pending-source-node",
+		Labels: []string{"Repository"},
+		Properties: map[string]interface{}{
+			"id": "repository:pending-source",
+		},
+	}}))
+
+	sourcePattern := nodePatternInfo{
+		variable: "source_repo",
+		labels:   []string{"Repository"},
+		properties: map[string]interface{}{
+			"id": "repository:pending-source",
+		},
+	}
+	sources, err := txExec.collectBoundRelationshipDeleteSources(txCtx, sourcePattern, true)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	require.Equal(t, "repository:pending-source", sources[0].Properties["id"])
+}
+
+func BenchmarkMatchPatternProperty_BoundRelationshipDeleteTransactionSourceLookup(b *testing.B) {
+	for _, repoCount := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("repositories=%d", repoCount), func(b *testing.B) {
+			exec, _ := newCountingExecutor(b)
+			ctx := context.Background()
+			_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+			require.NoError(b, err)
+			for i := 0; i < repoCount; i++ {
+				_, err = exec.Execute(ctx,
+					"CREATE (:Repository {id:$id})",
+					map[string]interface{}{"id": fmt.Sprintf("repository:unrelated-%05d", i)})
+				require.NoError(b, err)
+			}
+			_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+			require.NoError(b, err)
+
+			sourcePattern := nodePatternInfo{
+				variable: "source_repo",
+				labels:   []string{"Repository"},
+				properties: map[string]interface{}{
+					"id": "repository:source",
+				},
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sources, err := exec.collectBoundRelationshipDeleteSources(ctx, sourcePattern, true)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(sources) != 1 {
+					b.Fatalf("expected one source, got %d", len(sources))
+				}
+			}
+		})
+	}
+}
+
 func TestMatchPatternProperty_TryBoundRelationshipDeleteDeletesUnionAndLimitedMatches(t *testing.T) {
 	exec, _ := newCountingExecutor(t)
 

--- a/pkg/cypher/match_pattern_property_index_test.go
+++ b/pkg/cypher/match_pattern_property_index_test.go
@@ -33,7 +33,9 @@ package cypher
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -49,6 +51,10 @@ type scanCountingEngine struct {
 	*storage.MemoryEngine
 	allNodesCalls       int64
 	getNodesByLabelHits int64
+	outgoingEdgeCalls   int64
+	outgoingEdgeErr     error
+	incomingEdgeErr     error
+	getNodeErr          error
 }
 
 func (e *scanCountingEngine) AllNodes() ([]*storage.Node, error) {
@@ -61,14 +67,40 @@ func (e *scanCountingEngine) GetNodesByLabel(label string) ([]*storage.Node, err
 	return e.MemoryEngine.GetNodesByLabel(label)
 }
 
+func (e *scanCountingEngine) GetOutgoingEdges(nodeID storage.NodeID) ([]*storage.Edge, error) {
+	atomic.AddInt64(&e.outgoingEdgeCalls, 1)
+	if e.outgoingEdgeErr != nil {
+		return nil, e.outgoingEdgeErr
+	}
+	return e.MemoryEngine.GetOutgoingEdges(nodeID)
+}
+
+func (e *scanCountingEngine) GetIncomingEdges(nodeID storage.NodeID) ([]*storage.Edge, error) {
+	if e.incomingEdgeErr != nil {
+		return nil, e.incomingEdgeErr
+	}
+	return e.MemoryEngine.GetIncomingEdges(nodeID)
+}
+
+func (e *scanCountingEngine) GetNode(id storage.NodeID) (*storage.Node, error) {
+	if e.getNodeErr != nil {
+		return nil, e.getNodeErr
+	}
+	return e.MemoryEngine.GetNode(id)
+}
+
 func (e *scanCountingEngine) AllNodesCalls() int64 { return atomic.LoadInt64(&e.allNodesCalls) }
 func (e *scanCountingEngine) GetNodesByLabelCalls() int64 {
 	return atomic.LoadInt64(&e.getNodesByLabelHits)
+}
+func (e *scanCountingEngine) OutgoingEdgeCalls() int64 {
+	return atomic.LoadInt64(&e.outgoingEdgeCalls)
 }
 
 func (e *scanCountingEngine) reset() {
 	atomic.StoreInt64(&e.allNodesCalls, 0)
 	atomic.StoreInt64(&e.getNodesByLabelHits, 0)
+	atomic.StoreInt64(&e.outgoingEdgeCalls, 0)
 }
 
 // newCountingExecutor builds a StorageExecutor over a wrapped MemoryEngine.
@@ -316,4 +348,382 @@ func TestMatchPatternProperty_EdgeShapeNoDoubleScan(t *testing.T) {
 
 	require.Zerof(t, wrapped.AllNodesCalls(),
 		"graphify edge MATCH leaked %d AllNodes() calls", wrapped.AllNodesCalls())
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteUsesAdjacency(t *testing.T) {
+	exec, wrapped := newCountingExecutor(t)
+	seedScanTestPopulation(t, exec, 500)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+
+	for i := 0; i < 50; i++ {
+		_, err := exec.Execute(ctx,
+			"CREATE (:Repository {id:$id})",
+			map[string]interface{}{"id": fmt.Sprintf("repository:unrelated-%03d", i)})
+		require.NoError(t, err)
+	}
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:target'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:'repository:target'})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, nil)
+	require.NoError(t, err)
+
+	wrapped.reset()
+	deleteResult, err := exec.Execute(ctx, `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPENDS_ON|DEPLOYS_FROM|USES_MODULE]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+DELETE rel
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleteResult.Stats.RelationshipsDeleted)
+	require.LessOrEqual(t, wrapped.OutgoingEdgeCalls(), int64(1),
+		"bound relationship DELETE should expand only the bound source node, got %d outgoing probes",
+		wrapped.OutgoingEdgeCalls())
+
+	verify, err := exec.Execute(ctx, `
+MATCH ()-[rel:DEPLOYS_FROM]->()
+RETURN count(rel) AS c
+`, nil)
+	require.NoError(t, err)
+	require.Len(t, verify.Rows, 1)
+	require.Equal(t, int64(0), verify.Rows[0][0])
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteSegmentEligibility(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+	simple := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+`
+	require.True(t, isSimpleBoundRelationshipDeleteMatchSegment(simple))
+
+	limited, limitN, ok := parseBoundRelationshipDeleteWithLimitSegment(simple+`
+WITH rel LIMIT 1`, "rel")
+	require.True(t, ok)
+	require.Equal(t, 1, limitN)
+	require.Equal(t, strings.TrimSpace(simple), limited)
+
+	pseudo := strings.TrimSpace(simple) + " RETURN __delete_probe__"
+	returnIdx := findKeywordIndex(pseudo, "RETURN")
+	whereIdx := lastKeywordIndexBefore(pseudo, "WHERE", returnIdx)
+	clauses := splitMatchClauses(pseudo, whereIdx, returnIdx)
+	require.Len(t, clauses, 2)
+	sourcePattern := exec.parseNodePattern(context.Background(), clauses[0])
+	require.Equal(t, "source_repo", sourcePattern.variable)
+	relMatch := exec.parseTraversalPattern(context.Background(), clauses[1])
+	require.NotNil(t, relMatch)
+	require.Equal(t, "source_repo", relMatch.StartNode.variable)
+	require.Equal(t, "rel", relMatch.Relationship.Variable)
+	require.Equal(t, []string{"DEPLOYS_FROM"}, relMatch.Relationship.Types)
+	require.Equal(t, "outgoing", relMatch.Relationship.Direction)
+}
+
+func TestMatchPatternProperty_TryBoundRelationshipDeleteDeletesSimpleMatch(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:target'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:'repository:target'})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, nil)
+	require.NoError(t, err)
+
+	cypher := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+DELETE rel
+`
+	result, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx, `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+`, cypher, "rel", false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, result.Stats.RelationshipsDeleted)
+}
+
+func TestMatchPatternProperty_TryBoundRelationshipDeleteDeletesUnionAndLimitedMatches(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		_, err = exec.Execute(ctx,
+			"CREATE (:Repository {id:$id})",
+			map[string]interface{}{"id": fmt.Sprintf("repository:target-%d", i)})
+		require.NoError(t, err)
+		_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:$id})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, map[string]interface{}{"id": fmt.Sprintf("repository:target-%d", i)})
+		require.NoError(t, err)
+	}
+
+	result, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx, `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPENDS_ON|DEPLOYS_FROM|USES_MODULE]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+WITH rel LIMIT 1
+`, "", "rel", false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, result.Stats.RelationshipsDeleted)
+}
+
+func TestMatchPatternProperty_ExecuteDeleteUsesBoundRelationshipDelete(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:target'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:'repository:target'})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, nil)
+	require.NoError(t, err)
+
+	result, err := exec.executeDelete(ctx, `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+DELETE rel
+`)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Stats.RelationshipsDeleted)
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteRoutingPredicates(t *testing.T) {
+	cypher := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+DELETE rel
+`
+	trimmed := strings.TrimSpace(cypher)
+	require.Equal(t, 0, findKeywordIndex(trimmed, "MATCH"))
+	require.Equal(t, -1, findKeywordIndex(trimmed, "CREATE"))
+	require.Greater(t, findKeywordIndex(trimmed, "DELETE"), 0)
+	require.True(t, findKeywordIndex(trimmed, "DELETE") > 0)
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteHonorsWithLimit(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		_, err = exec.Execute(ctx,
+			"CREATE (:Repository {id:$id})",
+			map[string]interface{}{"id": fmt.Sprintf("repository:target-%d", i)})
+		require.NoError(t, err)
+		_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:$id})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, map[string]interface{}{"id": fmt.Sprintf("repository:target-%d", i)})
+		require.NoError(t, err)
+	}
+
+	deleteResult, err := exec.Execute(ctx, `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WITH rel LIMIT 1
+DELETE rel
+`, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleteResult.Stats.RelationshipsDeleted)
+
+	verify, err := exec.Execute(ctx, `
+MATCH ()-[rel:DEPLOYS_FROM]->()
+RETURN count(rel) AS c
+`, nil)
+	require.NoError(t, err)
+	require.Len(t, verify.Rows, 1)
+	require.Equal(t, int64(1), verify.Rows[0][0])
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteUsesTransactionSnapshot(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:target'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:'repository:target'})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, nil)
+	require.NoError(t, err)
+
+	inner := exec.storage.(*storage.NamespacedEngine).GetInnerEngine().(*scanCountingEngine)
+	require.NoError(t, inner.EnsureNamespaceMVCC("scan"))
+	tx, err := inner.BeginTransaction()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+	require.NoError(t, tx.SetNamespace("scan"))
+
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:late-target'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:'repository:late-target'})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, nil)
+	require.NoError(t, err)
+
+	txWrapper := &transactionStorageWrapper{tx: tx, underlying: exec.storage, namespace: "scan", separator: ":"}
+	txCtx := context.WithValue(ctx, ctxKeyTxStorage, txWrapper)
+	txExec := exec.cloneWithStorage(txWrapper)
+
+	result, ok, err := txExec.tryExecuteBoundRelationshipDelete(txCtx, `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+`, "", "rel", false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, result.Stats.RelationshipsDeleted)
+
+	require.NoError(t, tx.Commit())
+
+	verify, err := exec.Execute(ctx, `
+MATCH ()-[rel:DEPLOYS_FROM]->()
+RETURN count(rel) AS c
+`, nil)
+	require.NoError(t, err)
+	require.Len(t, verify.Rows, 1)
+	require.Equal(t, int64(1), verify.Rows[0][0])
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteReturnsCandidateLookupErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		direction string
+		configure func(*scanCountingEngine, error)
+	}{
+		{
+			name:      "outgoing",
+			direction: "outgoing",
+			configure: func(wrapped *scanCountingEngine, lookupErr error) {
+				wrapped.outgoingEdgeErr = lookupErr
+			},
+		},
+		{
+			name:      "incoming",
+			direction: "incoming",
+			configure: func(wrapped *scanCountingEngine, lookupErr error) {
+				wrapped.incomingEdgeErr = lookupErr
+			},
+		},
+		{
+			name:      "both outgoing",
+			direction: "both",
+			configure: func(wrapped *scanCountingEngine, lookupErr error) {
+				wrapped.outgoingEdgeErr = lookupErr
+			},
+		},
+		{
+			name:      "both incoming",
+			direction: "both",
+			configure: func(wrapped *scanCountingEngine, lookupErr error) {
+				wrapped.incomingEdgeErr = lookupErr
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, wrapped := newCountingExecutor(t)
+			lookupErr := errors.New(tt.name + " edge lookup failed")
+			tt.configure(wrapped, lookupErr)
+
+			_, err := exec.boundRelationshipDeleteCandidateEdges(wrapped, "source", tt.direction)
+			require.ErrorIs(t, err, lookupErr)
+		})
+	}
+}
+
+func TestMatchPatternProperty_TryBoundRelationshipDeletePropagatesCandidateLookupError(t *testing.T) {
+	exec, wrapped := newCountingExecutor(t)
+	seedScanTestPopulation(t, exec, 10)
+
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:source'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:target'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (source:Repository {id:'repository:source'})
+MATCH (target:Repository {id:'repository:target'})
+CREATE (source)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(target)
+`, nil)
+	require.NoError(t, err)
+
+	lookupErr := errors.New("outgoing edge lookup failed")
+	wrapped.outgoingEdgeErr = lookupErr
+	cypher := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPENDS_ON|DEPLOYS_FROM|USES_MODULE]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'
+DELETE rel
+`
+	result, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx,
+		`MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPENDS_ON|DEPLOYS_FROM|USES_MODULE]->(:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'`,
+		cypher,
+		"rel",
+		false)
+	require.ErrorIs(t, err, lookupErr)
+	require.True(t, ok)
+	require.Nil(t, result)
+}
+
+func TestMatchPatternProperty_BoundRelationshipDeleteReturnsTargetLookupError(t *testing.T) {
+	exec, wrapped := newCountingExecutor(t)
+
+	lookupErr := errors.New("target lookup failed")
+	wrapped.getNodeErr = lookupErr
+	_, ok, err := exec.boundRelationshipDeleteTargetNode(wrapped, "source", &storage.Edge{
+		StartNode: "source",
+		EndNode:   "target",
+	}, "outgoing")
+	require.ErrorIs(t, err, lookupErr)
+	require.False(t, ok)
 }

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -1382,7 +1382,7 @@ func (tx *BadgerTransaction) GetOutgoingEdges(nodeID NodeID) ([]*Edge, error) {
 		return nil, err
 	}
 
-	committed, err := tx.getCommittedAdjacentEdgesLocked(nodeID, "outgoing")
+	committed, err := tx.getCommittedAdjacentEdgesLocked(nodeID, Outgoing)
 	if err != nil {
 		return nil, err
 	}
@@ -1402,7 +1402,7 @@ func (tx *BadgerTransaction) GetIncomingEdges(nodeID NodeID) ([]*Edge, error) {
 		return nil, err
 	}
 
-	committed, err := tx.getCommittedAdjacentEdgesLocked(nodeID, "incoming")
+	committed, err := tx.getCommittedAdjacentEdgesLocked(nodeID, Incoming)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -1382,7 +1382,7 @@ func (tx *BadgerTransaction) GetOutgoingEdges(nodeID NodeID) ([]*Edge, error) {
 		return nil, err
 	}
 
-	committed, err := tx.engine.GetOutgoingEdges(nodeID)
+	committed, err := tx.getCommittedAdjacentEdgesLocked(nodeID, "outgoing")
 	if err != nil {
 		return nil, err
 	}
@@ -1402,7 +1402,7 @@ func (tx *BadgerTransaction) GetIncomingEdges(nodeID NodeID) ([]*Edge, error) {
 		return nil, err
 	}
 
-	committed, err := tx.engine.GetIncomingEdges(nodeID)
+	committed, err := tx.getCommittedAdjacentEdgesLocked(nodeID, "incoming")
 	if err != nil {
 		return nil, err
 	}
@@ -1510,7 +1510,7 @@ func (tx *BadgerTransaction) AllNodes() ([]*Node, error) {
 		return nil, err
 	}
 
-	committed, err := tx.engine.AllNodes()
+	committed, err := tx.getAllCommittedNodesLocked()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/badger_transaction_snapshot_reads.go
+++ b/pkg/storage/badger_transaction_snapshot_reads.go
@@ -7,6 +7,13 @@ func (tx *BadgerTransaction) getAllCommittedNodesLocked() ([]*Node, error) {
 	return tx.engine.GetNodesByLabelVisibleAt("", tx.readTS)
 }
 
+// getCommittedAdjacentEdgesLocked returns the committed edges adjacent to
+// nodeID in the requested direction. Under an active snapshot (non-zero read
+// timestamp) it resolves against the directional visible-at adjacency index so
+// the cost is O(deg(nodeID)) rather than O(E): the previous implementation
+// scanned every visible edge in the graph and filtered by endpoint in memory,
+// which degraded linearly with the total edge count on large graphs. Pending
+// transaction writes are merged by the caller.
 func (tx *BadgerTransaction) getCommittedAdjacentEdgesLocked(nodeID NodeID, direction string) ([]*Edge, error) {
 	if tx.readTS.IsZero() {
 		switch direction {
@@ -18,27 +25,12 @@ func (tx *BadgerTransaction) getCommittedAdjacentEdgesLocked(nodeID NodeID, dire
 			return nil, ErrInvalidData
 		}
 	}
-	edges, err := tx.engine.GetEdgesByTypeVisibleAt("", tx.readTS)
-	if err != nil {
-		return nil, err
+	switch direction {
+	case "outgoing":
+		return tx.engine.GetOutgoingEdgesVisibleAt(nodeID, tx.readTS)
+	case "incoming":
+		return tx.engine.GetIncomingEdgesVisibleAt(nodeID, tx.readTS)
+	default:
+		return nil, ErrInvalidData
 	}
-	filtered := make([]*Edge, 0, len(edges))
-	for _, edge := range edges {
-		if edge == nil {
-			continue
-		}
-		switch direction {
-		case "outgoing":
-			if edge.StartNode == nodeID {
-				filtered = append(filtered, edge)
-			}
-		case "incoming":
-			if edge.EndNode == nodeID {
-				filtered = append(filtered, edge)
-			}
-		default:
-			return nil, ErrInvalidData
-		}
-	}
-	return filtered, nil
 }

--- a/pkg/storage/badger_transaction_snapshot_reads.go
+++ b/pkg/storage/badger_transaction_snapshot_reads.go
@@ -1,0 +1,44 @@
+package storage
+
+func (tx *BadgerTransaction) getAllCommittedNodesLocked() ([]*Node, error) {
+	if tx.readTS.IsZero() {
+		return tx.engine.AllNodes()
+	}
+	return tx.engine.GetNodesByLabelVisibleAt("", tx.readTS)
+}
+
+func (tx *BadgerTransaction) getCommittedAdjacentEdgesLocked(nodeID NodeID, direction string) ([]*Edge, error) {
+	if tx.readTS.IsZero() {
+		switch direction {
+		case "outgoing":
+			return tx.engine.GetOutgoingEdges(nodeID)
+		case "incoming":
+			return tx.engine.GetIncomingEdges(nodeID)
+		default:
+			return nil, ErrInvalidData
+		}
+	}
+	edges, err := tx.engine.GetEdgesByTypeVisibleAt("", tx.readTS)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]*Edge, 0, len(edges))
+	for _, edge := range edges {
+		if edge == nil {
+			continue
+		}
+		switch direction {
+		case "outgoing":
+			if edge.StartNode == nodeID {
+				filtered = append(filtered, edge)
+			}
+		case "incoming":
+			if edge.EndNode == nodeID {
+				filtered = append(filtered, edge)
+			}
+		default:
+			return nil, ErrInvalidData
+		}
+	}
+	return filtered, nil
+}

--- a/pkg/storage/badger_transaction_snapshot_reads.go
+++ b/pkg/storage/badger_transaction_snapshot_reads.go
@@ -7,6 +7,18 @@ func (tx *BadgerTransaction) getAllCommittedNodesLocked() ([]*Node, error) {
 	return tx.engine.GetNodesByLabelVisibleAt("", tx.readTS)
 }
 
+// EdgeDirection selects which adjacency side an adjacency read resolves. It is
+// a typed enum rather than a raw string so the hot bound-relationship-delete
+// path compares an integer tag instead of magic strings.
+type EdgeDirection uint8
+
+const (
+	// Outgoing selects edges whose start node is the queried node.
+	Outgoing EdgeDirection = iota
+	// Incoming selects edges whose end node is the queried node.
+	Incoming
+)
+
 // getCommittedAdjacentEdgesLocked returns the committed edges adjacent to
 // nodeID in the requested direction. Under an active snapshot (non-zero read
 // timestamp) it resolves against the directional visible-at adjacency index so
@@ -14,21 +26,21 @@ func (tx *BadgerTransaction) getAllCommittedNodesLocked() ([]*Node, error) {
 // scanned every visible edge in the graph and filtered by endpoint in memory,
 // which degraded linearly with the total edge count on large graphs. Pending
 // transaction writes are merged by the caller.
-func (tx *BadgerTransaction) getCommittedAdjacentEdgesLocked(nodeID NodeID, direction string) ([]*Edge, error) {
+func (tx *BadgerTransaction) getCommittedAdjacentEdgesLocked(nodeID NodeID, direction EdgeDirection) ([]*Edge, error) {
 	if tx.readTS.IsZero() {
 		switch direction {
-		case "outgoing":
+		case Outgoing:
 			return tx.engine.GetOutgoingEdges(nodeID)
-		case "incoming":
+		case Incoming:
 			return tx.engine.GetIncomingEdges(nodeID)
 		default:
 			return nil, ErrInvalidData
 		}
 	}
 	switch direction {
-	case "outgoing":
+	case Outgoing:
 		return tx.engine.GetOutgoingEdgesVisibleAt(nodeID, tx.readTS)
-	case "incoming":
+	case Incoming:
 		return tx.engine.GetIncomingEdgesVisibleAt(nodeID, tx.readTS)
 	default:
 		return nil, ErrInvalidData

--- a/pkg/storage/badger_transaction_snapshot_reads_test.go
+++ b/pkg/storage/badger_transaction_snapshot_reads_test.go
@@ -93,9 +93,9 @@ func TestTransaction_SnapshotAdjacencyIsNodeLocalAndConsistent(t *testing.T) {
 }
 
 // TestTransaction_SnapshotAdjacencyRejectsUnknownDirection covers the defensive
-// guard in the snapshot branch: an unrecognized direction returns ErrInvalidData
-// rather than silently resolving. The callers only pass "outgoing"/"incoming",
-// so this guard is reachable only from within the package.
+// guard in the snapshot branch: an EdgeDirection outside Outgoing/Incoming
+// returns ErrInvalidData rather than silently resolving. The callers only pass
+// Outgoing/Incoming, so this guard is reachable only from within the package.
 func TestTransaction_SnapshotAdjacencyRejectsUnknownDirection(t *testing.T) {
 	engine := createTestBadgerEngine(t)
 	start, _, _ := seedSnapshotAdjacencyGraph(t, engine, 1)
@@ -106,7 +106,7 @@ func TestTransaction_SnapshotAdjacencyRejectsUnknownDirection(t *testing.T) {
 	require.False(t, tx.readTS.IsZero(), "read tx must pin a snapshot version")
 
 	tx.mu.Lock()
-	_, err = tx.getCommittedAdjacentEdgesLocked(start, "sideways")
+	_, err = tx.getCommittedAdjacentEdgesLocked(start, EdgeDirection(99))
 	tx.mu.Unlock()
 	require.ErrorIs(t, err, ErrInvalidData)
 }

--- a/pkg/storage/badger_transaction_snapshot_reads_test.go
+++ b/pkg/storage/badger_transaction_snapshot_reads_test.go
@@ -1,0 +1,145 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedSnapshotAdjacencyGraph creates a start node with a single outgoing edge
+// to target, plus unrelatedEdges edges wired between throwaway node pairs that
+// are NOT adjacent to start. It returns start, target, and the ID of the one
+// edge start actually owns. The unrelated edges inflate the total edge count so
+// a tx-snapshot adjacency read that scans all edges (O(E)) is distinguishable
+// from one that scans only start's adjacency (O(deg(start))).
+func seedSnapshotAdjacencyGraph(tb testing.TB, engine *BadgerEngine, unrelatedEdges int) (NodeID, NodeID, EdgeID) {
+	tb.Helper()
+
+	start := NodeID(prefixTestID("snap-adj-start"))
+	target := NodeID(prefixTestID("snap-adj-target"))
+	edgeID := EdgeID(prefixTestID("snap-adj-edge"))
+
+	_, err := engine.CreateNode(&Node{ID: start, Labels: []string{"Node"}})
+	require.NoError(tb, err)
+	_, err = engine.CreateNode(&Node{ID: target, Labels: []string{"Node"}})
+	require.NoError(tb, err)
+	require.NoError(tb, engine.CreateEdge(&Edge{ID: edgeID, StartNode: start, EndNode: target, Type: "LINKS"}))
+
+	for i := 0; i < unrelatedEdges; i++ {
+		from := NodeID(prefixTestID(fmt.Sprintf("snap-adj-noise-from-%d", i)))
+		to := NodeID(prefixTestID(fmt.Sprintf("snap-adj-noise-to-%d", i)))
+		_, err := engine.CreateNode(&Node{ID: from, Labels: []string{"Noise"}})
+		require.NoError(tb, err)
+		_, err = engine.CreateNode(&Node{ID: to, Labels: []string{"Noise"}})
+		require.NoError(tb, err)
+		require.NoError(tb, engine.CreateEdge(&Edge{
+			ID:        EdgeID(prefixTestID(fmt.Sprintf("snap-adj-noise-edge-%d", i))),
+			StartNode: from,
+			EndNode:   to,
+			Type:      "NOISE",
+		}))
+	}
+	return start, target, edgeID
+}
+
+// TestTransaction_SnapshotAdjacencyIsNodeLocalAndConsistent proves the Badger
+// transaction snapshot adjacency read returns exactly the bound node's edges
+// (not the whole graph's) and holds the snapshot across a concurrent commit.
+// This exercises getCommittedAdjacentEdgesLocked on the visible-at directional
+// adjacency path.
+func TestTransaction_SnapshotAdjacencyIsNodeLocalAndConsistent(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+
+	start, target, edgeID := seedSnapshotAdjacencyGraph(t, engine, 200)
+
+	txRead, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer txRead.Rollback()
+	require.False(t, txRead.readTS.IsZero(), "read tx must pin a snapshot version")
+
+	outBefore, err := txRead.GetOutgoingEdges(start)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(outBefore),
+		"outgoing adjacency must return only start's own edge, not the 200 unrelated edges")
+
+	inBefore, err := txRead.GetIncomingEdges(target)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(inBefore))
+
+	// Commit a second edge from start in a concurrent transaction.
+	laterTarget := NodeID(prefixTestID("snap-adj-target-later"))
+	laterEdgeID := EdgeID(prefixTestID("snap-adj-edge-later"))
+	txInsert, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	_, err = txInsert.CreateNode(&Node{ID: laterTarget, Labels: []string{"Node"}})
+	require.NoError(t, err)
+	require.NoError(t, txInsert.CreateEdge(&Edge{ID: laterEdgeID, StartNode: start, EndNode: laterTarget, Type: "LINKS"}))
+	require.NoError(t, txInsert.Commit())
+
+	// The read snapshot must not observe the post-begin edge.
+	outAfter, err := txRead.GetOutgoingEdges(start)
+	require.NoError(t, err)
+	require.Equal(t, sortedEdgeIDStrings(outBefore), sortedEdgeIDStrings(outAfter),
+		"snapshot read must be stable across a concurrent commit")
+
+	// A fresh transaction sees both edges.
+	txFresh, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer txFresh.Rollback()
+	freshOut, err := txFresh.GetOutgoingEdges(start)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(edgeID), string(laterEdgeID)}, sortedEdgeIDStrings(freshOut))
+}
+
+// TestTransaction_SnapshotAdjacencyRejectsUnknownDirection covers the defensive
+// guard in the snapshot branch: an unrecognized direction returns ErrInvalidData
+// rather than silently resolving. The callers only pass "outgoing"/"incoming",
+// so this guard is reachable only from within the package.
+func TestTransaction_SnapshotAdjacencyRejectsUnknownDirection(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+	start, _, _ := seedSnapshotAdjacencyGraph(t, engine, 1)
+
+	tx, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.False(t, tx.readTS.IsZero(), "read tx must pin a snapshot version")
+
+	tx.mu.Lock()
+	_, err = tx.getCommittedAdjacentEdgesLocked(start, "sideways")
+	tx.mu.Unlock()
+	require.ErrorIs(t, err, ErrInvalidData)
+}
+
+// BenchmarkTransaction_SnapshotAdjacency measures tx-snapshot outgoing adjacency
+// cost as the total edge count grows while the bound node's degree stays at 1.
+// A node-local read stays flat across edge counts; an all-edges scan degrades
+// linearly with the total edge count.
+func BenchmarkTransaction_SnapshotAdjacency(b *testing.B) {
+	for _, unrelatedEdges := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("edges=%d", unrelatedEdges), func(b *testing.B) {
+			engine, err := NewBadgerEngineInMemory()
+			require.NoError(b, err)
+			b.Cleanup(func() { engine.Close() })
+
+			start, _, _ := seedSnapshotAdjacencyGraph(b, engine, unrelatedEdges)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tx, err := engine.BeginTransaction()
+				if err != nil {
+					b.Fatal(err)
+				}
+				edges, err := tx.GetOutgoingEdges(start)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(edges) != 1 {
+					b.Fatalf("expected 1 outgoing edge, got %d", len(edges))
+				}
+				tx.Rollback()
+			}
+		})
+	}
+}

--- a/pkg/storage/transaction_snapshot_anomalies_test.go
+++ b/pkg/storage/transaction_snapshot_anomalies_test.go
@@ -144,6 +144,50 @@ func TestTransaction_LabelScanRepeatabilityWithinSnapshot(t *testing.T) {
 	require.Len(t, fresh, 4)
 }
 
+func TestTransaction_AllNodesRepeatabilityWithinSnapshot(t *testing.T) {
+	engine := NewMemoryEngine()
+	defer engine.Close()
+
+	for i := 0; i < 3; i++ {
+		_, err := engine.CreateNode(&Node{
+			ID:         NodeID(prefixTestID(fmt.Sprintf("all-node-%d", i))),
+			Labels:     []string{"Node"},
+			Properties: map[string]interface{}{"index": i},
+		})
+		require.NoError(t, err)
+	}
+
+	txScan, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer txScan.Rollback()
+
+	before, err := txScan.AllNodes()
+	require.NoError(t, err)
+	beforeIDs := sortedNodeIDs(before)
+
+	txInsert, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	_, err = txInsert.CreateNode(&Node{
+		ID:         NodeID(prefixTestID("all-node-new")),
+		Labels:     []string{"Node"},
+		Properties: map[string]interface{}{"index": 99},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txInsert.Commit())
+
+	after, err := txScan.AllNodes()
+	require.NoError(t, err)
+	afterIDs := sortedNodeIDs(after)
+	require.Equal(t, beforeIDs, afterIDs)
+
+	txFresh, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer txFresh.Rollback()
+	fresh, err := txFresh.AllNodes()
+	require.NoError(t, err)
+	require.Len(t, fresh, 4)
+}
+
 func TestTransaction_CreateEdgeConflictsWithConcurrentNodeDelete(t *testing.T) {
 	engine := NewMemoryEngine()
 	defer engine.Close()
@@ -175,6 +219,55 @@ func TestTransaction_CreateEdgeConflictsWithConcurrentNodeDelete(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 	_, err = engine.GetEdge(EdgeID(prefixTestID("edge-created-before-delete-commit")))
 	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestTransaction_AdjacencyRepeatabilityWithinSnapshot(t *testing.T) {
+	engine := NewMemoryEngine()
+	defer engine.Close()
+
+	start := NodeID(prefixTestID("adjacency-snapshot-start"))
+	target := NodeID(prefixTestID("adjacency-snapshot-target"))
+	firstEdgeID := EdgeID(prefixTestID("adjacency-snapshot-edge-first"))
+
+	_, err := engine.CreateNode(&Node{ID: start, Labels: []string{"Node"}})
+	require.NoError(t, err)
+	_, err = engine.CreateNode(&Node{ID: target, Labels: []string{"Node"}})
+	require.NoError(t, err)
+	require.NoError(t, engine.CreateEdge(&Edge{ID: firstEdgeID, StartNode: start, EndNode: target, Type: "LINKS"}))
+
+	txRead, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer txRead.Rollback()
+
+	outBefore, err := txRead.GetOutgoingEdges(start)
+	require.NoError(t, err)
+	inBefore, err := txRead.GetIncomingEdges(target)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(firstEdgeID)}, sortedEdgeIDStrings(outBefore))
+	require.Equal(t, []string{string(firstEdgeID)}, sortedEdgeIDStrings(inBefore))
+
+	laterTarget := NodeID(prefixTestID("adjacency-snapshot-target-later"))
+	laterEdgeID := EdgeID(prefixTestID("adjacency-snapshot-edge-later"))
+	txInsert, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	_, err = txInsert.CreateNode(&Node{ID: laterTarget, Labels: []string{"Node"}})
+	require.NoError(t, err)
+	require.NoError(t, txInsert.CreateEdge(&Edge{ID: laterEdgeID, StartNode: start, EndNode: laterTarget, Type: "LINKS"}))
+	require.NoError(t, txInsert.Commit())
+
+	outAfter, err := txRead.GetOutgoingEdges(start)
+	require.NoError(t, err)
+	inAfter, err := txRead.GetIncomingEdges(laterTarget)
+	require.NoError(t, err)
+	require.Equal(t, sortedEdgeIDStrings(outBefore), sortedEdgeIDStrings(outAfter))
+	require.Empty(t, inAfter)
+
+	txFresh, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer txFresh.Rollback()
+	freshOut, err := txFresh.GetOutgoingEdges(start)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(firstEdgeID), string(laterEdgeID)}, sortedEdgeIDStrings(freshOut))
 }
 
 func TestTransaction_EdgeTraversalRemainsSnapshotConsistentAcrossConcurrentDelete(t *testing.T) {
@@ -358,5 +451,16 @@ func sortedNodeIDs(nodes []*Node) []NodeID {
 		}
 	}
 	sort.Slice(ids, func(i, j int) bool { return string(ids[i]) < string(ids[j]) })
+	return ids
+}
+
+func sortedEdgeIDStrings(edges []*Edge) []string {
+	ids := make([]string, 0, len(edges))
+	for _, edge := range edges {
+		if edge != nil {
+			ids = append(ids, string(edge.ID))
+		}
+	}
+	sort.Strings(ids)
 	return ids
 }


### PR DESCRIPTION
## Summary

This PR improves one narrow relationship-delete shape: a query first binds a source node, then deletes one matching relationship from that source.

```cypher
MATCH (source:Label {id: ...})
MATCH (source)-[rel:TYPE|OTHER_TYPE]->(:TargetLabel)
WHERE rel.some_property = ...
DELETE rel
```

For that form, the executor can start from the already-bound source node instead of planning a broad traversal and discarding unrelated relationships later. The fast path still applies the relationship type, relationship properties, target-node pattern, and `WHERE` clause before deleting anything. Queries outside this strict shape continue through the existing delete paths.

The review pass tightened the safety boundaries around that optimization:

- The fast path now rejects non-simple row pipelines unless the only interposed pipeline is `WITH <rel> LIMIT <positive integer>`. It rejects `ORDER BY`, `SKIP`, `CALL`, `UNWIND`, and `OPTIONAL MATCH` in this path.
- `WITH rel LIMIT n DELETE rel` is now handled explicitly and deletes at most the limited row count.
- Transaction reads for `AllNodes`, `GetOutgoingEdges`, and `GetIncomingEdges` now use MVCC-visible committed state instead of current engine heads/indexes.
- Inside transaction wrappers, source-node collection avoids current property indexes and filters a snapshot-visible label/all-node population instead.
- Storage lookup errors from candidate relationship and target-node reads are returned to the caller instead of being treated as empty matches.

One deliberate trade-off: transaction-wrapper adjacency reads now prefer correctness over the current adjacency index until there is a snapshot-aware adjacency index. Non-transactional reads still use the existing adjacency index path.

## Verification

Passed locally on the rebased branch (`c4901451`):

- `go test ./pkg/cypher -run 'TestMatchPatternProperty_(BoundRelationshipDeleteSegmentEligibility|TryBoundRelationshipDeleteDeletesSimpleMatch|TryBoundRelationshipDeleteDeletesUnionAndLimitedMatches|ExecuteDeleteUsesBoundRelationshipDelete|BoundRelationshipDeleteRoutingPredicates|BoundRelationshipDeleteHonorsWithLimit|BoundRelationshipDeleteUsesTransactionSnapshot|BoundRelationshipDeleteUsesAdjacency|BoundRelationshipDeleteReturnsCandidateLookupErrors|TryBoundRelationshipDeletePropagatesCandidateLookupError|BoundRelationshipDeleteReturnsTargetLookupError)' -count=1 -v`\n- `go test ./pkg/storage -run 'TestTransaction_(AllNodesRepeatabilityWithinSnapshot|AdjacencyRepeatabilityWithinSnapshot|LabelScanRepeatabilityWithinSnapshot|EdgeTraversalRemainsSnapshotConsistentAcrossConcurrentDelete)' -count=1 -v`\n- `go test ./pkg/cypher -count=1`\n- `go test ./pkg/storage -count=1`\n- `go test ./pkg/cypher -run '^TestBenchmarkMatchCreateDelete$' -count=1 -v` — local run: `43341.64 ops/sec`, `0.023 ms/op`\n- `git diff --check`\n\nLocal setup note: `./scripts/build-llama.sh b9835` was run first so the normal untagged test binary links against `lib/llama/libllama_darwin_arm64.a`.\n