### PR TITLE
Fix UNIQUE commit lock false sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Large disjoint UNIQUE-constrained write batches no longer serialize on
+  hash-lock collisions.**
+  Replaced the fixed 256-stripe commit-lock table with an active,
+  reference-counted exact-value registry. Transactions touching the same
+  `(label, property, value)` still serialize through validation, Badger commit,
+  and unique-cache publication, while disjoint batches commit concurrently.
+  Registry-assigned ordering prevents AB-BA deadlocks, entries expire after the
+  last holder or waiter, and non-reflexive values such as NaN cannot leak lock
+  entries. Added real Badger commit, same-value retry, race, cleanup, and
+  8-writer/100-key performance coverage.
 - **Multi-MATCH relationship variable bound in a later clause was silently
   dropped.**
   `MATCH (s) WHERE s.uid IN $u MATCH (s)-[rel]->() WHERE

--- a/pkg/storage/badger_transaction.go
+++ b/pkg/storage/badger_transaction.go
@@ -2727,23 +2727,22 @@ func (tx *BadgerTransaction) checkTemporalConstraint(node *Node, c Constraint) e
 }
 
 // acquireUniqueConstraintCommitLocks collects the unique constraints touched
-// by this transaction's pending nodes and acquires bounded
-// per-(label, property, value) mutex stripes on the transaction's pinned
-// namespace's schema. Returns a release function that unlocks in reverse
-// order; safe to defer.
+// by this transaction's pending nodes and acquires exact
+// per-(label, property, value) mutexes on the transaction's pinned namespace's
+// schema. Returns a release function that unlocks in reverse order; safe to
+// defer.
 //
 // Locks are keyed by value, not only by constraint: a transaction adding
-// nodes with uids "X" and "Y" hashes those values to bounded lock stripes; a
-// peer transaction with uids "X" and "Z" serializes against "X" and commits
-// "Z" in parallel unless the bounded stripe hash collides. This was changed
-// from coarser per-(label, property) granularity that effectively serialized
-// every writer touching a UNIQUE-constrained property — see
-// uniqueConstraintLockKey doc.
+// nodes with uids "X" and "Y" acquires those exact values; a peer transaction
+// with uids "X" and "Z" serializes against "X", while fully disjoint batches
+// commit in parallel. This was changed from bounded hash stripes, which
+// effectively serialized large disjoint batches through false collisions —
+// see uniqueConstraintLockKey doc.
 //
 // The transaction is pinned to a single namespace at the first prefixed
 // write (see pinNamespaceFromIDLocked / SetNamespace). All pending nodes
 // therefore share that namespace, so we look up the schema once instead of
-// re-parsing each node ID. Stripe ordering inside the schema's own
+// re-parsing each node ID. Exact-key ordering inside the schema's own
 // acquireUniqueConstraintCommitLocks prevents AB-BA deadlocks between peer
 // transactions in the same namespace.
 //

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -14,7 +14,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"hash/fnv"
 	"reflect"
 	"sort"
 	"strings"
@@ -38,8 +37,6 @@ const (
 	ConstraintCardinality     ConstraintType = "CARDINALITY"
 	ConstraintPolicy          ConstraintType = "RELATIONSHIP_POLICY"
 )
-
-const uniqueConstraintCommitLockStripeCount = 256
 
 // ConstraintEntityType distinguishes node constraints from relationship constraints.
 type ConstraintEntityType string
@@ -77,14 +74,13 @@ func (c Constraint) EffectiveEntityType() ConstraintEntityType {
 type SchemaManager struct {
 	mu sync.RWMutex
 
-	// Bounded commit-time mutex stripes for UNIQUE constraint values.
-	// BadgerTransaction.Commit acquires the relevant stripe before
-	// validateAllConstraints and releases it after RegisterUniqueValue, so two
-	// transactions touching the same constrained value cannot both validate
-	// against an empty cache and then register conflicting values. Stripes keep
-	// the registry fixed-size; unrelated values normally commit in parallel,
-	// with rare hash collisions causing conservative serialization.
-	uniqueConstraintCommitLockStripes [uniqueConstraintCommitLockStripeCount]sync.Mutex
+	// Active commit-time locks for exact UNIQUE constraint values. Entries are
+	// reference-counted across holders and waiters, then removed when unused, so
+	// same-value transactions serialize without false contention between
+	// disjoint production-sized batches or unbounded historical-key growth.
+	uniqueConstraintCommitLocksMu sync.Mutex
+	uniqueConstraintCommitLocks   map[uniqueConstraintLockKey]*uniqueConstraintCommitLock
+	uniqueConstraintCommitOrder   uint64
 
 	// Constraints
 	uniqueConstraints       map[string]*UniqueConstraint      // key: "Label:property"
@@ -750,15 +746,14 @@ func propertyIndexValueKey(value interface{}) (interface{}, bool) {
 }
 
 // uniqueConstraintLockKey identifies one (label, property, value) triple for
-// the purpose of acquiring a commit-time mutex stripe. Two transactions whose
+// the purpose of acquiring a commit-time mutex. Two transactions whose
 // pending nodes touch the same (label, property, value) serialize at commit;
-// transactions touching disjoint values usually commit in parallel unless the
-// bounded stripe hash collides. The granularity is per constrained value, not
-// per constraint.
+// transactions touching disjoint values commit in parallel. The granularity
+// is per constrained value, not per constraint.
 //
 // The value is stored in its canonical comparable form returned by
 // uniqueConstraintValueKey so semantically equal but type-distinct values
-// (e.g. int and int64) hash to the same lock and serialize correctly. Values
+// (e.g. int and int64) use the same lock and serialize correctly. Values
 // that are not comparable cannot acquire a lock; their constraint is still
 // validated at commit but without commit-window serialization. (In practice
 // every UNIQUE-constrained property in Eshu and Neo4j-compatible workloads
@@ -778,22 +773,18 @@ type uniqueConstraintLockKey struct {
 	value    interface{}
 }
 
+type uniqueConstraintCommitLock struct {
+	mu    sync.Mutex
+	refs  int
+	order uint64
+}
+
 type uniqueConstraintLockRequest struct {
-	stripe   int
-	orderKey string
+	key  uniqueConstraintLockKey
+	lock *uniqueConstraintCommitLock
 }
 
-func uniqueConstraintLockOrderKey(k uniqueConstraintLockKey) string {
-	return fmt.Sprintf("%s\x00%s\x00%T\x00%#v", k.label, k.property, k.value, k.value)
-}
-
-func uniqueConstraintLockStripeIndex(k uniqueConstraintLockKey) int {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(uniqueConstraintLockOrderKey(k)))
-	return int(h.Sum64() % uniqueConstraintCommitLockStripeCount)
-}
-
-// acquireUniqueConstraintCommitLocks acquires UNIQUE value mutex stripes in a
+// acquireUniqueConstraintCommitLocks acquires exact UNIQUE value mutexes in a
 // deterministic order and returns a release function.
 // Deterministic ordering eliminates the AB-BA deadlock risk when two
 // transactions both touch overlapping sets of constrained values.
@@ -802,12 +793,14 @@ func uniqueConstraintLockStripeIndex(k uniqueConstraintLockKey) int {
 // no-op release function so callers can safely defer the result regardless
 // of whether locks were acquired.
 //
-// The lock guards the entire commit window for its specific value —
+// Each lock guards the entire commit window for its specific value —
 // validateAllConstraints, badgerTx.Commit, and the RegisterUniqueValue call
 // that publishes the committed value to the constraint cache — so a
 // subsequent transaction touching the same value always observes a coherent
-// cache. Transactions touching disjoint values acquire disjoint stripes and
-// commit in parallel unless they hit the same bounded stripe.
+// cache. Transactions touching disjoint values always acquire disjoint locks.
+// Registry entries count both holders and waiters and are evicted when that
+// count reaches zero, bounding memory by active commit demand rather than the
+// historical graph cardinality.
 func (sm *SchemaManager) acquireUniqueConstraintCommitLocks(keys []uniqueConstraintLockKey) func() {
 	if len(keys) == 0 {
 		return func() {}
@@ -815,38 +808,67 @@ func (sm *SchemaManager) acquireUniqueConstraintCommitLocks(keys []uniqueConstra
 	requests := make([]uniqueConstraintLockRequest, 0, len(keys))
 	seen := make(map[uniqueConstraintLockKey]struct{}, len(keys))
 	for _, k := range keys {
+		valueType := reflect.TypeOf(k.value)
+		if valueType != nil && !valueType.Comparable() {
+			continue
+		}
+		if k.value != nil && k.value != k.value {
+			// Non-reflexive comparable values such as NaN never conflict
+			// under equality and cannot be safely used as registry map keys:
+			// a lookup or delete with the same value would never find them.
+			continue
+		}
 		if _, dup := seen[k]; dup {
 			continue
 		}
 		seen[k] = struct{}{}
-		requests = append(requests, uniqueConstraintLockRequest{
-			stripe:   uniqueConstraintLockStripeIndex(k),
-			orderKey: uniqueConstraintLockOrderKey(k),
-		})
+		requests = append(requests, uniqueConstraintLockRequest{key: k})
 	}
-	sort.Slice(requests, func(i, j int) bool {
-		if requests[i].stripe != requests[j].stripe {
-			return requests[i].stripe < requests[j].stripe
+	if len(requests) == 0 {
+		return func() {}
+	}
+
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	if sm.uniqueConstraintCommitLocks == nil {
+		sm.uniqueConstraintCommitLocks = make(map[uniqueConstraintLockKey]*uniqueConstraintCommitLock, len(requests))
+	}
+	if len(sm.uniqueConstraintCommitLocks) == 0 {
+		sm.uniqueConstraintCommitOrder = 0
+	}
+	for i := range requests {
+		lock := sm.uniqueConstraintCommitLocks[requests[i].key]
+		if lock == nil {
+			sm.uniqueConstraintCommitOrder++
+			if sm.uniqueConstraintCommitOrder == 0 {
+				panic("UNIQUE commit lock order overflow")
+			}
+			lock = &uniqueConstraintCommitLock{order: sm.uniqueConstraintCommitOrder}
+			sm.uniqueConstraintCommitLocks[requests[i].key] = lock
 		}
-		return requests[i].orderKey < requests[j].orderKey
+		lock.refs++
+		requests[i].lock = lock
+	}
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	sort.Slice(requests, func(i, j int) bool {
+		return requests[i].lock.order < requests[j].lock.order
 	})
 
-	locks := make([]*sync.Mutex, 0, len(requests))
-	lastStripe := -1
-	for _, req := range requests {
-		if req.stripe == lastStripe {
-			continue
-		}
-		lastStripe = req.stripe
-		locks = append(locks, &sm.uniqueConstraintCommitLockStripes[req.stripe])
-	}
-
-	for _, m := range locks {
-		m.Lock()
+	for i := range requests {
+		requests[i].lock.mu.Lock()
 	}
 	return func() {
-		for i := len(locks) - 1; i >= 0; i-- {
-			locks[i].Unlock()
+		for i := len(requests) - 1; i >= 0; i-- {
+			requests[i].lock.mu.Unlock()
+		}
+
+		sm.uniqueConstraintCommitLocksMu.Lock()
+		defer sm.uniqueConstraintCommitLocksMu.Unlock()
+		for i := range requests {
+			request := requests[i]
+			request.lock.refs--
+			if request.lock.refs == 0 && sm.uniqueConstraintCommitLocks[request.key] == request.lock {
+				delete(sm.uniqueConstraintCommitLocks, request.key)
+			}
 		}
 	}
 }

--- a/pkg/storage/unique_lock_badger_concurrency_test.go
+++ b/pkg/storage/unique_lock_badger_concurrency_test.go
@@ -243,8 +243,8 @@ func BenchmarkBadgerUniqueConstraintCommit_DisjointFunctionBatches(b *testing.B)
 	if err := engine.rebuildUniqueConstraintValues("test", schema); err != nil {
 		b.Fatalf("rebuildUniqueConstraintValues: %v", err)
 	}
-	b.ReportMetric(badgerUniqueLockWriters, "writers")
-	b.ReportMetric(badgerUniqueLockKeysPerWriter, "keys/writer")
+	b.ReportMetric(float64(badgerUniqueLockWriters), "writers")
+	b.ReportMetric(float64(badgerUniqueLockKeysPerWriter), "keys/writer")
 	b.ResetTimer()
 
 	for iteration := range b.N {

--- a/pkg/storage/unique_lock_badger_concurrency_test.go
+++ b/pkg/storage/unique_lock_badger_concurrency_test.go
@@ -1,0 +1,356 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	badgerUniqueLockWriters       = 8
+	badgerUniqueLockKeysPerWriter = 100
+)
+
+// TestBadgerUniqueConstraintCommit_DisjointFunctionBatchesAreParallel proves
+// the exact lock contract through real BadgerTransaction.Commit calls. The
+// retained Eshu route updates existing Function nodes with disjoint uid values,
+// so unrelated writers must all reach commit-time UNIQUE validation together.
+func TestBadgerUniqueConstraintCommit_DisjointFunctionBatchesAreParallel(t *testing.T) {
+	engine := newTestEngine(t)
+	schema := engine.GetSchemaForNamespace("test")
+	if err := schema.AddUniqueConstraint("function_uid", "Function", "uid"); err != nil {
+		t.Fatalf("AddUniqueConstraint: %v", err)
+	}
+
+	seedBadgerUniqueFunctions(t, engine)
+	if err := engine.rebuildUniqueConstraintValues("test", schema); err != nil {
+		t.Fatalf("rebuildUniqueConstraintValues: %v", err)
+	}
+
+	transactions := make([]*BadgerTransaction, badgerUniqueLockWriters)
+	for writer := range badgerUniqueLockWriters {
+		tx, err := engine.BeginTransaction()
+		if err != nil {
+			t.Fatalf("BeginTransaction writer %d: %v", writer, err)
+		}
+		if err := tx.SetDeferredConstraintValidation(true); err != nil {
+			t.Fatalf("SetDeferredConstraintValidation writer %d: %v", writer, err)
+		}
+		for key := range badgerUniqueLockKeysPerWriter {
+			node := badgerUniqueFunctionNode(writer, key, 1)
+			if err := tx.UpdateNode(node); err != nil {
+				t.Fatalf("UpdateNode writer %d key %d: %v", writer, key, err)
+			}
+		}
+		transactions[writer] = tx
+	}
+
+	schema.mu.RLock()
+	constraint := schema.uniqueConstraints["Function:uid"]
+	schema.mu.RUnlock()
+	if constraint == nil {
+		t.Fatal("Function.uid UNIQUE constraint missing")
+	}
+	constraint.mu.Lock()
+	constraint.valuesCacheComplete = false
+	constraint.mu.Unlock()
+
+	enteredValidation := make(chan struct{}, len(transactions))
+	releaseValidation := make(chan struct{})
+	restoreHook := setUniqueConstraintScanHook(func() {
+		select {
+		case enteredValidation <- struct{}{}:
+		default:
+		}
+		<-releaseValidation
+	})
+	defer restoreHook()
+
+	start := make(chan struct{})
+	errors := make(chan error, len(transactions))
+	var wg sync.WaitGroup
+	for _, tx := range transactions {
+		tx := tx
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errors <- tx.Commit()
+		}()
+	}
+	close(start)
+
+	admitted := 0
+	deadline := time.NewTimer(2 * time.Second)
+collect:
+	for admitted < len(transactions) {
+		select {
+		case <-enteredValidation:
+			admitted++
+		case <-deadline.C:
+			break collect
+		}
+	}
+	close(releaseValidation)
+	if !deadline.Stop() {
+		select {
+		case <-deadline.C:
+		default:
+		}
+	}
+	wg.Wait()
+	close(errors)
+
+	if admitted != len(transactions) {
+		t.Fatalf("real disjoint Badger commits entered UNIQUE validation concurrently = %d/%d, want %d/%d", admitted, len(transactions), len(transactions), len(transactions))
+	}
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("disjoint Badger commit: %v", err)
+		}
+	}
+	assertBadgerUniqueFunctionExactness(t, engine, schema, 1)
+}
+
+func TestBadgerUniqueConstraintCommit_SameUIDRetryPreservesExactness(t *testing.T) {
+	engine := newTestEngine(t)
+	schema := engine.GetSchemaForNamespace("test")
+	if err := schema.AddUniqueConstraint("function_uid", "Function", "uid"); err != nil {
+		t.Fatalf("AddUniqueConstraint: %v", err)
+	}
+
+	nodeID := NodeID("test:same-uid")
+	uid := "content-entity:same-uid"
+	if _, err := engine.CreateNode(&Node{
+		ID:         nodeID,
+		Labels:     []string{"Function"},
+		Properties: map[string]interface{}{"uid": uid, "revision": 0},
+	}); err != nil {
+		t.Fatalf("CreateNode seed: %v", err)
+	}
+	if err := engine.rebuildUniqueConstraintValues("test", schema); err != nil {
+		t.Fatalf("rebuildUniqueConstraintValues: %v", err)
+	}
+
+	type commitResult struct {
+		revision int
+		err      error
+	}
+	transactions := make([]*BadgerTransaction, 2)
+	for index := range transactions {
+		tx, err := engine.BeginTransaction()
+		if err != nil {
+			t.Fatalf("BeginTransaction revision %d: %v", index+1, err)
+		}
+		if err := tx.SetDeferredConstraintValidation(true); err != nil {
+			t.Fatalf("SetDeferredConstraintValidation revision %d: %v", index+1, err)
+		}
+		if err := tx.UpdateNode(&Node{
+			ID:         nodeID,
+			Labels:     []string{"Function"},
+			Properties: map[string]interface{}{"uid": uid, "revision": index + 1},
+		}); err != nil {
+			t.Fatalf("UpdateNode revision %d: %v", index+1, err)
+		}
+		transactions[index] = tx
+	}
+
+	start := make(chan struct{})
+	results := make(chan commitResult, len(transactions))
+	for index, tx := range transactions {
+		revision := index + 1
+		tx := tx
+		go func() {
+			<-start
+			results <- commitResult{revision: revision, err: tx.Commit()}
+		}()
+	}
+	close(start)
+
+	var winner, loser commitResult
+	for range transactions {
+		result := <-results
+		if result.err == nil {
+			if winner.revision != 0 {
+				t.Fatalf("same-UID initial commits both succeeded: revisions %d and %d", winner.revision, result.revision)
+			}
+			winner = result
+		} else {
+			if loser.revision != 0 {
+				t.Fatalf("same-UID initial commits both failed: %v; %v", loser.err, result.err)
+			}
+			loser = result
+		}
+	}
+	if winner.revision == 0 || loser.revision == 0 {
+		t.Fatalf("same-UID initial result winner=%+v loser=%+v, want one of each", winner, loser)
+	}
+	var violation *ConstraintViolationError
+	if !errors.As(loser.err, &violation) || violation.Type != ConstraintUnique {
+		t.Fatalf("same-UID loser error = %T %v, want UNIQUE ConstraintViolationError", loser.err, loser.err)
+	}
+	if !errors.Is(loser.err, ErrConflict) {
+		t.Fatalf("same-UID loser error = %v, want ErrConflict cause", loser.err)
+	}
+	if violation.Label != "Function" || len(violation.Properties) != 1 || violation.Properties[0] != "uid" {
+		t.Fatalf("same-UID violation target = %s.%v, want Function.[uid]", violation.Label, violation.Properties)
+	}
+
+	retry, err := engine.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction retry: %v", err)
+	}
+	if err := retry.SetDeferredConstraintValidation(true); err != nil {
+		t.Fatalf("SetDeferredConstraintValidation retry: %v", err)
+	}
+	if err := retry.UpdateNode(&Node{
+		ID:         nodeID,
+		Labels:     []string{"Function"},
+		Properties: map[string]interface{}{"uid": uid, "revision": loser.revision},
+	}); err != nil {
+		t.Fatalf("UpdateNode retry: %v", err)
+	}
+	if err := retry.Commit(); err != nil {
+		t.Fatalf("Commit retry: %v", err)
+	}
+
+	nodes, err := engine.GetNodesByLabel("Function")
+	if err != nil {
+		t.Fatalf("GetNodesByLabel Function: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != nodeID || nodes[0].Properties["uid"] != uid || nodes[0].Properties["revision"] != loser.revision {
+		t.Fatalf("same-UID final nodes = %#v, want one node %s at retry revision %d", nodes, nodeID, loser.revision)
+	}
+	cachedID, found, constrained := schema.LookupUniqueConstraintValue("Function", "uid", uid)
+	if !constrained || !found || cachedID != nodeID {
+		t.Fatalf("same-UID cache = (%s, %v, %v), want (%s, true, true)", cachedID, found, constrained, nodeID)
+	}
+}
+
+func BenchmarkBadgerUniqueConstraintCommit_DisjointFunctionBatches(b *testing.B) {
+	engine, err := NewBadgerEngineInMemory()
+	if err != nil {
+		b.Fatalf("NewBadgerEngineInMemory: %v", err)
+	}
+	b.Cleanup(func() { _ = engine.Close() })
+	schema := engine.GetSchemaForNamespace("test")
+	if err := schema.AddUniqueConstraint("function_uid", "Function", "uid"); err != nil {
+		b.Fatalf("AddUniqueConstraint: %v", err)
+	}
+	seedBadgerUniqueFunctions(b, engine)
+	if err := engine.rebuildUniqueConstraintValues("test", schema); err != nil {
+		b.Fatalf("rebuildUniqueConstraintValues: %v", err)
+	}
+	b.ReportMetric(badgerUniqueLockWriters, "writers")
+	b.ReportMetric(badgerUniqueLockKeysPerWriter, "keys/writer")
+	b.ResetTimer()
+
+	for iteration := range b.N {
+		b.StopTimer()
+		transactions := make([]*BadgerTransaction, badgerUniqueLockWriters)
+		for writer := range badgerUniqueLockWriters {
+			tx, err := engine.BeginTransaction()
+			if err != nil {
+				b.Fatalf("BeginTransaction writer %d: %v", writer, err)
+			}
+			if err := tx.SetDeferredConstraintValidation(true); err != nil {
+				b.Fatalf("SetDeferredConstraintValidation writer %d: %v", writer, err)
+			}
+			for key := range badgerUniqueLockKeysPerWriter {
+				if err := tx.UpdateNode(badgerUniqueFunctionNode(writer, key, iteration+1)); err != nil {
+					b.Fatalf("UpdateNode writer %d key %d: %v", writer, key, err)
+				}
+			}
+			transactions[writer] = tx
+		}
+
+		start := make(chan struct{})
+		errors := make(chan error, len(transactions))
+		var wg sync.WaitGroup
+		for _, tx := range transactions {
+			tx := tx
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errors <- tx.Commit()
+			}()
+		}
+		b.StartTimer()
+		close(start)
+		wg.Wait()
+		b.StopTimer()
+		close(errors)
+		for err := range errors {
+			if err != nil {
+				b.Fatalf("disjoint Badger commit: %v", err)
+			}
+		}
+	}
+}
+
+func seedBadgerUniqueFunctions(t testing.TB, engine *BadgerEngine) {
+	t.Helper()
+	tx, err := engine.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction seed: %v", err)
+	}
+	if err := tx.SetDeferredConstraintValidation(true); err != nil {
+		t.Fatalf("SetDeferredConstraintValidation seed: %v", err)
+	}
+	for writer := range badgerUniqueLockWriters {
+		for key := range badgerUniqueLockKeysPerWriter {
+			if _, err := tx.CreateNode(badgerUniqueFunctionNode(writer, key, 0)); err != nil {
+				t.Fatalf("CreateNode seed writer %d key %d: %v", writer, key, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit seed: %v", err)
+	}
+}
+
+func badgerUniqueFunctionNode(writer, key, revision int) *Node {
+	return &Node{
+		ID:     NodeID(fmt.Sprintf("test:function-%02d-%03d", writer, key)),
+		Labels: []string{"Function"},
+		Properties: map[string]interface{}{
+			"uid":      fmt.Sprintf("content-entity:writer-%02d:key-%03d", writer, key),
+			"writer":   writer,
+			"key":      key,
+			"revision": revision,
+		},
+	}
+}
+
+func assertBadgerUniqueFunctionExactness(t *testing.T, engine *BadgerEngine, schema *SchemaManager, revision int) {
+	t.Helper()
+	nodes, err := engine.GetNodesByLabel("Function")
+	if err != nil {
+		t.Fatalf("GetNodesByLabel Function: %v", err)
+	}
+	wantCount := badgerUniqueLockWriters * badgerUniqueLockKeysPerWriter
+	if len(nodes) != wantCount {
+		t.Fatalf("Function count = %d, want %d", len(nodes), wantCount)
+	}
+	seenUIDs := make(map[string]NodeID, len(nodes))
+	for _, node := range nodes {
+		uid, ok := node.Properties["uid"].(string)
+		if !ok || uid == "" {
+			t.Fatalf("node %s uid = %#v, want non-empty string", node.ID, node.Properties["uid"])
+		}
+		if previous, duplicate := seenUIDs[uid]; duplicate {
+			t.Fatalf("duplicate Function uid %q on %s and %s", uid, previous, node.ID)
+		}
+		seenUIDs[uid] = node.ID
+		if node.Properties["revision"] != revision {
+			t.Fatalf("node %s revision = %#v, want %d", node.ID, node.Properties["revision"], revision)
+		}
+		cachedID, found, constrained := schema.LookupUniqueConstraintValue("Function", "uid", uid)
+		if !constrained || !found || cachedID != node.ID {
+			t.Fatalf("Function.uid cache for %q = (%s, %v, %v), want (%s, true, true)", uid, cachedID, found, constrained, node.ID)
+		}
+	}
+}

--- a/pkg/storage/unique_lock_batch_concurrency_test.go
+++ b/pkg/storage/unique_lock_batch_concurrency_test.go
@@ -1,0 +1,107 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	uniqueLockBatchWriters       = 8
+	uniqueLockBatchKeysPerWriter = 100
+)
+
+// TestUniqueConstraintCommitLocks_DisjointBatchesAreParallel reproduces the
+// production-sized false-sharing gap that the single-key granularity test does
+// not cover. Every writer owns a disjoint set of exact UNIQUE values, so all
+// writers must be able to enter the protected commit window concurrently.
+func TestUniqueConstraintCommitLocks_DisjointBatchesAreParallel(t *testing.T) {
+	sm := &SchemaManager{}
+	batches := disjointUniqueLockBatches(uniqueLockBatchWriters, uniqueLockBatchKeysPerWriter)
+
+	start := make(chan struct{})
+	acquired := make(chan struct{}, len(batches))
+	releaseAll := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, batch := range batches {
+		batch := batch
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			release := sm.acquireUniqueConstraintCommitLocks(batch)
+			acquired <- struct{}{}
+			<-releaseAll
+			release()
+		}()
+	}
+	close(start)
+
+	deadline := time.NewTimer(250 * time.Millisecond)
+	defer deadline.Stop()
+	acquiredBeforeRelease := 0
+collect:
+	for acquiredBeforeRelease < len(batches) {
+		select {
+		case <-acquired:
+			acquiredBeforeRelease++
+		case <-deadline.C:
+			break collect
+		}
+	}
+	close(releaseAll)
+	wg.Wait()
+
+	if acquiredBeforeRelease != len(batches) {
+		t.Fatalf(
+			"disjoint UNIQUE batches acquired concurrently = %d/%d, want %d/%d; bounded lock stripes are serializing unrelated values",
+			acquiredBeforeRelease,
+			len(batches),
+			len(batches),
+			len(batches),
+		)
+	}
+}
+
+func BenchmarkUniqueConstraintCommitLocks_DisjointBatches(b *testing.B) {
+	batches := disjointUniqueLockBatches(uniqueLockBatchWriters, uniqueLockBatchKeysPerWriter)
+	b.ReportMetric(float64(uniqueLockBatchWriters), "writers")
+	b.ReportMetric(float64(uniqueLockBatchKeysPerWriter), "keys/writer")
+	b.ResetTimer()
+
+	for range b.N {
+		sm := &SchemaManager{}
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for _, batch := range batches {
+			batch := batch
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				release := sm.acquireUniqueConstraintCommitLocks(batch)
+				time.Sleep(time.Millisecond)
+				release()
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+}
+
+func disjointUniqueLockBatches(writers, keysPerWriter int) [][]uniqueConstraintLockKey {
+	batches := make([][]uniqueConstraintLockKey, writers)
+	for writer := range writers {
+		batch := make([]uniqueConstraintLockKey, keysPerWriter)
+		for key := range keysPerWriter {
+			batch[key] = uniqueConstraintLockKey{
+				label:    "Function",
+				property: "uid",
+				value:    fmt.Sprintf("content-entity:writer-%02d:key-%03d", writer, key),
+			}
+		}
+		batches[writer] = batch
+	}
+	return batches
+}

--- a/pkg/storage/unique_lock_granularity_test.go
+++ b/pkg/storage/unique_lock_granularity_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -8,8 +10,7 @@ import (
 
 // TestUniqueConstraintCommitLocks_DisjointValuesAreParallel pins the
 // contract that two transactions whose pending nodes touch disjoint values
-// for the same (label, property) constraint can commit in parallel when the
-// bounded stripe hash keeps their lock domains separate — they do NOT
+// for the same (label, property) constraint commit in parallel — they do NOT
 // serialize on the full constraint.
 //
 // Earlier per-(label, property) granularity collapsed throughput to
@@ -17,15 +18,12 @@ import (
 // workers + collector + ingester all writing TerraformResource nodes with
 // disjoint uids would serialize at the commit boundary, an effective
 // WORKERS=1 contract in disguise. This test fails (deadlock or timeout)
-// under the old coarse granularity and passes under value-keyed stripe
+// under the old coarse granularity and passes under exact value-keyed
 // granularity.
 func TestUniqueConstraintCommitLocks_DisjointValuesAreParallel(t *testing.T) {
 	sm := &SchemaManager{}
 	heldKey := uniqueConstraintLockKey{label: "TerraformResource", property: "uid", value: "X"}
 	disjointKey := uniqueConstraintLockKey{label: "TerraformResource", property: "uid", value: "Y"}
-	for uniqueConstraintLockStripeIndex(heldKey) == uniqueConstraintLockStripeIndex(disjointKey) {
-		disjointKey.value = disjointKey.value.(string) + "Y"
-	}
 
 	// T1 holds the lock for value "X" indefinitely (until we signal).
 	t1Acquired := make(chan struct{})
@@ -65,12 +63,123 @@ func TestUniqueConstraintCommitLocks_DisjointValuesAreParallel(t *testing.T) {
 	<-t2Done
 }
 
-func TestUniqueConstraintLockKeyOrderDistinguishesValueTypes(t *testing.T) {
-	stringKey := uniqueConstraintLockKey{label: "TerraformResource", property: "uid", value: "1"}
-	floatKey := uniqueConstraintLockKey{label: "TerraformResource", property: "uid", value: 1.0}
+func TestUniqueConstraintCommitLocks_RegistryEntriesExpire(t *testing.T) {
+	sm := &SchemaManager{}
+	keys := []uniqueConstraintLockKey{
+		{label: "Function", property: "uid", value: "X"},
+		{label: "Function", property: "uid", value: "Y"},
+	}
 
-	if uniqueConstraintLockOrderKey(stringKey) == uniqueConstraintLockOrderKey(floatKey) {
-		t.Fatal("lock order key collapsed distinct value types with the same display string")
+	release := sm.acquireUniqueConstraintCommitLocks(keys)
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	active := len(sm.uniqueConstraintCommitLocks)
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	if active != len(keys) {
+		t.Fatalf("active UNIQUE commit locks = %d, want %d", active, len(keys))
+	}
+
+	release()
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	remaining := len(sm.uniqueConstraintCommitLocks)
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("UNIQUE commit locks after release = %d, want 0", remaining)
+	}
+}
+
+func TestUniqueConstraintCommitLocks_CollidingFormattedKeysHaveDistinctOrder(t *testing.T) {
+	sm := &SchemaManager{}
+	value := "same-value"
+	first := uniqueConstraintLockKey{label: "a", property: "b\x00c", value: value}
+	second := uniqueConstraintLockKey{label: "a\x00b", property: "c", value: value}
+	legacyOrder := func(key uniqueConstraintLockKey) string {
+		return fmt.Sprintf("%s\x00%s\x00%T\x00%#v", key.label, key.property, key.value, key.value)
+	}
+	if legacyOrder(first) != legacyOrder(second) {
+		t.Fatal("test setup requires distinct exact keys with the same legacy formatted order key")
+	}
+
+	release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{first, second})
+	defer release()
+
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	firstLock := sm.uniqueConstraintCommitLocks[first]
+	secondLock := sm.uniqueConstraintCommitLocks[second]
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	if firstLock == nil || secondLock == nil {
+		t.Fatal("both exact UNIQUE keys must have active lock entries")
+	}
+	if firstLock.order == secondLock.order {
+		t.Fatal("distinct exact UNIQUE keys must have distinct shared acquisition order")
+	}
+}
+
+func TestUniqueConstraintCommitLocks_NaNDoesNotLeakRegistryEntry(t *testing.T) {
+	sm := &SchemaManager{}
+	release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{
+		{label: "Metric", property: "value", value: math.NaN()},
+	})
+	release()
+
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	remaining := len(sm.uniqueConstraintCommitLocks)
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("UNIQUE commit locks after NaN release = %d, want 0", remaining)
+	}
+}
+
+func TestUniqueConstraintCommitLocks_WaitersKeepEntryAlive(t *testing.T) {
+	sm := &SchemaManager{}
+	key := uniqueConstraintLockKey{label: "Function", property: "uid", value: "X"}
+
+	releaseHolder := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{key})
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	entry := sm.uniqueConstraintCommitLocks[key]
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+
+	waiterAcquired := make(chan struct{})
+	releaseWaiter := make(chan struct{})
+	waiterDone := make(chan struct{})
+	go func() {
+		defer close(waiterDone)
+		release := sm.acquireUniqueConstraintCommitLocks([]uniqueConstraintLockKey{key})
+		close(waiterAcquired)
+		<-releaseWaiter
+		release()
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		sm.uniqueConstraintCommitLocksMu.Lock()
+		refs := entry.refs
+		sm.uniqueConstraintCommitLocksMu.Unlock()
+		if refs == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("holder plus waiter refs = %d, want 2", refs)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	releaseHolder()
+	<-waiterAcquired
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	activeEntry := sm.uniqueConstraintCommitLocks[key]
+	refs := entry.refs
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	if activeEntry != entry || refs != 1 {
+		t.Fatalf("active waiter entry = (%p, refs=%d), want (%p, refs=1)", activeEntry, refs, entry)
+	}
+
+	close(releaseWaiter)
+	<-waiterDone
+	sm.uniqueConstraintCommitLocksMu.Lock()
+	remaining := len(sm.uniqueConstraintCommitLocks)
+	sm.uniqueConstraintCommitLocksMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("UNIQUE commit locks after last waiter = %d, want 0", remaining)
 	}
 }
 
@@ -128,13 +237,13 @@ func TestUniqueConstraintCommitLocks_SameValueSerializes(t *testing.T) {
 
 // TestUniqueConstraintCommitLocks_DeterministicOrderingNoDeadlock verifies
 // that two transactions touching overlapping sets of values acquire locks
-// in the same total order (sorted by label, then property, then value),
+// in the same stable registry-assigned total order,
 // preventing AB-BA deadlock.
 //
 // Without sort-order acquisition: T1 wants {X, Y}, T2 wants {Y, X}. T1
 // holds X, asks for Y; T2 holds Y, asks for X. Deadlock. With sorted
-// acquisition, both transactions request X first, then Y; one waits, the
-// other progresses.
+// acquisition, both transactions request the earlier registered entry first;
+// one waits while the other progresses.
 func TestUniqueConstraintCommitLocks_DeterministicOrderingNoDeadlock(t *testing.T) {
 	sm := &SchemaManager{}
 


### PR DESCRIPTION
## What changed

Replace the fixed 256-stripe UNIQUE commit-lock table with an active exact-key registry.

Transactions that touch the same `(label, property, value)` still serialize across constraint validation, Badger commit, and unique-cache publication. Disjoint write batches no longer serialize because unrelated values happened to hash to the same stripe.

The registry:

- reserves references for holders and waiters before blocking, preventing entry deletion/ABA;
- assigns every active exact key a stable total order, preventing AB-BA deadlocks;
- removes entries after the last holder or waiter;
- skips non-reflexive values such as NaN, which cannot conflict under equality and cannot be safely deleted from a Go map.

This addresses the concurrent graph-write timeout shape retained in [Eshu #5122](https://github.com/eshu-hq/eshu/issues/5122) without reducing worker or writer concurrency.

## Same-machine proof

| Proof | Shipped stripes | Exact-key registry |
| --- | ---: | ---: |
| 8 writers x 100 disjoint keys admitted together | 1/8 | 8/8 |
| Lock-window benchmark median | ~10.1 ms/op | ~1.41 ms/op |
| Real Badger commit benchmark median | ~10.16 ms/op | ~6.89 ms/op |
| Same-UID concurrent commits | one winner, retryable loser | one winner, retryable loser |
| Final Function UID exactness | — | 800 rows, 800 distinct UIDs, cache mappings exact |

The focused lock benchmark is about 7.2x faster. The realistic cache-complete Badger commit benchmark is about 32% lower latency on the same machine.

A local Eshu end-to-end run kept graph concurrency enabled (8 graph writes in flight and 16 Nornic entity workers):

- 77,690 entities plus 4,579 statements in the larger repository scope;
- canonical graph write: 14.54 seconds;
- 830 Function chunks, typically 0.10–0.22 seconds each;
- queue terminal: 33 succeeded, 0 dead;
- graph readback: 121,576 nodes, 271,964 edges;
- Function exactness: 87,130 rows, 87,130 distinct non-null UIDs;
- no graph-write timeout, claimed-concurrent-commit, dead-letter, restart, or OOM signal.

That is local representative proof, not a claim that the full remote corpus is complete.

## Verification

```text
go test -tags 'noui nolocalllm' ./pkg/storage -run '^Test(BadgerUniqueConstraintCommit|UniqueConstraintCommitLocks)' -count=3
go test -race -tags 'noui nolocalllm' ./pkg/storage -run '^Test(BadgerUniqueConstraintCommit|UniqueConstraintCommitLocks)' -count=3
go test -tags 'noui nolocalllm' ./pkg/storage -count=1
golangci-lint run --build-tags noui --new-from-rev=8603da03a921112dbc9d426d0cd3aaa15b5a8713 ./pkg/storage
```

The repository-wide headless suite passes when excluding `pkg/localllm`, `pkg/heimdall`, and `TestLoadPluginsFromDir`. The unchanged baseline fails those surfaces because the local Darwin Llama archive is absent; the same baseline plugin test was run to confirm that limitation.

## Review

Cold review found no P0, P1, or P2 issue. Tests cover disjoint batches, overlapping lock order, holder/waiter lifecycle, registry cleanup, NaN cleanup, real Badger commits, same-UID conflict/retry behavior, and exact unique-cache readback.
