### PR TITLE
fix(cypher): bind UNWIND deletes in explicit transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to NornicDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Bolt explicit transactions now bind top-level `UNWIND` rows before
+  relationship deletion.**
+  `session.ExecuteWrite` queries shaped as `UNWIND ... MATCH ... DELETE`
+  previously routed directly to the delete handler before the UNWIND variable
+  was bound, returned success with zero delete counters, and left matching
+  relationships intact. Explicit transactions now use the same UNWIND-first
+  dispatch order as autocommit, and aggregate per-row mutation counters for
+  Bolt result summaries.
+
 ## [v1.1.11] - 7/9/2026
 
 ### Added

--- a/pkg/bolt/execute_write_relationship_delete_test.go
+++ b/pkg/bolt/execute_write_relationship_delete_test.go
@@ -1,0 +1,179 @@
+package bolt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseManagerBoltExecuteWriteDeletesUnwindMatchedRelationship(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	mgr := &mockDBManager{
+		stores: map[string]storage.Engine{
+			"nornic": storage.NewNamespacedEngine(base, "nornic"),
+		},
+		defaultDB: "nornic",
+	}
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		MaxConnections:  8,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	port := startBoltTestServer(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, driver.Close(context.Background()))
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		require.NoError(t, session.Close(ctx))
+	}()
+
+	for _, query := range []string{
+		"CREATE (:Function {uid: 'source-delete-a'}), (:Function {uid: 'target-delete-a'}), (:Function {uid: 'source-delete-b'}), (:Function {uid: 'target-delete-b'}), (:Function {uid: 'source-keep'}), (:Function {uid: 'target-keep'}), (:Function {uid: 'source-rollback'}), (:Function {uid: 'target-rollback'})",
+		"MATCH (s:Function {uid: 'source-delete-a'}), (t:Function {uid: 'target-delete-a'}) CREATE (s)-[:TAINT_FLOWS_TO {evidence_source: 'wanted'}]->(t)",
+		"MATCH (s:Function {uid: 'source-delete-b'}), (t:Function {uid: 'target-delete-b'}) CREATE (s)-[:TAINT_FLOWS_TO {evidence_source: 'wanted'}]->(t)",
+		"MATCH (s:Function {uid: 'source-delete-a'}), (t:Function {uid: 'target-delete-b'}) CREATE (s)-[:TAINT_FLOWS_TO {evidence_source: 'other'}]->(t)",
+		"MATCH (s:Function {uid: 'source-keep'}), (t:Function {uid: 'target-keep'}) CREATE (s)-[:TAINT_FLOWS_TO {evidence_source: 'wanted'}]->(t)",
+		"MATCH (s:Function {uid: 'source-rollback'}), (t:Function {uid: 'target-rollback'}) CREATE (s)-[:TAINT_FLOWS_TO {evidence_source: 'wanted'}]->(t)",
+	} {
+		result, runErr := session.Run(ctx, query, nil)
+		require.NoError(t, runErr)
+		_, consumeErr := result.Consume(ctx)
+		require.NoError(t, consumeErr)
+	}
+
+	executeDelete := func(uids []string) neo4jdriver.ResultSummary {
+		t.Helper()
+		summaryValue, executeErr := session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+			result, runErr := tx.Run(ctx, `UNWIND $uids AS suid
+MATCH (s:Function {uid: suid})-[rel:TAINT_FLOWS_TO]->()
+WHERE rel.evidence_source = $evidence_source
+DELETE rel`, map[string]any{
+				"uids":            uids,
+				"evidence_source": "wanted",
+			})
+			if runErr != nil {
+				return nil, runErr
+			}
+			return result.Consume(ctx)
+		})
+		require.NoError(t, executeErr)
+		summary, ok := summaryValue.(neo4jdriver.ResultSummary)
+		require.True(t, ok, "ExecuteWrite result type = %T, want neo4j.ResultSummary", summaryValue)
+		return summary
+	}
+
+	rollbackErr := errors.New("force rollback")
+	_, err = session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, runErr := tx.Run(ctx, `UNWIND $uids AS suid
+MATCH (s:Function {uid: suid})-[rel:TAINT_FLOWS_TO]->()
+WHERE rel.evidence_source = $evidence_source
+DELETE rel`, map[string]any{
+			"uids":            []string{"source-rollback"},
+			"evidence_source": "wanted",
+		})
+		if runErr != nil {
+			return nil, runErr
+		}
+		summary, consumeErr := result.Consume(ctx)
+		if consumeErr != nil {
+			return nil, consumeErr
+		}
+		require.Equal(t, 1, summary.Counters().RelationshipsDeleted())
+		return nil, rollbackErr
+	})
+	require.ErrorIs(t, err, rollbackErr)
+
+	result, err := session.Run(ctx, `MATCH (:Function {uid: 'source-rollback'})-[rel:TAINT_FLOWS_TO]->(:Function {uid: 'target-rollback'}) RETURN count(rel)`, nil)
+	require.NoError(t, err)
+	record, err := result.Single(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), record.Values[0], "callback error must roll back the relationship deletion")
+
+	summary := executeDelete(nil)
+	require.Zero(t, summary.Counters().RelationshipsDeleted(), "empty UNWIND input must be a no-op")
+
+	summary = executeDelete([]string{"source-delete-a", "missing-source", "source-delete-a", "source-delete-b"})
+	require.Equal(t, 2, summary.Counters().RelationshipsDeleted())
+
+	assertSurvivors := func() {
+		t.Helper()
+		result, runErr := session.Run(ctx, `MATCH (s:Function)-[rel:TAINT_FLOWS_TO]->(t:Function)
+RETURN s.uid, rel.evidence_source, t.uid
+ORDER BY s.uid, rel.evidence_source, t.uid`, nil)
+		require.NoError(t, runErr)
+		records, collectErr := result.Collect(ctx)
+		require.NoError(t, collectErr)
+		require.Len(t, records, 3)
+		require.Equal(t, []any{"source-delete-a", "other", "target-delete-b"}, records[0].Values)
+		require.Equal(t, []any{"source-keep", "wanted", "target-keep"}, records[1].Values)
+		require.Equal(t, []any{"source-rollback", "wanted", "target-rollback"}, records[2].Values)
+	}
+	assertSurvivors()
+
+	result, err = session.Run(ctx, "MATCH (n:Function) RETURN n", nil)
+	require.NoError(t, err)
+	records, err := result.Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, records, 8, "relationship deletion must preserve all endpoint nodes")
+
+	summary = executeDelete([]string{"source-delete-a", "source-delete-b"})
+	require.Zero(t, summary.Counters().RelationshipsDeleted(), "repeated delete must be idempotent")
+
+	assertSurvivors()
+
+	result, err = session.Run(ctx, "CREATE (:MutationNode {uid: 'mutation-a', legacy: true}), (:MutationNode {uid: 'mutation-b', legacy: true})", nil)
+	require.NoError(t, err)
+	_, err = result.Consume(ctx)
+	require.NoError(t, err)
+
+	executeMutation := func(query string) neo4jdriver.ResultSummary {
+		t.Helper()
+		summaryValue, executeErr := session.ExecuteWrite(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+			result, runErr := tx.Run(ctx, query, map[string]any{
+				"uids": []string{"mutation-a", "mutation-b"},
+			})
+			if runErr != nil {
+				return nil, runErr
+			}
+			return result.Consume(ctx)
+		})
+		require.NoError(t, executeErr)
+		summary, ok := summaryValue.(neo4jdriver.ResultSummary)
+		require.True(t, ok, "ExecuteWrite result type = %T, want neo4j.ResultSummary", summaryValue)
+		return summary
+	}
+
+	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) SET n.marked = true")
+	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND MATCH SET must aggregate per-row counters")
+
+	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) REMOVE n.legacy")
+	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND MATCH REMOVE must aggregate per-row counters")
+
+	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) DETACH DELETE n")
+	require.Equal(t, 2, summary.Counters().NodesDeleted(), "UNWIND MATCH DELETE must aggregate per-row counters")
+
+	result, err = session.Run(ctx, "MATCH (n:MutationNode) RETURN count(n)", nil)
+	require.NoError(t, err)
+	record, err = result.Single(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), record.Values[0])
+}

--- a/pkg/bolt/execute_write_relationship_delete_test.go
+++ b/pkg/bolt/execute_write_relationship_delete_test.go
@@ -13,6 +13,9 @@ import (
 
 func TestDatabaseManagerBoltExecuteWriteDeletesUnwindMatchedRelationship(t *testing.T) {
 	base := storage.NewMemoryEngine()
+	t.Cleanup(func() {
+		require.NoError(t, base.Close())
+	})
 	mgr := &mockDBManager{
 		stores: map[string]storage.Engine{
 			"nornic": storage.NewNamespacedEngine(base, "nornic"),
@@ -162,14 +165,28 @@ ORDER BY s.uid, rel.evidence_source, t.uid`, nil)
 		return summary
 	}
 
-	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) SET n.marked = true")
-	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND MATCH SET must aggregate per-row counters")
+	summary = executeMutation("UNWIND $uids AS uid CREATE (n:UnwindCreated {uid: uid}) SET n.marked = true")
+	require.Equal(t, 2, summary.Counters().NodesCreated(), "UNWIND CREATE must aggregate per-row node counters")
+	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND CREATE SET must aggregate per-row property counters")
 
-	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) REMOVE n.legacy")
-	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND MATCH REMOVE must aggregate per-row counters")
+	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) WITH n SET n.marked = true")
+	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND MATCH WITH SET must aggregate per-row counters")
+	result, err = session.Run(ctx, "MATCH (n:MutationNode {marked: true}) RETURN count(n)", nil)
+	require.NoError(t, err)
+	record, err = result.Single(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), record.Values[0], "UNWIND MATCH WITH SET must update every matched node")
 
-	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) DETACH DELETE n")
-	require.Equal(t, 2, summary.Counters().NodesDeleted(), "UNWIND MATCH DELETE must aggregate per-row counters")
+	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) WITH n REMOVE n.legacy")
+	require.Equal(t, 2, summary.Counters().PropertiesSet(), "UNWIND MATCH WITH REMOVE must aggregate per-row counters")
+	result, err = session.Run(ctx, "MATCH (n:MutationNode {legacy: true}) RETURN count(n)", nil)
+	require.NoError(t, err)
+	record, err = result.Single(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), record.Values[0], "UNWIND MATCH WITH REMOVE must update every matched node")
+
+	summary = executeMutation("UNWIND $uids AS uid MATCH (n:MutationNode {uid: uid}) WITH n DETACH DELETE n")
+	require.Equal(t, 2, summary.Counters().NodesDeleted(), "UNWIND MATCH WITH DELETE must aggregate per-row counters")
 
 	result, err = session.Run(ctx, "MATCH (n:MutationNode) RETURN count(n)", nil)
 	require.NoError(t, err)

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -1000,6 +1000,7 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 			if subResult == nil {
 				continue
 			}
+			addQueryStats(result.Stats, subResult.Stats)
 			if len(result.Columns) == 0 {
 				result.Columns = append([]string(nil), subResult.Columns...)
 			}

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -742,6 +742,7 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 					withPrefix = strings.TrimSpace(mutationPart[:withIdx])
 				}
 				countAlias, countReturnOnly := parseUnwindBatchCountReturn(returnPart)
+				countReturnOnly = returnPart != "" && countReturnOnly
 				var processedRows int64
 				for _, item := range items {
 					fullQuery := mutationPart
@@ -774,9 +775,8 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 					if err != nil {
 						return nil, fmt.Errorf("UNWIND mutation failed: %w", err)
 					}
-					if mutationResult != nil && mutationResult.Stats != nil {
-						result.Stats.NodesCreated += mutationResult.Stats.NodesCreated
-						result.Stats.RelationshipsCreated += mutationResult.Stats.RelationshipsCreated
+					if mutationResult != nil {
+						addQueryStats(result.Stats, mutationResult.Stats)
 					}
 					if mutationResult != nil && returnPart != "" && len(mutationResult.Rows) > 0 {
 						if len(result.Columns) == 0 {
@@ -902,9 +902,8 @@ func (e *StorageExecutor) executeUnwind(ctx context.Context, cypher string) (*Ex
 
 				// Accumulate stats when available. Some execution paths can return a
 				// nil Stats pointer even when the side-effect succeeded.
-				if mutationResult != nil && mutationResult.Stats != nil {
-					result.Stats.NodesCreated += mutationResult.Stats.NodesCreated
-					result.Stats.RelationshipsCreated += mutationResult.Stats.RelationshipsCreated
+				if mutationResult != nil {
+					addQueryStats(result.Stats, mutationResult.Stats)
 				}
 
 				// If there's a RETURN clause, collect the result rows
@@ -1798,9 +1797,8 @@ func (e *StorageExecutor) executeUnwindCompoundMutationBatch(ctx context.Context
 		if !supported {
 			return nil, false, nil
 		}
-		if fast != nil && fast.Stats != nil {
-			result.Stats.NodesCreated += fast.Stats.NodesCreated
-			result.Stats.RelationshipsCreated += fast.Stats.RelationshipsCreated
+		if fast != nil {
+			addQueryStats(result.Stats, fast.Stats)
 		}
 	}
 	e.markCompoundQueryFastPathUsed()

--- a/pkg/cypher/executor_mutations.go
+++ b/pkg/cypher/executor_mutations.go
@@ -2234,12 +2234,29 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 		return nil, fmt.Errorf("REMOVE requires a MATCH clause first (e.g., MATCH (n) REMOVE n.property)")
 	}
 
-	// Execute the match first
-	matchQuery := normalized[matchIdx:removeIdx] + " RETURN *"
+	// Execute the MATCH/WITH pipeline while preserving every entity that can
+	// remain in scope after WITH. Returning explicit variables avoids the
+	// legacy MATCH/WITH projection treating RETURN * as an unbound expression.
+	matchSegment := normalized[matchIdx:removeIdx]
+	matchPartEnd := len(matchSegment)
+	if withIdx := findKeywordIndex(matchSegment, "WITH"); withIdx >= 0 {
+		matchPartEnd = withIdx
+	}
+	matchPattern := strings.TrimSpace(matchSegment[len("MATCH"):matchPartEnd])
+	matchVars := e.extractVariableNamesFromPattern(matchPattern)
+	withAliases := extractWithAliases(matchSegment)
+	allVars := dedupeNonEmpty(matchVars, withAliases)
+	matchQuery := matchSegment + " RETURN *"
+	if len(allVars) > 0 {
+		matchQuery = matchSegment + " RETURN " + strings.Join(allVars, ", ")
+	}
 	matchResult, err := e.executeMatch(ctx, matchQuery)
 	if err != nil {
 		return nil, err
 	}
+	// MATCH ... WITH projections can surface nodes as maps. REMOVE needs the
+	// live storage entities so property and label mutations reach the graph.
+	e.normalizeSetMatchRowsToNodes(matchResult, store)
 
 	// Parse REMOVE clause: REMOVE n.prop1, n.prop2, n:Label
 	var removePart string

--- a/pkg/cypher/query_stats.go
+++ b/pkg/cypher/query_stats.go
@@ -1,0 +1,14 @@
+package cypher
+
+// addQueryStats accumulates mutation counters from nested execution paths.
+func addQueryStats(total, delta *QueryStats) {
+	if total == nil || delta == nil {
+		return
+	}
+	total.NodesCreated += delta.NodesCreated
+	total.NodesDeleted += delta.NodesDeleted
+	total.RelationshipsCreated += delta.RelationshipsCreated
+	total.RelationshipsDeleted += delta.RelationshipsDeleted
+	total.PropertiesSet += delta.PropertiesSet
+	total.LabelsAdded += delta.LabelsAdded
+}

--- a/pkg/cypher/query_stats_test.go
+++ b/pkg/cypher/query_stats_test.go
@@ -1,0 +1,38 @@
+package cypher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddQueryStats(t *testing.T) {
+	total := &QueryStats{
+		NodesCreated:         1,
+		NodesDeleted:         2,
+		RelationshipsCreated: 3,
+		RelationshipsDeleted: 4,
+		PropertiesSet:        5,
+		LabelsAdded:          6,
+	}
+	addQueryStats(total, &QueryStats{
+		NodesCreated:         6,
+		NodesDeleted:         5,
+		RelationshipsCreated: 4,
+		RelationshipsDeleted: 3,
+		PropertiesSet:        2,
+		LabelsAdded:          1,
+	})
+
+	require.Equal(t, &QueryStats{
+		NodesCreated:         7,
+		NodesDeleted:         7,
+		RelationshipsCreated: 7,
+		RelationshipsDeleted: 7,
+		PropertiesSet:        7,
+		LabelsAdded:          7,
+	}, total)
+
+	addQueryStats(nil, total)
+	addQueryStats(total, nil)
+}

--- a/pkg/cypher/transaction.go
+++ b/pkg/cypher/transaction.go
@@ -428,6 +428,14 @@ func (e *StorageExecutor) executeQueryAgainstStorage(ctx context.Context, cypher
 		return e.executeMultipleCreates(ctx, cypher)
 	}
 
+	// Bind top-level UNWIND rows before classifying mutations in the trailing
+	// query. Autocommit uses the same ordering; routing DELETE first would drop
+	// the UNWIND binding and silently turn a matched relationship delete into a
+	// successful no-op inside an explicit transaction.
+	if strings.HasPrefix(upper, "UNWIND") {
+		return e.executeUnwind(ctx, cypher)
+	}
+
 	// Check for DELETE queries (MATCH...DELETE, DETACH DELETE)
 	// But NOT if it's a MATCH...CREATE...DELETE pattern (handled above)
 	hasCreate := findKeywordIndex(cypher, "CREATE") > 0
@@ -562,8 +570,6 @@ func (e *StorageExecutor) executeQueryAgainstStorage(ctx context.Context, cypher
 		strings.HasPrefix(upper, "ALTER PROMOTION PROFILE"),
 		strings.HasPrefix(upper, "ALTER PROMOTION POLICY"):
 		return e.executeKnowledgePolicyDDL(ctx, cypher)
-	case strings.HasPrefix(upper, "UNWIND"):
-		return e.executeUnwind(ctx, cypher)
 	case strings.HasPrefix(upper, "WITH"):
 		return e.executeWith(ctx, cypher)
 	case strings.HasPrefix(upper, "FOREACH"):

--- a/pkg/cypher/transaction_unwind_delete_bench_test.go
+++ b/pkg/cypher/transaction_unwind_delete_bench_test.go
@@ -1,0 +1,98 @@
+package cypher
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+func BenchmarkUnwindRelationshipDeleteTransactionRouting(b *testing.B) {
+	const query = `UNWIND $uids AS suid
+MATCH (s:Function {uid: suid})-[rel:TAINT_FLOWS_TO]->()
+DELETE rel`
+
+	for _, batchSize := range []int{1, 100} {
+		b.Run(fmt.Sprintf("batch_%d", batchSize), func(b *testing.B) {
+			for _, explicit := range []bool{false, true} {
+				name := "autocommit"
+				if explicit {
+					name = "explicit"
+				}
+				b.Run(name, func(b *testing.B) {
+					ctx := context.Background()
+					b.ReportAllocs()
+
+					for i := 0; i < b.N; i++ {
+						b.StopTimer()
+						store := storage.NewMemoryEngine()
+						exec := NewStorageExecutor(store)
+						uids := make([]string, 0, batchSize)
+						edgeIDs := make([]storage.EdgeID, 0, batchSize)
+						for j := 0; j < batchSize; j++ {
+							uid := fmt.Sprintf("source-%d", j)
+							targetUID := fmt.Sprintf("target-%d", j)
+							sourceID, err := store.CreateNode(&storage.Node{
+								ID:         storage.NodeID("nornic:" + uid),
+								Labels:     []string{"Function"},
+								Properties: map[string]any{"uid": uid},
+							})
+							if err != nil {
+								b.Fatal(err)
+							}
+							targetID, err := store.CreateNode(&storage.Node{
+								ID:         storage.NodeID("nornic:" + targetUID),
+								Labels:     []string{"Function"},
+								Properties: map[string]any{"uid": targetUID},
+							})
+							if err != nil {
+								b.Fatal(err)
+							}
+							edgeID := storage.EdgeID(fmt.Sprintf("nornic:edge-%d", j))
+							if err := store.CreateEdge(&storage.Edge{
+								ID:        edgeID,
+								StartNode: sourceID,
+								EndNode:   targetID,
+								Type:      "TAINT_FLOWS_TO",
+							}); err != nil {
+								b.Fatal(err)
+							}
+							uids = append(uids, uid)
+							edgeIDs = append(edgeIDs, edgeID)
+						}
+						b.StartTimer()
+
+						if explicit {
+							if _, err := exec.Execute(ctx, "BEGIN", nil); err != nil {
+								b.Fatal(err)
+							}
+						}
+						result, err := exec.Execute(ctx, query, map[string]any{"uids": uids})
+						if err != nil {
+							b.Fatal(err)
+						}
+						if explicit {
+							if _, err := exec.Execute(ctx, "COMMIT", nil); err != nil {
+								b.Fatal(err)
+							}
+						}
+						b.StopTimer()
+
+						if result.Stats == nil || result.Stats.RelationshipsDeleted != batchSize {
+							b.Fatalf("relationships deleted = %+v, want %d", result.Stats, batchSize)
+						}
+						for _, edgeID := range edgeIDs {
+							if _, err := store.GetEdge(edgeID); err == nil {
+								b.Fatalf("edge %s survived", edgeID)
+							}
+						}
+						if err := store.Close(); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/cypher/transaction_unwind_delete_test.go
+++ b/pkg/cypher/transaction_unwind_delete_test.go
@@ -1,0 +1,86 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExplicitTransactionUnwindDeleteCommitAndRollback prevents a regression
+// where explicit transactions routed DELETE before binding a top-level UNWIND
+// variable, silently committing zero relationship deletions.
+func TestExplicitTransactionUnwindDeleteCommitAndRollback(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		terminal      string
+		remainingEdge int64
+	}{
+		{name: "commit", terminal: "COMMIT", remainingEdge: 0},
+		{name: "rollback", terminal: "ROLLBACK", remainingEdge: 1},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := storage.NewMemoryEngine()
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			exec := NewStorageExecutor(storage.NewNamespacedEngine(store, "test"))
+			ctx := context.Background()
+
+			for _, query := range []string{
+				"CREATE (:Function {uid: 'source'}), (:Function {uid: 'target'})",
+				"MATCH (s:Function {uid: 'source'}), (t:Function {uid: 'target'}) CREATE (s)-[:TAINT_FLOWS_TO {evidence_source: 'wanted'}]->(t)",
+			} {
+				_, err := exec.Execute(ctx, query, nil)
+				require.NoError(t, err)
+			}
+
+			_, err := exec.Execute(ctx, "BEGIN", nil)
+			require.NoError(t, err)
+			result, err := exec.Execute(ctx, `UNWIND $uids AS suid
+MATCH (s:Function {uid: suid})-[rel:TAINT_FLOWS_TO]->()
+WHERE rel.evidence_source = $evidence_source
+DELETE rel`, map[string]any{
+				"uids":            []string{"source", "missing", "source"},
+				"evidence_source": "wanted",
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, result.Stats.RelationshipsDeleted)
+
+			_, err = exec.Execute(ctx, testCase.terminal, nil)
+			require.NoError(t, err)
+
+			result, err = exec.Execute(ctx, "MATCH (:Function {uid: 'source'})-[rel:TAINT_FLOWS_TO]->(:Function {uid: 'target'}) RETURN count(rel)", nil)
+			require.NoError(t, err)
+			require.Equal(t, testCase.remainingEdge, countFromResult(t, result))
+		})
+	}
+}
+
+func TestExplicitTransactionUnwindDeleteEmptyInput(t *testing.T) {
+	store := storage.NewMemoryEngine()
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	exec := NewStorageExecutor(storage.NewNamespacedEngine(store, "test"))
+	ctx := context.Background()
+
+	for _, query := range []string{
+		"CREATE (:Function {uid: 'source'}), (:Function {uid: 'target'})",
+		"MATCH (s:Function {uid: 'source'}), (t:Function {uid: 'target'}) CREATE (s)-[:TAINT_FLOWS_TO]->(t)",
+	} {
+		_, err := exec.Execute(ctx, query, nil)
+		require.NoError(t, err)
+	}
+
+	_, err := exec.Execute(ctx, "BEGIN", nil)
+	require.NoError(t, err)
+	result, err := exec.Execute(ctx, `UNWIND $uids AS suid
+MATCH (s:Function {uid: suid})-[rel:TAINT_FLOWS_TO]->()
+DELETE rel`, map[string]any{"uids": []string{}})
+	require.NoError(t, err)
+	require.Zero(t, result.Stats.RelationshipsDeleted)
+	_, err = exec.Execute(ctx, "COMMIT", nil)
+	require.NoError(t, err)
+
+	result, err = exec.Execute(ctx, "MATCH (:Function {uid: 'source'})-[rel:TAINT_FLOWS_TO]->(:Function {uid: 'target'}) RETURN count(rel)", nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), countFromResult(t, result))
+}


### PR DESCRIPTION
## Description

Bolt explicit transactions silently skipped mutations shaped as `UNWIND ... MATCH ... DELETE`. The transaction router classified the trailing mutation before binding the top-level `UNWIND` row, so the match returned zero rows and the transaction committed successfully with no operations.

This aligns explicit transaction routing with autocommit: leading `UNWIND` is evaluated first, then each bound mutation runs inside the active transaction. Nested mutation statistics are accumulated so Bolt summaries report the writes that actually occurred.

Related: eshu-hq/eshu#4902

## Changes

- Route top-level `UNWIND` before generic mutation classification in explicit transactions.
- Accumulate all nested mutation counters into the outer UNWIND result.
- Add a real `neo4j-go-driver` `ExecuteWrite` regression and a focused Cypher transaction regression.
- Cover commit, explicit rollback, callback-error rollback, empty input, duplicate and missing IDs, wrong-evidence and out-of-scope survivors, endpoint preservation, repeat idempotence, `SET`, `REMOVE`, and node `DETACH DELETE` counters.
- Add fixed-cardinality batch-1 and batch-100 benchmarks.
- Document the fix in the changelog.

## Necessity and compatibility proof

Untouched v1.1.11/current main (`8603da03`) fails the direct regression for both commit and rollback cases:

```text
expected relationships deleted: 1
actual relationships deleted:   0
```

The same managed-transaction query was run against official Neo4j 5.26.28 Community (`neo4j@sha256:4bae36aff76271e27fd6a6ed0835413f86a284cd179cfb1cb7d188f5f7533aca`). Neo4j and this branch both report:

- callback transaction: 1 relationship deleted before the forced rollback; the edge survives afterward;
- committed transaction with duplicate and missing IDs: 2 relationships deleted;
- exact survivors: `[source-a, other, target-b]`, `[source-keep, wanted, target-keep]`, `[source-rollback, wanted, target-rollback]`.

`MemoryEngine` is BadgerDB in-memory mode, so the regression uses the same transaction implementation as persistent production storage.

## Local verification

```text
go test -tags nolocalllm ./pkg/cypher \
  -run "^TestExplicitTransactionUnwindDelete" -count=20
PASS

go test -tags nolocalllm ./pkg/cypher ./pkg/bolt -count=1
PASS: cypher 14.630s; bolt 18.850s

go test -tags nolocalllm -race ./pkg/cypher ./pkg/bolt \
  -run "TestExplicitTransactionUnwindDelete|TestDatabaseManagerBoltExecuteWriteDeletesUnwindMatchedRelationship" -count=1
PASS

golangci-lint run --allow-parallel-runners --build-tags nolocalllm \
  --new-from-rev=origin/main ./pkg/cypher/... ./pkg/bolt/...
0 issues

go build -tags "nolocalllm noui" ./cmd/nornicdb
PASS
```

Coverage is maintained and slightly improved:

| Package/function | v1.1.11 | PR |
| --- | ---: | ---: |
| `pkg/cypher` | 90.187676% | 90.192215% |
| `pkg/bolt` | 89.560440% | 89.560440% |
| `addQueryStats` | n/a | 100% |

The checkout-wide local command remains blocked by absent generated UI assets and optional local-LLM/plugin archives. The changed packages pass locally; GitHub CI exercises the configured full build/test/coverage environment.

## Performance sanity

The benchmark uses a fresh fixed-cardinality store per operation, keeps setup and verification outside the timer, and proves every intended edge is gone. Pre-fix timing is not a valid baseline because it performed zero deletes. Five samples at 10 operations each produced these medians:

| Batch | Autocommit | Explicit transaction | Result |
| ---: | ---: | ---: | --- |
| 1 | 267.446 us/op | 245.346 us/op | 1/1 deleted |
| 100 | 72.189 ms/op | 63.841 ms/op | 100/100 deleted |

Explicit transactions also used fewer bytes and allocations at both sizes. This is a no-obvious-regression check, not a speedup claim.

## Checklist

- [x] Exact failing production path captured before implementation
- [x] Commit and rollback behavior covered
- [x] Empty, duplicate, missing, negative-control, and idempotent inputs covered
- [x] Bolt counters agree with stored graph truth
- [x] Neo4j compatibility oracle run
- [x] Coverage maintained or improved
- [x] Benchmark and race checks run
- [x] `CHANGELOG.md` updated
- [ ] Fresh post-push CI and owner review complete