### PR TITLE
cover the bound relationship delete fast-path branches (follow-up to #230)

### DIFF
--- a/pkg/cypher/executor_mutations_relationship_delete_paths_test.go
+++ b/pkg/cypher/executor_mutations_relationship_delete_paths_test.go
@@ -128,3 +128,110 @@ WITH rel LIMIT 1`
 	require.NoError(t, err)
 	require.Equal(t, int64(1), verify.Rows[0][0], "one edge should remain")
 }
+
+// TestBoundRelationshipDelete_EligibilityGuards covers the pattern-shape guards
+// that decline the fast path when the two-clause bound-delete form is not met.
+func TestBoundRelationshipDelete_EligibilityGuards(t *testing.T) {
+	cases := []struct {
+		name      string
+		segment   string
+		deleteVar string
+	}{
+		{"unparseable with/limit segment", `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(:Repository)
+WITH rel SKIP 1`, "rel"},
+		{"limit base not simple", `
+MATCH (a) WITH a
+MATCH (a)-[rel]->(b)
+WITH rel LIMIT 1`, "rel"},
+		{"source clause has no variable", `
+MATCH ()
+MATCH (source_repo)-[rel]->(b)`, "rel"},
+		{"relationship pattern is chained", `
+MATCH (source_repo)
+MATCH (source_repo)-[rel]->(b)-[other]->(c)`, "rel"},
+		{"start variable not the source", `
+MATCH (source_repo)
+MATCH (other)-[rel]->(b)`, "rel"},
+		{"relationship variable is not the delete var", `
+MATCH (source_repo)
+MATCH (source_repo)-[other]->(b)`, "rel"},
+		{"variable length relationship", `
+MATCH (source_repo)
+MATCH (source_repo)-[rel*1..2]->(b)`, "rel"},
+	}
+	exec := seedBoundDeleteFixture(t, 1)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, ok, err := exec.tryExecuteBoundRelationshipDelete(context.Background(), tc.segment, "", tc.deleteVar, false)
+			require.NoError(t, err)
+			require.False(t, ok, "fast path should decline this shape")
+			require.Nil(t, res)
+		})
+	}
+}
+
+// TestBoundRelationshipDelete_DirectionVariants exercises the incoming and
+// both-direction candidate-edge branches.
+func TestBoundRelationshipDelete_DirectionVariants(t *testing.T) {
+	t.Run("incoming", func(t *testing.T) {
+		exec := seedBoundDeleteFixture(t, 1)
+		seg := `
+MATCH (target:Repository {id:'repository:target-a'})
+MATCH (target)<-[rel:DEPLOYS_FROM]-(:Repository)`
+		res, ok, err := exec.tryExecuteBoundRelationshipDelete(context.Background(), seg, "", "rel", false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, 1, res.Stats.RelationshipsDeleted)
+	})
+	t.Run("both", func(t *testing.T) {
+		exec := seedBoundDeleteFixture(t, 1)
+		seg := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]-(:Repository)`
+		res, ok, err := exec.tryExecuteBoundRelationshipDelete(context.Background(), seg, "", "rel", false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, 1, res.Stats.RelationshipsDeleted)
+	})
+}
+
+// TestBoundRelationshipDelete_NamedEndNodeWithWhere covers the branch that binds
+// a named end-node variable into the WHERE evaluation path.
+func TestBoundRelationshipDelete_NamedEndNodeWithWhere(t *testing.T) {
+	exec := seedBoundDeleteFixture(t, 1)
+	seg := `
+MATCH (source_repo:Repository {id:'repository:source'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]->(dest:Repository)
+WHERE rel.evidence_source = 'resolver/cross-repo'`
+	res, ok, err := exec.tryExecuteBoundRelationshipDelete(context.Background(), seg, "", "rel", false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, res.Stats.RelationshipsDeleted)
+}
+
+// TestBoundRelationshipDelete_SelfLoopBothDirectionDedup covers the seen-edge
+// dedup branch: a self-loop edge appears in both the outgoing and incoming
+// candidate sets for a both-direction match and must be deleted once.
+func TestBoundRelationshipDelete_SelfLoopBothDirectionDedup(t *testing.T) {
+	exec, _ := newCountingExecutor(t)
+	ctx := context.Background()
+	_, err := exec.Execute(ctx, "CREATE INDEX repo_id IF NOT EXISTS FOR (r:Repository) ON (r.id)", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, "CREATE (:Repository {id:'repository:self'})", nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+MATCH (s:Repository {id:'repository:self'})
+CREATE (s)-[:DEPLOYS_FROM {evidence_source:'resolver/cross-repo'}]->(s)
+`, nil)
+	require.NoError(t, err)
+
+	seg := `
+MATCH (source_repo:Repository {id:'repository:self'})
+MATCH (source_repo)-[rel:DEPLOYS_FROM]-(:Repository)`
+	res, ok, err := exec.tryExecuteBoundRelationshipDelete(ctx, seg, "", "rel", false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, res.Stats.RelationshipsDeleted, "self-loop edge must be deleted exactly once")
+}

--- a/pkg/storage/badger_transaction_snapshot_reads_test.go
+++ b/pkg/storage/badger_transaction_snapshot_reads_test.go
@@ -123,25 +123,26 @@ func TestTransaction_CommittedAdjacencyNoSnapshotUsesCurrentIndex(t *testing.T) 
 	require.NoError(t, err)
 	defer tx.Rollback()
 
-	// Force the no-snapshot path deterministically.
+	// The *Locked helpers require tx.mu held. Capture every result while
+	// holding the lock, release it, then assert: a failing assertion calls
+	// runtime.Goexit, which would run the deferred Rollback (also locks
+	// tx.mu) and deadlock if we asserted under the lock.
 	tx.mu.Lock()
-	tx.readTS = MVCCVersion{}
-	require.True(t, tx.readTS.IsZero())
-
-	out, err := tx.getCommittedAdjacentEdgesLocked(start, Outgoing)
-	require.NoError(t, err)
-	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(out))
-
-	in, err := tx.getCommittedAdjacentEdgesLocked(target, Incoming)
-	require.NoError(t, err)
-	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(in))
-
-	_, err = tx.getCommittedAdjacentEdgesLocked(start, EdgeDirection(99))
-	require.ErrorIs(t, err, ErrInvalidData)
-
-	nodes, err := tx.getAllCommittedNodesLocked()
+	tx.readTS = MVCCVersion{} // force the no-snapshot path deterministically
+	zeroed := tx.readTS.IsZero()
+	out, outErr := tx.getCommittedAdjacentEdgesLocked(start, Outgoing)
+	in, inErr := tx.getCommittedAdjacentEdgesLocked(target, Incoming)
+	_, badDirErr := tx.getCommittedAdjacentEdgesLocked(start, EdgeDirection(99))
+	nodes, nodesErr := tx.getAllCommittedNodesLocked()
 	tx.mu.Unlock()
-	require.NoError(t, err)
+
+	require.True(t, zeroed)
+	require.NoError(t, outErr)
+	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(out))
+	require.NoError(t, inErr)
+	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(in))
+	require.ErrorIs(t, badDirErr, ErrInvalidData)
+	require.NoError(t, nodesErr)
 	require.NotEmpty(t, nodes)
 }
 

--- a/pkg/storage/badger_transaction_snapshot_reads_test.go
+++ b/pkg/storage/badger_transaction_snapshot_reads_test.go
@@ -111,6 +111,40 @@ func TestTransaction_SnapshotAdjacencyRejectsUnknownDirection(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidData)
 }
 
+// TestTransaction_CommittedAdjacencyNoSnapshotUsesCurrentIndex covers the
+// no-snapshot branch (zero read timestamp) of the committed-adjacency and
+// committed-nodes helpers, where reads fall back to the current index/head
+// rather than the visible-at path.
+func TestTransaction_CommittedAdjacencyNoSnapshotUsesCurrentIndex(t *testing.T) {
+	engine := createTestBadgerEngine(t)
+	start, target, edgeID := seedSnapshotAdjacencyGraph(t, engine, 1)
+
+	tx, err := engine.BeginTransaction()
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// Force the no-snapshot path deterministically.
+	tx.mu.Lock()
+	tx.readTS = MVCCVersion{}
+	require.True(t, tx.readTS.IsZero())
+
+	out, err := tx.getCommittedAdjacentEdgesLocked(start, Outgoing)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(out))
+
+	in, err := tx.getCommittedAdjacentEdgesLocked(target, Incoming)
+	require.NoError(t, err)
+	require.Equal(t, []string{string(edgeID)}, sortedEdgeIDStrings(in))
+
+	_, err = tx.getCommittedAdjacentEdgesLocked(start, EdgeDirection(99))
+	require.ErrorIs(t, err, ErrInvalidData)
+
+	nodes, err := tx.getAllCommittedNodesLocked()
+	tx.mu.Unlock()
+	require.NoError(t, err)
+	require.NotEmpty(t, nodes)
+}
+
 // BenchmarkTransaction_SnapshotAdjacency measures tx-snapshot outgoing adjacency
 // cost as the total edge count grows while the bound node's degree stays at 1.
 // A node-local read stays flat across edge counts; an all-edges scan degrades


### PR DESCRIPTION
Quick follow-up to #230 now that it's merged. Backfilling the branch coverage on the bound relationship delete fast path and the transaction snapshot adjacency reader we added there — tests only, no production change.

**pkg/cypher** (`tryExecuteBoundRelationshipDelete` 84% -> 93%, candidate-edge discovery -> 100%):
- the eligibility guards that decline the fast path: unparseable `WITH/LIMIT`, non-simple limit base, sourceless first clause, chained relationship, start var != source, rel var != delete var, variable-length hop
- incoming and both-direction candidate discovery
- a named end-node bound into the `WHERE` evaluation path
- self-loop both-direction dedup — the edge shows up on both the outgoing and incoming side and must be deleted exactly once

**pkg/storage**:
- the no-snapshot branch of `getCommittedAdjacentEdgesLocked` / `getAllCommittedNodesLocked` (zero read timestamp falls back to the current index/head), including the `EdgeDirection` guard

Verification:

```text
go test ./pkg/cypher ./pkg/storage -count=1
ok github.com/orneryd/nornicdb/pkg/cypher
ok github.com/orneryd/nornicdb/pkg/storage
```
