### PR TITLE
fix(cypher): correctly evaluate relationship-existence predicates and guard non-detach DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **WHERE relationship-existence predicates now recognize bracket-less and
+  undirected patterns, and bare `COUNT`/`EXISTS` subquery bodies.**
+  `WHERE (n)--()`, `WHERE (n)-->()`, `WHERE (n)<--()`, and the bracketed
+  undirected form `WHERE (n)-[r]-()` previously fell through to the
+  relationship-pattern gate's default branch, which treats an unrecognized
+  expression as `true` -- so `WHERE NOT (n)--()` matched nothing and
+  `WHERE (n)--()` was always true, regardless of the graph's actual shape.
+  Separately, `COUNT { (n)--() }` and `EXISTS { (n)--() }` required their
+  subquery body to start with `MATCH`, so a bare (unprefixed) body always
+  returned `0` / `false`. Both gates now recognize the full range of
+  bracket-less and undirected existence patterns.
+- **Non-DETACH `DELETE` of a node that still has relationships now errors
+  instead of silently cascade-deleting its edges (behavior change).**
+  `MATCH (n) DELETE n` previously called the storage engine's
+  `DeleteNode` unconditionally, which cascade-deletes every adjacent edge --
+  so a plain `DELETE` on a connected node quietly removed its relationships
+  too, diverging from openCypher/Neo4j semantics. `DELETE` now validates that
+  every node in the deletion plan has no relationships left outside the
+  statement's own edge deletions *before* mutating anything (so a multi-row
+  `DELETE` is judged as a whole, not partially applied), and errors with the
+  same "still has relationships" wording Neo4j uses. Deleting a node together
+  with its own edge in one statement (`DELETE a, r`) still works, since the
+  edge being removed no longer counts as residual. Existing callers relying on
+  the old silent cascade must switch to `DETACH DELETE`.
+- **An `OPTIONAL MATCH`-bound relationship variable resolved to `nil` inside
+  `DELETE`/`SET`/`REMOVE`'s internal match probes, even when the `OPTIONAL
+  MATCH` genuinely matched.** `executeDelete`, `executeSet`, and
+  `executeRemove` each build an internal
+  `MATCH ... OPTIONAL MATCH (a)-[r:TYPE]->(b) RETURN <vars>` probe and execute
+  it via the low-level match path instead of the dispatcher that normally
+  detects `OPTIONAL MATCH`. That low-level path located the relationship
+  bracket by scanning forward from the character right after the first node
+  group's closing paren, an assumption the embedded `OPTIONAL MATCH (n)` text
+  broke: the corrupted substring handed to the relationship-pattern parser no
+  longer started with `[`, so the bound variable, type, and properties were
+  silently dropped. A relationship pattern embedded after `OPTIONAL MATCH` is
+  now routed through the same compound-match handler the top-level dispatcher
+  already uses, so the relationship variable resolves to the real edge.
+- **`REMOVE` did not support relationship variables at all.** `REMOVE r.prop`
+  silently no-op'd (it only inspected `*storage.Node` values in the matched
+  rows) and, independent of that gap, a `REMOVE` query returning more than one
+  node variable emitted one duplicated result row per node instead of one row
+  per match. `REMOVE` now removes properties from relationship variables the
+  same way `SET` already does, and its `RETURN` handling builds exactly one
+  row per matched row regardless of how many node/relationship variables are
+  in scope. The same fix applies to a chained `SET ... REMOVE ...` clause in a
+  single statement.
 - **Bolt explicit transactions now bind top-level `UNWIND` rows before
   routing to mutation handlers.**
   `session.ExecuteWrite` queries shaped as `UNWIND ... MATCH ... DELETE`

--- a/pkg/bolt/orphan_sweep_e2e_test.go
+++ b/pkg/bolt/orphan_sweep_e2e_test.go
@@ -1,0 +1,111 @@
+package bolt
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoltOrphanSweepRelationshipExistenceAndDeleteGuard drives the three
+// proven relationship-existence bugs and the non-DETACH DELETE guard
+// through a real in-process Bolt connection (neo4j-go-driver/v5), matching
+// eshu #5147: WHERE NOT (n)--() must match only orphans, COUNT { (n)--() }
+// = 0 must agree, and a non-DETACH DELETE of a connected node must surface
+// a driver-visible error instead of silently cascading its edges.
+func TestBoltOrphanSweepRelationshipExistenceAndDeleteGuard(t *testing.T) {
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() {
+		require.NoError(t, base.Close())
+	})
+	mgr := &mockDBManager{
+		stores: map[string]storage.Engine{
+			"nornic": storage.NewNamespacedEngine(base, "nornic"),
+		},
+		defaultDB: "nornic",
+	}
+	server := NewWithDatabaseManager(&Config{
+		Port:            0,
+		MaxConnections:  8,
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+	}, &mockExecutor{}, mgr)
+	port := startBoltTestServer(t, server)
+
+	ctx := context.Background()
+	driver, err := neo4jdriver.NewDriverWithContext(
+		fmt.Sprintf("bolt://127.0.0.1:%d", port),
+		neo4jdriver.NoAuth(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, driver.Close(context.Background()))
+	})
+	require.NoError(t, driver.VerifyConnectivity(ctx))
+
+	session := driver.NewSession(ctx, neo4jdriver.SessionConfig{
+		AccessMode:   neo4jdriver.AccessModeWrite,
+		DatabaseName: "nornic",
+	})
+	defer func() {
+		require.NoError(t, session.Close(ctx))
+	}()
+
+	_, err = session.Run(ctx, "CREATE (:Item {name: 'orphan'})", nil)
+	require.NoError(t, err)
+	_, err = session.Run(ctx, `
+		CREATE (c:Item {name: 'connected'})
+		CREATE (p:Item {name: 'peer'})
+		CREATE (c)-[:CONTAINS]->(p)
+	`, nil)
+	require.NoError(t, err)
+
+	t.Run("WHERE NOT (n)--() matches only the orphan", func(t *testing.T) {
+		result, runErr := session.Run(ctx, `MATCH (n:Item) WHERE NOT (n)--() RETURN n.name`, nil)
+		require.NoError(t, runErr)
+		records, collectErr := result.Collect(ctx)
+		require.NoError(t, collectErr)
+		require.Len(t, records, 1, "only the orphan should have no relationships")
+		require.Equal(t, "orphan", records[0].Values[0])
+	})
+
+	t.Run("COUNT subquery bare body DETACH DELETE removes only the orphan", func(t *testing.T) {
+		result, runErr := session.Run(ctx, `MATCH (n:Item) WHERE COUNT { (n)--() } = 0 DETACH DELETE n`, nil)
+		require.NoError(t, runErr)
+		summary, consumeErr := result.Consume(ctx)
+		require.NoError(t, consumeErr)
+		require.Equal(t, 1, summary.Counters().NodesDeleted(), "exactly one orphan should be deleted")
+
+		countResult, runErr := session.Run(ctx, "MATCH (n:Item) RETURN count(n)", nil)
+		require.NoError(t, runErr)
+		record, singleErr := countResult.Single(ctx)
+		require.NoError(t, singleErr)
+		require.Equal(t, int64(2), record.Values[0], "connected and peer must survive")
+
+		edgeResult, runErr := session.Run(ctx, `MATCH (:Item {name: 'connected'})-[r:CONTAINS]->(:Item {name: 'peer'}) RETURN count(r)`, nil)
+		require.NoError(t, runErr)
+		edgeRecord, singleErr := edgeResult.Single(ctx)
+		require.NoError(t, singleErr)
+		require.Equal(t, int64(1), edgeRecord.Values[0], "the CONTAINS relationship must survive")
+	})
+
+	t.Run("non-DETACH DELETE of a connected node surfaces a driver-visible error", func(t *testing.T) {
+		_, runErr := session.Run(ctx, `MATCH (n:Item {name: 'connected'}) DELETE n`, nil)
+		if runErr == nil {
+			// Some drivers defer errors until the result is consumed.
+			result, _ := session.Run(ctx, `MATCH (n:Item {name: 'connected'}) DELETE n`, nil)
+			_, runErr = result.Consume(ctx)
+		}
+		require.Error(t, runErr, "deleting a node that still has relationships without DETACH must fail")
+		require.Contains(t, runErr.Error(), "still has relationships")
+
+		countResult, err := session.Run(ctx, "MATCH (n:Item {name: 'connected'}) RETURN count(n)", nil)
+		require.NoError(t, err)
+		record, err := countResult.Single(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), record.Values[0], "connected node must survive the rejected delete")
+	})
+}

--- a/pkg/cypher/cypher_helpers_extra_test.go
+++ b/pkg/cypher/cypher_helpers_extra_test.go
@@ -2693,7 +2693,7 @@ func TestCypherHelpers_MutationRelationshipPatternHelpers(t *testing.T) {
 	assert.True(t, exec.evaluateRelationshipPatternInWhere(n1, "n", "(n)-[:KNOWS]->()"))
 	assert.False(t, exec.evaluateRelationshipPatternInWhere(n1, "n", "(n)-[:LIKES]->()"))
 	assert.True(t, exec.evaluateRelationshipPatternInWhere(n2, "n", "(n)<-[:KNOWS]-()"))
-	assert.True(t, exec.evaluateRelationshipPatternInWhere(n2, "n", "(n)-[:ANY]-()"))
+	assert.False(t, exec.evaluateRelationshipPatternInWhere(n2, "n", "(n)-[:ANY]-()"))
 	assert.True(t, exec.evaluateRelationshipPatternInWhere(n1, "n", "(n)-[:KNOWS]->()-[:LIKES]->()"))
 
 	assert.False(t, exec.checkChainedPattern(n1, "x", "(n)-[:KNOWS]->()-[:LIKES]->()", ""))

--- a/pkg/cypher/delete_connected_guard_test.go
+++ b/pkg/cypher/delete_connected_guard_test.go
@@ -1,0 +1,165 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ====================================================================================
+// BUG: non-DETACH DELETE of a connected node silently cascade-deletes its edges
+// ====================================================================================
+// Discovered: eshu #5147
+// Impact: `MATCH (n) DELETE n` on a node that still has relationships
+//         silently succeeded and cascade-deleted its edges instead of
+//         erroring, diverging from openCypher/Neo4j semantics.
+// Root Cause: executeDelete's generic path called store.DeleteNode with no
+//         adjacency check; the storage engines (e.g. BadgerEngine.DeleteNode)
+//         cascade-delete a node's edges unconditionally.
+// Behavior change: non-DETACH DELETE of a connected node now fails
+//         unconditionally (matching Neo4j). Callers relying on the old
+//         silent cascade must switch to DETACH DELETE.
+// ====================================================================================
+
+func setupDeleteGuardFixture(t *testing.T) (*StorageExecutor, storage.Engine) {
+	t.Helper()
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	store := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `CREATE (o:Item {name: 'orphan'})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		CREATE (c:Item {name: 'connected'})
+		CREATE (p:Item {name: 'peer'})
+		CREATE (c)-[:CONTAINS]->(p)
+	`, nil)
+	require.NoError(t, err)
+
+	return exec, store
+}
+
+func countItemsByName(t *testing.T, exec *StorageExecutor, name string) int64 {
+	t.Helper()
+	result, err := exec.Execute(context.Background(), `MATCH (n:Item {name: $name}) RETURN count(n)`, map[string]interface{}{"name": name})
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	return result.Rows[0][0].(int64)
+}
+
+func TestDeleteConnectedNodeWithoutDetach_Errors(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `MATCH (n:Item {name: 'connected'}) DELETE n`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has relationships")
+
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "connected"), "node must survive a rejected delete")
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "peer"), "peer node must survive")
+
+	result, err := exec.Execute(ctx, `MATCH (:Item {name: 'connected'})-[r:CONTAINS]->(:Item {name: 'peer'}) RETURN count(r)`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	assert.Equal(t, int64(1), result.Rows[0][0].(int64), "edge must survive a rejected delete")
+}
+
+func TestDeleteOrphanNodeWithoutDetach_Succeeds(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `MATCH (n:Item {name: 'orphan'}) DELETE n`, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Stats.NodesDeleted)
+	assert.Equal(t, int64(0), countItemsByName(t, exec, "orphan"))
+}
+
+func TestDetachDeleteConnectedNode_Succeeds(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `MATCH (n:Item {name: 'connected'}) DETACH DELETE n`, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Stats.NodesDeleted)
+	assert.GreaterOrEqual(t, result.Stats.RelationshipsDeleted, 1)
+	assert.Equal(t, int64(0), countItemsByName(t, exec, "connected"))
+}
+
+func TestDeleteNodeAndItsOwnEdgeTogether_Succeeds(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `MATCH (a:Item {name: 'connected'})-[r:CONTAINS]->(b:Item {name: 'peer'}) DELETE a, r`, nil)
+	require.NoError(t, err, "deleting a node together with its own edge in the same statement must succeed")
+	assert.Equal(t, 1, result.Stats.NodesDeleted)
+	assert.Equal(t, int64(0), countItemsByName(t, exec, "connected"))
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "peer"), "peer node itself must survive")
+}
+
+func TestDeleteMultipleNodesWithSurvivingEdge_Errors(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	// Deletes both endpoints but does not name the edge between them, so
+	// each endpoint still has a "residual" relationship from the
+	// statement's point of view -- this must error rather than silently
+	// cascade the edge away.
+	_, err := exec.Execute(ctx, `MATCH (a:Item {name: 'connected'}), (b:Item {name: 'peer'}) DELETE a, b`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has relationships")
+
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "connected"))
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "peer"))
+}
+
+func TestDeleteConnectedNodeParameterizedWhere_Errors(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `MATCH (n:Item) WHERE n.name = $name DELETE n`, map[string]interface{}{"name": "connected"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has relationships")
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "connected"))
+}
+
+func TestDeleteConnectedNodeExplicitTransactionRollback_Errors(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, "BEGIN", nil)
+	require.NoError(t, err)
+
+	_, err = exec.Execute(ctx, `MATCH (n:Item {name: 'connected'}) DELETE n`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has relationships")
+
+	_, err = exec.Execute(ctx, "ROLLBACK", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "connected"), "node must survive after rollback of a rejected delete")
+}
+
+func TestDeleteMultiRowOneConnected_ErrorsAndDeletesNothing(t *testing.T) {
+	exec, _ := setupDeleteGuardFixture(t)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `CREATE (n:Item {name: 'orphan2'})`, nil)
+	require.NoError(t, err)
+
+	// Matches orphan, orphan2, and connected in one statement -- the
+	// connected node must abort the whole DELETE. Validation must run for
+	// the entire plan before any mutation, so the orphans must not be
+	// deleted either (statement atomicity).
+	_, err = exec.Execute(ctx, `MATCH (n:Item) WHERE n.name IN ['orphan', 'orphan2', 'connected'] DELETE n`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has relationships")
+
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "orphan"), "orphan must survive: statement is all-or-nothing")
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "orphan2"), "orphan2 must survive: statement is all-or-nothing")
+	assert.Equal(t, int64(1), countItemsByName(t, exec, "connected"))
+}

--- a/pkg/cypher/executor_mutations.go
+++ b/pkg/cypher/executor_mutations.go
@@ -2229,16 +2229,6 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 	matchVars := e.extractVariableNamesFromPattern(matchPattern)
 	withAliases := extractWithAliases(matchSegment)
 	allVars := dedupeNonEmpty(matchVars, withAliases)
-
-	// Include variables referenced only in the REMOVE/RETURN clauses so a
-	// relationship variable bound inside a bracketed pattern (e.g. the "r" in
-	// "OPTIONAL MATCH (n)-[r:TYPE]->(m)") stays in the probe's projection.
-	// extractVariableNamesFromPattern above only scans node groups outside
-	// "[...]", so a bare "REMOVE r.prop" previously vanished from matchQuery's
-	// RETURN list entirely -- the probe never asked for r, so the mutation
-	// loop below never saw a *storage.Edge to remove the property from (eshu
-	// #5147, same root cause class as the OPTIONAL MATCH rel-var fix in
-	// executeSet).
 	removeLen := len("REMOVE")
 	var removePart string
 	if returnIdx > 0 && returnIdx > removeIdx {
@@ -2253,6 +2243,12 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 	scopeVars := extractScopeVariablesFromRemoveAndReturn(removePart, returnScopePart)
 	allVars = dedupeNonEmpty(allVars, scopeVars)
 
+	// Include variables referenced only in the REMOVE/RETURN clauses so a
+	// relationship variable bound inside a bracketed pattern (e.g. the "r" in
+	// "OPTIONAL MATCH (n)-[r:TYPE]->(m)") stays in the probe's projection.
+	// extractVariableNamesFromPattern above only scans node groups outside
+	// "[...]", so a bare "REMOVE r.prop" previously vanished from matchQuery's
+	// RETURN list entirely.
 	matchQuery := matchSegment + " RETURN *"
 	if len(allVars) > 0 {
 		matchQuery = matchSegment + " RETURN " + strings.Join(allVars, ", ")
@@ -2266,23 +2262,28 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 	e.normalizeSetMatchRowsToNodes(matchResult, store)
 	e.normalizeSetMatchRowsToEdges(matchResult, store)
 
-	// Split by comma and parse property and label removals.
-	propsToRemove, labelsToRemove := e.parseRemoveItems(removePart)
+	removeTargets := parseRemoveTargetBindings(removePart)
 
-	// Update matched nodes and relationships. REMOVE r.prop on a relationship
-	// variable requires the same *storage.Edge handling SET already applies
-	// (see the SET assignment loop above) -- relationships have no labels to
-	// remove, only properties, so labelsToRemove never applies to an edge.
+	// Update matched nodes and relationships for the variables explicitly named
+	// in the REMOVE clause.
 	for _, row := range matchResult.Rows {
-		for _, val := range row {
+		for colIdx, val := range row {
+			if colIdx >= len(matchResult.Columns) {
+				continue
+			}
+			varName := matchResult.Columns[colIdx]
+			propTargets := removeTargets.propertyNames(varName)
+			labelTargets := removeTargets.labelNames(varName)
+			if len(propTargets) == 0 && len(labelTargets) == 0 {
+				continue
+			}
 			switch entity := val.(type) {
 			case *storage.Node:
 				if entity == nil {
 					continue
 				}
 				invalidated := false
-				// Remove specified properties
-				for _, prop := range propsToRemove {
+				for _, prop := range propTargets {
 					if _, exists := entity.Properties[prop]; exists {
 						delete(entity.Properties, prop)
 						result.Stats.PropertiesSet++ // Neo4j counts removals as properties set
@@ -2294,15 +2295,14 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 				if invalidated {
 					embeddingutil.InvalidateManagedEmbeddings(entity)
 				}
-				if len(labelsToRemove) > 0 {
+				if len(labelTargets) > 0 {
 					oldLabels := make([]string, len(entity.Labels))
 					copy(oldLabels, entity.Labels)
-					next, removed := removeNodeLabels(entity.Labels, labelsToRemove)
+					next, removed := removeNodeLabels(entity.Labels, labelTargets)
 					if removed > 0 {
 						entity.Labels = next
-						// Validate policy constraints before committing the label change.
 						if err := validatePolicyOnLabelChange(store, entity, oldLabels); err != nil {
-							entity.Labels = oldLabels // restore
+							entity.Labels = oldLabels
 							return nil, err
 						}
 					}
@@ -2315,7 +2315,7 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 				if entity == nil {
 					continue
 				}
-				for _, prop := range propsToRemove {
+				for _, prop := range propTargets {
 					if _, exists := entity.Properties[prop]; exists {
 						delete(entity.Properties, prop)
 						result.Stats.PropertiesSet++ // Neo4j counts removals as properties set
@@ -2453,16 +2453,25 @@ func (e *StorageExecutor) applyRemoveToMatchedRows(
 	removePart string,
 	result *ExecuteResult,
 ) error {
-	propsToRemove, labelsToRemove := e.parseRemoveItems(removePart)
+	removeTargets := parseRemoveTargetBindings(removePart)
 	for _, row := range matchResult.Rows {
-		for _, val := range row {
+		for colIdx, val := range row {
+			if colIdx >= len(matchResult.Columns) {
+				continue
+			}
+			varName := matchResult.Columns[colIdx]
+			propTargets := removeTargets.propertyNames(varName)
+			labelTargets := removeTargets.labelNames(varName)
+			if len(propTargets) == 0 && len(labelTargets) == 0 {
+				continue
+			}
 			switch entity := val.(type) {
 			case *storage.Node:
 				if entity == nil {
 					continue
 				}
 				invalidated := false
-				for _, prop := range propsToRemove {
+				for _, prop := range propTargets {
 					if _, exists := entity.Properties[prop]; exists {
 						delete(entity.Properties, prop)
 						result.Stats.PropertiesSet++
@@ -2471,14 +2480,14 @@ func (e *StorageExecutor) applyRemoveToMatchedRows(
 						}
 					}
 				}
-				if len(labelsToRemove) > 0 {
+				if len(labelTargets) > 0 {
 					oldLabels := make([]string, len(entity.Labels))
 					copy(oldLabels, entity.Labels)
-					next, removed := removeNodeLabels(entity.Labels, labelsToRemove)
+					next, removed := removeNodeLabels(entity.Labels, labelTargets)
 					if removed > 0 {
 						entity.Labels = next
 						if err := validatePolicyOnLabelChange(store, entity, oldLabels); err != nil {
-							entity.Labels = oldLabels // restore
+							entity.Labels = oldLabels
 							return err
 						}
 					}
@@ -2491,12 +2500,10 @@ func (e *StorageExecutor) applyRemoveToMatchedRows(
 				}
 				e.notifyNodeMutated(string(entity.ID))
 			case *storage.Edge:
-				// Relationships have no labels to remove, only properties
-				// (see the mirrored *storage.Node handling in executeRemove).
 				if entity == nil {
 					continue
 				}
-				for _, prop := range propsToRemove {
+				for _, prop := range propTargets {
 					if _, exists := entity.Properties[prop]; exists {
 						delete(entity.Properties, prop)
 						result.Stats.PropertiesSet++
@@ -2933,22 +2940,7 @@ func (e *StorageExecutor) evaluateRelationshipPatternInWhere(node *storage.Node,
 	}
 	var checkIncoming, checkOutgoing bool
 	var relTypes []string
-	if strings.Contains(pattern, "<-[") {
-		checkIncoming = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
-	}
-	if strings.Contains(pattern, "]->(") || strings.Contains(pattern, "]->") {
-		checkOutgoing = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "-[")
-	}
-	if !checkIncoming && !checkOutgoing {
-		// Bracket-less pattern (e.g. "(n)-->()", "()<--(n)") -- the checks
-		// above only recognize bracketed arrows, so fall back to direction
-		// detection on the bare arrow itself (eshu #5147).
-		if in, out, ok := bareRelDirection(pattern, variable); ok {
-			checkIncoming, checkOutgoing = in, out
-		}
-	}
+	checkIncoming, checkOutgoing, relTypes = e.relationshipExistencePatternDirections(pattern, variable)
 	if checkIncoming {
 		edges, _ := e.storage.GetIncomingEdges(node.ID)
 		for _, edge := range edges {
@@ -3026,22 +3018,7 @@ func (e *StorageExecutor) checkSubqueryMatch(ctx context.Context, node *storage.
 	var checkIncoming, checkOutgoing bool
 	var relTypes []string
 
-	if strings.Contains(pattern, "<-[") {
-		checkIncoming = true
-		// Extract relationship type if specified
-		relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
-	}
-	if strings.Contains(pattern, "]->(") || strings.Contains(pattern, "]->") {
-		checkOutgoing = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "-[")
-	}
-	if !checkIncoming && !checkOutgoing {
-		// Bracket-less pattern (e.g. "(n)-->()", "(n)--()") -- the checks
-		// above only recognize bracketed arrows (eshu #5147).
-		if in, out, ok := bareRelDirection(pattern, variable); ok {
-			checkIncoming, checkOutgoing = in, out
-		}
-	}
+	checkIncoming, checkOutgoing, relTypes = e.relationshipExistencePatternDirections(pattern, variable)
 
 	// Check for matching edges
 	if checkIncoming {
@@ -3560,6 +3537,63 @@ func (e *StorageExecutor) extractRelTypesFromPattern(pattern, prefix string) []s
 	return types
 }
 
+func (e *StorageExecutor) relationshipExistencePatternDirections(pattern, variable string) (incoming, outgoing bool, relTypes []string) {
+	if groupStart := strings.Index(pattern, "("+variable+")"); groupStart >= 0 || strings.Contains(pattern, "("+variable+":") {
+		if groupStart < 0 {
+			groupStart = strings.Index(pattern, "("+variable+":")
+		}
+		groupEnd := groupStart + len(variable) + 2
+		if strings.HasPrefix(pattern[groupStart:], "("+variable+":") {
+			closeRel := strings.Index(pattern[groupStart:], ")")
+			if closeRel >= 0 {
+				groupEnd = groupStart + closeRel + 1
+			}
+		}
+		before := pattern[:groupStart]
+		after := pattern[groupEnd:]
+
+		switch {
+		case strings.HasPrefix(after, "<-["):
+			incoming = true
+			relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
+		case strings.HasPrefix(after, "-["):
+			relTypes = e.extractRelTypesFromPattern(pattern, "-[")
+			if strings.Contains(after, "]->") {
+				outgoing = true
+			} else if strings.Contains(after, "]-") {
+				incoming = true
+				outgoing = true
+			}
+		}
+
+		switch {
+		case strings.HasSuffix(before, "]->"):
+			incoming = true
+			if len(relTypes) == 0 {
+				relTypes = e.extractRelTypesFromPattern(pattern, "-[")
+			}
+		case strings.Contains(before, "<-[") && strings.HasSuffix(before, "]-"):
+			outgoing = true
+			if len(relTypes) == 0 {
+				relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
+			}
+		case strings.HasSuffix(before, "]-"):
+			incoming = true
+			outgoing = true
+			if len(relTypes) == 0 {
+				relTypes = e.extractRelTypesFromPattern(pattern, "-[")
+			}
+		}
+	}
+
+	if !incoming && !outgoing {
+		if in, out, ok := bareRelDirection(pattern, variable); ok {
+			return in, out, nil
+		}
+	}
+	return incoming, outgoing, relTypes
+}
+
 // edgeTypeMatches checks if an edge type matches any of the allowed types
 func (e *StorageExecutor) edgeTypeMatches(edgeType string, allowedTypes []string) bool {
 	for _, t := range allowedTypes {
@@ -3706,29 +3740,7 @@ func (e *StorageExecutor) countSubqueryMatches(node *storage.Node, variable, sub
 	var checkIncoming, checkOutgoing bool
 	var relTypes []string
 
-	// Variable on left side of "<-[" means incoming to variable.
-	if strings.Contains(pattern, "("+variable+")<-[") || strings.Contains(pattern, "("+variable+":") && strings.Contains(pattern, "<-[") {
-		checkIncoming = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
-	}
-	// Variable on left side of "-[" means outgoing from variable.
-	if strings.Contains(pattern, "("+variable+")-[") || strings.Contains(pattern, "("+variable+":") && strings.Contains(pattern, ")-[") {
-		checkOutgoing = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "-[")
-	}
-
-	// Variable on right side of "]->" means incoming to variable.
-	if strings.Contains(pattern, "]->("+variable+")") || strings.Contains(pattern, "]->("+variable+":") {
-		checkIncoming = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "-[")
-	}
-	// Variable on right side of "]-(...)" in an incoming-arrow pattern means outgoing from variable:
-	// e.g. ()<-[r]-(n)
-	if (strings.Contains(pattern, "]-("+variable+")") || strings.Contains(pattern, "]-("+variable+":")) &&
-		strings.Contains(pattern, "<-[") {
-		checkOutgoing = true
-		relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
-	}
+	checkIncoming, checkOutgoing, relTypes = e.relationshipExistencePatternDirections(pattern, variable)
 
 	if !checkIncoming && !checkOutgoing {
 		// Bracket-less pattern (e.g. "(n)-->()", "(n)--()") -- the checks

--- a/pkg/cypher/executor_mutations.go
+++ b/pkg/cypher/executor_mutations.go
@@ -189,58 +189,41 @@ func (e *StorageExecutor) executeDelete(ctx context.Context, cypher string) (*Ex
 	e.normalizeSetMatchRowsToNodes(matchResult, store)
 
 	// Delete matched nodes and/or relationships.
-	// Pre-size dedup maps based on match result to reduce rehashing.
-	rowCount := len(matchResult.Rows)
-	deletedNodeIDs := make(map[string]struct{}, rowCount)
-	deletedEdgeIDs := make(map[string]struct{}, rowCount)
-	edgeIDsToDelete := make([]storage.EdgeID, 0, rowCount)
+	//
+	// This runs as collect -> validate -> apply (see
+	// executor_mutations_delete_guard.go) so a non-DETACH DELETE is judged
+	// as a whole statement before anything is mutated: a multi-row DELETE
+	// must not partially apply before a later row is found to still have
+	// relationships, and a plain "DELETE n" on a connected node must error
+	// instead of silently cascading its edges away (eshu #5147).
+	nodeIDs, edgeIDsToDelete := collectDeleteMutationTargets(matchResult)
 
-	for _, row := range matchResult.Rows {
-		for _, val := range row {
-			deleteTarget := classifyDeleteTargetValue(val)
+	if !detach {
+		if err := validateNoResidualRelationships(store, nodeIDs, edgeIDsToDelete); err != nil {
+			return nil, err
+		}
+	}
 
-			// Handle relationship deletion
-			if deleteTarget.kind == deleteProjectionRelationship {
-				edgeID := string(deleteTarget.edgeID)
-				if _, seen := deletedEdgeIDs[edgeID]; seen {
-					continue
-				}
-				deletedEdgeIDs[edgeID] = struct{}{}
-				edgeIDsToDelete = append(edgeIDsToDelete, deleteTarget.edgeID)
-				continue
+	for _, nodeID := range nodeIDs {
+		if detach {
+			// Count edges that will be deleted with the node (for stats).
+			// Combine outgoing + incoming in a single stats tally.
+			edgesCount := 0
+			if needEdgeStats {
+				outgoingEdges, _ := store.GetOutgoingEdges(nodeID)
+				incomingEdges, _ := store.GetIncomingEdges(nodeID)
+				edgesCount = len(outgoingEdges) + len(incomingEdges)
 			}
 
-			// Handle node deletion
-			if deleteTarget.kind != deleteProjectionNode {
-				continue
+			if err := store.DeleteNode(nodeID); err == nil {
+				result.Stats.NodesDeleted++
+				result.Stats.RelationshipsDeleted += edgesCount
+				e.removeNodeFromSearch(string(nodeID))
 			}
-			nodeID := string(deleteTarget.nodeID)
-			if _, seen := deletedNodeIDs[nodeID]; seen {
-				continue
-			}
-
-			if detach {
-				// Count edges that will be deleted with the node (for stats).
-				// Combine outgoing + incoming in a single stats tally.
-				edgesCount := 0
-				if needEdgeStats {
-					outgoingEdges, _ := store.GetOutgoingEdges(storage.NodeID(nodeID))
-					incomingEdges, _ := store.GetIncomingEdges(storage.NodeID(nodeID))
-					edgesCount = len(outgoingEdges) + len(incomingEdges)
-				}
-
-				if err := store.DeleteNode(storage.NodeID(nodeID)); err == nil {
-					result.Stats.NodesDeleted++
-					result.Stats.RelationshipsDeleted += edgesCount
-					deletedNodeIDs[nodeID] = struct{}{}
-					e.removeNodeFromSearch(nodeID)
-				}
-			} else {
-				if err := store.DeleteNode(storage.NodeID(nodeID)); err == nil {
-					result.Stats.NodesDeleted++
-					deletedNodeIDs[nodeID] = struct{}{}
-					e.removeNodeFromSearch(nodeID)
-				}
+		} else {
+			if err := store.DeleteNode(nodeID); err == nil {
+				result.Stats.NodesDeleted++
+				e.removeNodeFromSearch(string(nodeID))
 			}
 		}
 	}
@@ -2246,6 +2229,30 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 	matchVars := e.extractVariableNamesFromPattern(matchPattern)
 	withAliases := extractWithAliases(matchSegment)
 	allVars := dedupeNonEmpty(matchVars, withAliases)
+
+	// Include variables referenced only in the REMOVE/RETURN clauses so a
+	// relationship variable bound inside a bracketed pattern (e.g. the "r" in
+	// "OPTIONAL MATCH (n)-[r:TYPE]->(m)") stays in the probe's projection.
+	// extractVariableNamesFromPattern above only scans node groups outside
+	// "[...]", so a bare "REMOVE r.prop" previously vanished from matchQuery's
+	// RETURN list entirely -- the probe never asked for r, so the mutation
+	// loop below never saw a *storage.Edge to remove the property from (eshu
+	// #5147, same root cause class as the OPTIONAL MATCH rel-var fix in
+	// executeSet).
+	removeLen := len("REMOVE")
+	var removePart string
+	if returnIdx > 0 && returnIdx > removeIdx {
+		removePart = strings.TrimSpace(normalized[removeIdx+removeLen : returnIdx])
+	} else {
+		removePart = strings.TrimSpace(normalized[removeIdx+removeLen:])
+	}
+	returnScopePart := ""
+	if returnIdx > removeIdx {
+		returnScopePart = strings.TrimSpace(normalized[returnIdx+6:])
+	}
+	scopeVars := extractScopeVariablesFromRemoveAndReturn(removePart, returnScopePart)
+	allVars = dedupeNonEmpty(allVars, scopeVars)
+
 	matchQuery := matchSegment + " RETURN *"
 	if len(allVars) > 0 {
 		matchQuery = matchSegment + " RETURN " + strings.Join(allVars, ", ")
@@ -2257,61 +2264,77 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 	// MATCH ... WITH projections can surface nodes as maps. REMOVE needs the
 	// live storage entities so property and label mutations reach the graph.
 	e.normalizeSetMatchRowsToNodes(matchResult, store)
-
-	// Parse REMOVE clause: REMOVE n.prop1, n.prop2, n:Label
-	var removePart string
-	removeLen := len("REMOVE")
-	if returnIdx > 0 && returnIdx > removeIdx {
-		removePart = strings.TrimSpace(normalized[removeIdx+removeLen : returnIdx])
-	} else {
-		removePart = strings.TrimSpace(normalized[removeIdx+removeLen:])
-	}
+	e.normalizeSetMatchRowsToEdges(matchResult, store)
 
 	// Split by comma and parse property and label removals.
 	propsToRemove, labelsToRemove := e.parseRemoveItems(removePart)
 
-	// Update matched nodes
+	// Update matched nodes and relationships. REMOVE r.prop on a relationship
+	// variable requires the same *storage.Edge handling SET already applies
+	// (see the SET assignment loop above) -- relationships have no labels to
+	// remove, only properties, so labelsToRemove never applies to an edge.
 	for _, row := range matchResult.Rows {
 		for _, val := range row {
-			node, ok := val.(*storage.Node)
-			if !ok || node == nil {
-				continue
-			}
-			invalidated := false
-			// Remove specified properties
-			for _, prop := range propsToRemove {
-				if _, exists := node.Properties[prop]; exists {
-					delete(node.Properties, prop)
-					result.Stats.PropertiesSet++ // Neo4j counts removals as properties set
-					if !embeddingutil.IsMetadataPropertyKey(prop) {
-						invalidated = true
+			switch entity := val.(type) {
+			case *storage.Node:
+				if entity == nil {
+					continue
+				}
+				invalidated := false
+				// Remove specified properties
+				for _, prop := range propsToRemove {
+					if _, exists := entity.Properties[prop]; exists {
+						delete(entity.Properties, prop)
+						result.Stats.PropertiesSet++ // Neo4j counts removals as properties set
+						if !embeddingutil.IsMetadataPropertyKey(prop) {
+							invalidated = true
+						}
 					}
 				}
-			}
-			if invalidated {
-				embeddingutil.InvalidateManagedEmbeddings(node)
-			}
-			if len(labelsToRemove) > 0 {
-				oldLabels := make([]string, len(node.Labels))
-				copy(oldLabels, node.Labels)
-				next, removed := removeNodeLabels(node.Labels, labelsToRemove)
-				if removed > 0 {
-					node.Labels = next
-					// Validate policy constraints before committing the label change.
-					if err := validatePolicyOnLabelChange(store, node, oldLabels); err != nil {
-						node.Labels = oldLabels // restore
-						return nil, err
+				if invalidated {
+					embeddingutil.InvalidateManagedEmbeddings(entity)
+				}
+				if len(labelsToRemove) > 0 {
+					oldLabels := make([]string, len(entity.Labels))
+					copy(oldLabels, entity.Labels)
+					next, removed := removeNodeLabels(entity.Labels, labelsToRemove)
+					if removed > 0 {
+						entity.Labels = next
+						// Validate policy constraints before committing the label change.
+						if err := validatePolicyOnLabelChange(store, entity, oldLabels); err != nil {
+							entity.Labels = oldLabels // restore
+							return nil, err
+						}
 					}
 				}
+				if err := store.UpdateNode(entity); err != nil {
+					return nil, err
+				}
+				e.notifyNodeMutated(string(entity.ID))
+			case *storage.Edge:
+				if entity == nil {
+					continue
+				}
+				for _, prop := range propsToRemove {
+					if _, exists := entity.Properties[prop]; exists {
+						delete(entity.Properties, prop)
+						result.Stats.PropertiesSet++ // Neo4j counts removals as properties set
+					}
+				}
+				if err := store.UpdateEdge(entity); err != nil {
+					return nil, err
+				}
+				e.notifyEdgeMutated(string(entity.ID))
 			}
-			if err := store.UpdateNode(node); err != nil {
-				return nil, err
-			}
-			e.notifyNodeMutated(string(node.ID))
 		}
 	}
 
-	// Handle RETURN
+	// Handle RETURN. Build exactly one result row per matchResult row
+	// (mirroring executeSet's RETURN handling below via varMap/relMap +
+	// extractVariableNameFromReturnItem) instead of emitting one row per
+	// *storage.Node encountered in the row -- the latter both dropped every
+	// relationship variable and duplicated rows whenever a row bound more
+	// than one node variable.
 	if returnIdx > 0 && returnIdx > removeIdx {
 		returnPart := strings.TrimSpace(normalized[returnIdx+6:])
 		returnItems := e.parseReturnItems(returnPart)
@@ -2323,19 +2346,41 @@ func (e *StorageExecutor) executeRemove(ctx context.Context, cypher string) (*Ex
 				result.Columns[i] = item.expr
 			}
 		}
-		// Return updated nodes
 		for _, row := range matchResult.Rows {
-			for _, val := range row {
-				node, ok := val.(*storage.Node)
-				if !ok || node == nil {
+			varMap := make(map[string]*storage.Node, len(matchResult.Columns))
+			relMap := make(map[string]*storage.Edge, len(matchResult.Columns))
+			for i, colName := range matchResult.Columns {
+				if i >= len(row) {
 					continue
 				}
-				resultRow := make([]interface{}, len(returnItems))
-				for i, item := range returnItems {
-					resultRow[i] = e.resolveReturnItem(ctx, item, "n", node)
+				switch entity := row[i].(type) {
+				case *storage.Node:
+					if entity != nil {
+						varMap[colName] = entity
+					}
+				case *storage.Edge:
+					if entity != nil {
+						relMap[colName] = entity
+					}
 				}
-				result.Rows = append(result.Rows, resultRow)
 			}
+
+			resultRow := make([]interface{}, len(returnItems))
+			for i, item := range returnItems {
+				varName := extractVariableNameFromReturnItem(item.expr)
+				if varName != "" {
+					if node, ok := varMap[varName]; ok {
+						resultRow[i] = e.resolveReturnItem(ctx, item, varName, node)
+						continue
+					}
+					if _, ok := relMap[varName]; ok {
+						resultRow[i] = e.evaluateExpressionWithContext(ctx, item.expr, varMap, relMap)
+						continue
+					}
+				}
+				resultRow[i] = e.evaluateExpressionWithContext(ctx, item.expr, varMap, relMap)
+			}
+			result.Rows = append(result.Rows, resultRow)
 		}
 	}
 
@@ -2411,39 +2456,57 @@ func (e *StorageExecutor) applyRemoveToMatchedRows(
 	propsToRemove, labelsToRemove := e.parseRemoveItems(removePart)
 	for _, row := range matchResult.Rows {
 		for _, val := range row {
-			node, ok := val.(*storage.Node)
-			if !ok || node == nil {
-				continue
-			}
-			invalidated := false
-			for _, prop := range propsToRemove {
-				if _, exists := node.Properties[prop]; exists {
-					delete(node.Properties, prop)
-					result.Stats.PropertiesSet++
-					if !embeddingutil.IsMetadataPropertyKey(prop) {
-						invalidated = true
+			switch entity := val.(type) {
+			case *storage.Node:
+				if entity == nil {
+					continue
+				}
+				invalidated := false
+				for _, prop := range propsToRemove {
+					if _, exists := entity.Properties[prop]; exists {
+						delete(entity.Properties, prop)
+						result.Stats.PropertiesSet++
+						if !embeddingutil.IsMetadataPropertyKey(prop) {
+							invalidated = true
+						}
 					}
 				}
-			}
-			if len(labelsToRemove) > 0 {
-				oldLabels := make([]string, len(node.Labels))
-				copy(oldLabels, node.Labels)
-				next, removed := removeNodeLabels(node.Labels, labelsToRemove)
-				if removed > 0 {
-					node.Labels = next
-					if err := validatePolicyOnLabelChange(store, node, oldLabels); err != nil {
-						node.Labels = oldLabels // restore
-						return err
+				if len(labelsToRemove) > 0 {
+					oldLabels := make([]string, len(entity.Labels))
+					copy(oldLabels, entity.Labels)
+					next, removed := removeNodeLabels(entity.Labels, labelsToRemove)
+					if removed > 0 {
+						entity.Labels = next
+						if err := validatePolicyOnLabelChange(store, entity, oldLabels); err != nil {
+							entity.Labels = oldLabels // restore
+							return err
+						}
 					}
 				}
+				if invalidated {
+					embeddingutil.InvalidateManagedEmbeddings(entity)
+				}
+				if err := store.UpdateNode(entity); err != nil {
+					return err
+				}
+				e.notifyNodeMutated(string(entity.ID))
+			case *storage.Edge:
+				// Relationships have no labels to remove, only properties
+				// (see the mirrored *storage.Node handling in executeRemove).
+				if entity == nil {
+					continue
+				}
+				for _, prop := range propsToRemove {
+					if _, exists := entity.Properties[prop]; exists {
+						delete(entity.Properties, prop)
+						result.Stats.PropertiesSet++
+					}
+				}
+				if err := store.UpdateEdge(entity); err != nil {
+					return err
+				}
+				e.notifyEdgeMutated(string(entity.ID))
 			}
-			if invalidated {
-				embeddingutil.InvalidateManagedEmbeddings(node)
-			}
-			if err := store.UpdateNode(node); err != nil {
-				return err
-			}
-			e.notifyNodeMutated(string(node.ID))
 		}
 	}
 	return nil
@@ -2878,6 +2941,14 @@ func (e *StorageExecutor) evaluateRelationshipPatternInWhere(node *storage.Node,
 		checkOutgoing = true
 		relTypes = e.extractRelTypesFromPattern(pattern, "-[")
 	}
+	if !checkIncoming && !checkOutgoing {
+		// Bracket-less pattern (e.g. "(n)-->()", "()<--(n)") -- the checks
+		// above only recognize bracketed arrows, so fall back to direction
+		// detection on the bare arrow itself (eshu #5147).
+		if in, out, ok := bareRelDirection(pattern, variable); ok {
+			checkIncoming, checkOutgoing = in, out
+		}
+	}
 	if checkIncoming {
 		edges, _ := e.storage.GetIncomingEdges(node.ID)
 		for _, edge := range edges {
@@ -2906,14 +2977,25 @@ func (e *StorageExecutor) evaluateRelationshipPatternInWhere(node *storage.Node,
 func (e *StorageExecutor) checkSubqueryMatch(ctx context.Context, node *storage.Node, variable, subquery string) bool {
 	// Parse the MATCH pattern from the subquery
 	// Format: MATCH (var)<-[:TYPE]-(other) WHERE ...
+	//
+	// EXISTS { ... } and COUNT { ... } also allow an *implicit* MATCH: a
+	// bare pattern body with no "MATCH " keyword (e.g. "EXISTS { (n)--() }").
+	// The previous version required the "MATCH " prefix unconditionally, so
+	// a bare body always returned false here (eshu #5147).
+	subquery = strings.TrimSpace(subquery)
 	upperSub := strings.ToUpper(subquery)
 
-	if !strings.HasPrefix(upperSub, "MATCH ") {
+	var pattern string
+	switch {
+	case strings.HasPrefix(upperSub, "MATCH "):
+		pattern = strings.TrimSpace(subquery[6:])
+	case strings.HasPrefix(subquery, "("):
+		pattern = subquery
+	default:
 		return false
 	}
 
 	// Split out any WHERE clause from the pattern
-	pattern := strings.TrimSpace(subquery[6:])
 	innerWhere := ""
 
 	// Use regex to find WHERE with any whitespace before it (including newlines)
@@ -2952,6 +3034,13 @@ func (e *StorageExecutor) checkSubqueryMatch(ctx context.Context, node *storage.
 	if strings.Contains(pattern, "]->(") || strings.Contains(pattern, "]->") {
 		checkOutgoing = true
 		relTypes = e.extractRelTypesFromPattern(pattern, "-[")
+	}
+	if !checkIncoming && !checkOutgoing {
+		// Bracket-less pattern (e.g. "(n)-->()", "(n)--()") -- the checks
+		// above only recognize bracketed arrows (eshu #5147).
+		if in, out, ok := bareRelDirection(pattern, variable); ok {
+			checkIncoming, checkOutgoing = in, out
+		}
 	}
 
 	// Check for matching edges
@@ -3589,14 +3678,24 @@ func (e *StorageExecutor) evaluateCountSubqueryComparison(node *storage.Node, va
 
 // countSubqueryMatches counts how many matches a subquery produces
 func (e *StorageExecutor) countSubqueryMatches(node *storage.Node, variable, subquery string) int64 {
-	// Parse the MATCH pattern from the subquery
+	// Parse the MATCH pattern from the subquery.
+	//
+	// COUNT { ... } allows an *implicit* MATCH: a bare pattern body with no
+	// "MATCH " keyword (e.g. "COUNT { (n)--() }"). The previous version
+	// required the "MATCH " prefix unconditionally, so a bare body always
+	// returned 0 here (eshu #5147).
+	subquery = strings.TrimSpace(subquery)
 	upperSub := strings.ToUpper(subquery)
 
-	if !strings.HasPrefix(upperSub, "MATCH ") {
+	var pattern string
+	switch {
+	case strings.HasPrefix(upperSub, "MATCH "):
+		pattern = strings.TrimSpace(subquery[6:])
+	case strings.HasPrefix(subquery, "("):
+		pattern = subquery
+	default:
 		return 0
 	}
-
-	pattern := strings.TrimSpace(subquery[6:])
 
 	// Check if pattern references our variable
 	if !strings.Contains(pattern, "("+variable+")") && !strings.Contains(pattern, "("+variable+":") {
@@ -3629,6 +3728,14 @@ func (e *StorageExecutor) countSubqueryMatches(node *storage.Node, variable, sub
 		strings.Contains(pattern, "<-[") {
 		checkOutgoing = true
 		relTypes = e.extractRelTypesFromPattern(pattern, "<-[")
+	}
+
+	if !checkIncoming && !checkOutgoing {
+		// Bracket-less pattern (e.g. "(n)-->()", "(n)--()") -- the checks
+		// above only recognize bracketed arrows (eshu #5147).
+		if in, out, ok := bareRelDirection(pattern, variable); ok {
+			checkIncoming, checkOutgoing = in, out
+		}
 	}
 
 	// Count matching edges

--- a/pkg/cypher/executor_mutations_delete_guard.go
+++ b/pkg/cypher/executor_mutations_delete_guard.go
@@ -1,0 +1,104 @@
+package cypher
+
+import (
+	"fmt"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+// collectDeleteMutationTargets walks matchResult.Rows and classifies every
+// projected value into either a node or relationship delete target,
+// deduplicating repeats across rows. It performs no storage mutation --
+// this is the "collect" phase of DELETE's collect -> validate -> apply
+// pipeline (see validateNoResidualRelationships), which must complete
+// before any validation or mutation so a multi-row, multi-variable DELETE
+// (e.g. "DELETE a, r") can be judged as a whole statement.
+func collectDeleteMutationTargets(matchResult *ExecuteResult) (nodeIDs []storage.NodeID, edgeIDs []storage.EdgeID) {
+	seenNodes := make(map[string]struct{}, len(matchResult.Rows))
+	seenEdges := make(map[string]struct{}, len(matchResult.Rows))
+	nodeIDs = make([]storage.NodeID, 0, len(matchResult.Rows))
+	edgeIDs = make([]storage.EdgeID, 0, len(matchResult.Rows))
+
+	for _, row := range matchResult.Rows {
+		for _, val := range row {
+			target := classifyDeleteTargetValue(val)
+			switch target.kind {
+			case deleteProjectionRelationship:
+				key := string(target.edgeID)
+				if _, seen := seenEdges[key]; seen {
+					continue
+				}
+				seenEdges[key] = struct{}{}
+				edgeIDs = append(edgeIDs, target.edgeID)
+			case deleteProjectionNode:
+				key := string(target.nodeID)
+				if _, seen := seenNodes[key]; seen {
+					continue
+				}
+				seenNodes[key] = struct{}{}
+				nodeIDs = append(nodeIDs, target.nodeID)
+			}
+		}
+	}
+
+	return nodeIDs, edgeIDs
+}
+
+// validateNoResidualRelationships enforces openCypher/Neo4j DELETE
+// semantics: a non-DETACH DELETE of a node that still has relationships is
+// an error, not a silent cascade. NornicDB's storage layer
+// (BadgerEngine.DeleteNode) cascades every adjacent edge unconditionally,
+// so without this check a plain "DELETE n" on a connected node quietly
+// deleted its edges too -- the third proven bug behind eshu #5147.
+//
+// This must run BEFORE any node or edge in the plan is mutated: validating
+// mid-apply would let a multi-row DELETE partially commit before a later
+// row is found to violate the constraint, breaking statement atomicity.
+//
+// An edge attached to a candidate node does not count as residual if the
+// same statement is also deleting that edge (e.g.
+// "MATCH (a)-[r]->(b) DELETE a, r"); edgeIDs holds every edge this
+// statement is about to remove, so those are subtracted before the check.
+func validateNoResidualRelationships(store storage.Engine, nodeIDs []storage.NodeID, edgeIDs []storage.EdgeID) error {
+	if len(nodeIDs) == 0 {
+		return nil
+	}
+
+	beingDeleted := make(map[storage.EdgeID]struct{}, len(edgeIDs))
+	for _, id := range edgeIDs {
+		beingDeleted[id] = struct{}{}
+	}
+
+	for _, nodeID := range nodeIDs {
+		outgoing, err := store.GetOutgoingEdges(nodeID)
+		if err != nil {
+			return err
+		}
+		for _, edge := range outgoing {
+			if _, deleting := beingDeleted[edge.ID]; !deleting {
+				return residualRelationshipDeleteError(nodeID)
+			}
+		}
+
+		incoming, err := store.GetIncomingEdges(nodeID)
+		if err != nil {
+			return err
+		}
+		for _, edge := range incoming {
+			if _, deleting := beingDeleted[edge.ID]; !deleting {
+				return residualRelationshipDeleteError(nodeID)
+			}
+		}
+	}
+
+	return nil
+}
+
+// residualRelationshipDeleteError builds the error returned when a
+// non-DETACH DELETE targets a node that still has relationships. The
+// wording mirrors Neo4j's own "still has relationships" DELETE error so
+// clients that pattern-match on that message keep working against
+// NornicDB.
+func residualRelationshipDeleteError(nodeID storage.NodeID) error {
+	return fmt.Errorf("Cannot delete node %s, because it still has relationships. To delete this node, you must first delete its relationships (or use DETACH DELETE)", nodeID)
+}

--- a/pkg/cypher/executor_mutations_remove_scope.go
+++ b/pkg/cypher/executor_mutations_remove_scope.go
@@ -7,15 +7,11 @@ import "strings"
 // clause, mirroring extractScopeVariablesFromSetAndReturn (executor_mutations.go).
 // executeRemove uses this to keep every variable the REMOVE/RETURN clauses
 // actually need in its internal MATCH probe's projection.
-//
-// extractVariableNamesFromPattern only scans node groups outside "[...]", so
-// a relationship variable bound solely inside a bracketed pattern (e.g. the
-// "r" in "OPTIONAL MATCH (n)-[r:TYPE]->(m)") is invisible to it. Without this
-// helper, "REMOVE r.prop" silently dropped r from the probe's RETURN list, so
-// the mutation loop never received a *storage.Edge to remove the property
-// from -- the relationship-agnostic parseRemoveItems call site never even
-// learns r is the intended target, only that "prop" should be removed from
-// whatever entity in scope has it (eshu #5147).
+type removeTargetBindings struct {
+	propsByVar  map[string][]string
+	labelsByVar map[string][]string
+}
+
 func extractScopeVariablesFromRemoveAndReturn(removePart, returnPart string) []string {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, 4)
@@ -36,16 +32,14 @@ func extractScopeVariablesFromRemoveAndReturn(removePart, returnPart string) []s
 		if item == "" {
 			continue
 		}
-		var varName string
 		switch {
 		case strings.Contains(item, "."):
-			varName = strings.TrimSpace(item[:strings.Index(item, ".")])
+			add(strings.TrimSpace(item[:strings.Index(item, ".")]))
 		case strings.Contains(item, ":"):
-			varName = strings.TrimSpace(item[:strings.Index(item, ":")])
+			add(strings.TrimSpace(item[:strings.Index(item, ":")]))
 		default:
-			varName = item
+			add(item)
 		}
-		add(varName)
 	}
 
 	if strings.TrimSpace(returnPart) != "" {
@@ -60,5 +54,50 @@ func extractScopeVariablesFromRemoveAndReturn(removePart, returnPart string) []s
 			add(extractVariableNameFromReturnItem(expr))
 		}
 	}
+
 	return out
+}
+
+func parseRemoveTargetBindings(removePart string) removeTargetBindings {
+	bindings := removeTargetBindings{
+		propsByVar:  make(map[string][]string),
+		labelsByVar: make(map[string][]string),
+	}
+
+	for _, raw := range strings.Split(removePart, ",") {
+		item := strings.TrimSpace(raw)
+		if item == "" {
+			continue
+		}
+		if dotIdx := strings.Index(item, "."); dotIdx >= 0 {
+			varName := strings.TrimSpace(item[:dotIdx])
+			propName := strings.TrimSpace(item[dotIdx+1:])
+			if isValidIdentifier(varName) && propName != "" {
+				bindings.propsByVar[varName] = append(bindings.propsByVar[varName], propName)
+			}
+			continue
+		}
+		if colonIdx := strings.Index(item, ":"); colonIdx >= 0 {
+			varName := strings.TrimSpace(item[:colonIdx])
+			if !isValidIdentifier(varName) {
+				continue
+			}
+			for _, label := range strings.Split(item[colonIdx+1:], ":") {
+				label = strings.TrimSpace(label)
+				if label != "" {
+					bindings.labelsByVar[varName] = append(bindings.labelsByVar[varName], label)
+				}
+			}
+		}
+	}
+
+	return bindings
+}
+
+func (b removeTargetBindings) propertyNames(varName string) []string {
+	return b.propsByVar[varName]
+}
+
+func (b removeTargetBindings) labelNames(varName string) []string {
+	return b.labelsByVar[varName]
 }

--- a/pkg/cypher/executor_mutations_remove_scope.go
+++ b/pkg/cypher/executor_mutations_remove_scope.go
@@ -1,0 +1,64 @@
+package cypher
+
+import "strings"
+
+// extractScopeVariablesFromRemoveAndReturn extracts every variable name
+// referenced in a REMOVE clause (e.g. "r.prop", "n:Label") and a RETURN
+// clause, mirroring extractScopeVariablesFromSetAndReturn (executor_mutations.go).
+// executeRemove uses this to keep every variable the REMOVE/RETURN clauses
+// actually need in its internal MATCH probe's projection.
+//
+// extractVariableNamesFromPattern only scans node groups outside "[...]", so
+// a relationship variable bound solely inside a bracketed pattern (e.g. the
+// "r" in "OPTIONAL MATCH (n)-[r:TYPE]->(m)") is invisible to it. Without this
+// helper, "REMOVE r.prop" silently dropped r from the probe's RETURN list, so
+// the mutation loop never received a *storage.Edge to remove the property
+// from -- the relationship-agnostic parseRemoveItems call site never even
+// learns r is the intended target, only that "prop" should be removed from
+// whatever entity in scope has it (eshu #5147).
+func extractScopeVariablesFromRemoveAndReturn(removePart, returnPart string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 4)
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" || !isValidIdentifier(v) {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+
+	for _, raw := range strings.Split(removePart, ",") {
+		item := strings.TrimSpace(raw)
+		if item == "" {
+			continue
+		}
+		var varName string
+		switch {
+		case strings.Contains(item, "."):
+			varName = strings.TrimSpace(item[:strings.Index(item, ".")])
+		case strings.Contains(item, ":"):
+			varName = strings.TrimSpace(item[:strings.Index(item, ":")])
+		default:
+			varName = item
+		}
+		add(varName)
+	}
+
+	if strings.TrimSpace(returnPart) != "" {
+		for _, raw := range splitTopLevelCommaKeepEmpty(returnPart) {
+			expr := strings.TrimSpace(raw)
+			if expr == "" {
+				continue
+			}
+			if asIdx := findKeywordIndex(expr, "AS"); asIdx > 0 {
+				expr = strings.TrimSpace(expr[:asIdx])
+			}
+			add(extractVariableNameFromReturnItem(expr))
+		}
+	}
+	return out
+}

--- a/pkg/cypher/executor_mutations_where_eval.go
+++ b/pkg/cypher/executor_mutations_where_eval.go
@@ -534,7 +534,13 @@ func (e *StorageExecutor) evaluateWhere(ctx context.Context, node *storage.Node,
 	// Handle relationship patterns like (n)-[:TYPE]->() that may appear as "n)-[:TYPE]->()"
 	// after stripping outer parens from NOT (n)-[:TYPE]->(). Must run BEFORE operator check
 	// so "->" is not misinterpreted as ">" comparison.
-	hasRelPattern := (strings.Contains(whereClause, "-[") && (strings.Contains(whereClause, "]->") || strings.Contains(whereClause, "<-")))
+	//
+	// containsRelExistencePattern also recognizes bracket-less patterns
+	// ((n)--(), (n)-->(), (n)<--()) and the bracketed *undirected* form
+	// ((n)-[r]-()) -- the previous gate only matched a bracketed pattern
+	// with an explicit arrow, so those forms fell through to
+	// evaluateWhereAsBoolean's default-true branch (eshu #5147).
+	hasRelPattern := containsRelExistencePattern(whereClause)
 	refsVar := strings.Contains(whereClause, "("+variable+")") || strings.Contains(whereClause, "("+variable+":") ||
 		strings.HasPrefix(whereClause, variable+")") || strings.HasPrefix(whereClause, variable+":")
 	if hasRelPattern && refsVar {

--- a/pkg/cypher/executor_mutations_where_eval.go
+++ b/pkg/cypher/executor_mutations_where_eval.go
@@ -531,15 +531,8 @@ func (e *StorageExecutor) evaluateWhere(ctx context.Context, node *storage.Node,
 		return e.evaluateIsNull(ctx, node, variable, whereClause, true)
 	}
 
-	// Handle relationship patterns like (n)-[:TYPE]->() that may appear as "n)-[:TYPE]->()"
-	// after stripping outer parens from NOT (n)-[:TYPE]->(). Must run BEFORE operator check
-	// so "->" is not misinterpreted as ">" comparison.
-	//
-	// containsRelExistencePattern also recognizes bracket-less patterns
-	// ((n)--(), (n)-->(), (n)<--()) and the bracketed *undirected* form
-	// ((n)-[r]-()) -- the previous gate only matched a bracketed pattern
-	// with an explicit arrow, so those forms fell through to
-	// evaluateWhereAsBoolean's default-true branch (eshu #5147).
+	// Handle relationship-existence patterns before operator checks so arrow
+	// syntax is not misinterpreted as a comparison operator.
 	hasRelPattern := containsRelExistencePattern(whereClause)
 	refsVar := strings.Contains(whereClause, "("+variable+")") || strings.Contains(whereClause, "("+variable+":") ||
 		strings.HasPrefix(whereClause, variable+")") || strings.HasPrefix(whereClause, variable+":")

--- a/pkg/cypher/match.go
+++ b/pkg/cypher/match.go
@@ -381,6 +381,36 @@ func (e *StorageExecutor) executeMatch(ctx context.Context, cypher string) (*Exe
 	}
 	matchPart = strings.TrimSpace(matchPart)
 
+	// A relationship pattern embedded after a literal "OPTIONAL MATCH" keyword
+	// (e.g. matchPart == "(n) OPTIONAL MATCH (n)-[r:TYPE]->(m)") must be routed
+	// through executeCompoundMatchOptionalMatch instead of the naive
+	// relationship-pattern branch below.
+	//
+	// executeMatchWithRelationshipsWithPath -> parseTraversalPatternStateMachine
+	// locates the relationship bracket by scanning forward from the character
+	// right after the FIRST node group's closing paren, assuming that
+	// character starts the "-[" (or "<-[") relationship syntax. The literal
+	// "OPTIONAL MATCH (n)" text between the outer MATCH's node and the
+	// optional relationship breaks that assumption: it gets folded into the
+	// substring handed to parseRelationshipPattern, which requires the
+	// substring (after stripping a leading arrow) to start with "[". Since the
+	// corrupted substring starts with whitespace instead, that check never
+	// fires and the relationship variable/type/properties are silently
+	// dropped -- e.g. a probe built by executeDelete/executeSet/executeRemove's
+	// internal "MATCH ... OPTIONAL MATCH ... RETURN <vars>" probe resolves an
+	// OPTIONAL MATCH-bound relationship variable to nil even though the
+	// OPTIONAL MATCH genuinely matched (eshu #5147).
+	//
+	// This is only reachable here when a caller invokes executeMatch directly
+	// with an embedded OPTIONAL MATCH: the top-level dispatcher
+	// (executeWithoutTransaction) already routes "MATCH ... OPTIONAL MATCH
+	// ..." queries to executeCompoundMatchOptionalMatch before they would ever
+	// reach this function.
+	if (strings.Contains(matchPart, "-[") || strings.Contains(matchPart, "]-")) &&
+		findKeywordIndex(matchPart, "OPTIONAL MATCH") >= 0 {
+		return e.executeCompoundMatchOptionalMatch(ctx, originalCypher)
+	}
+
 	// Check for relationship pattern: (a)-[r:TYPE]->(b) or (a)<-[r]-(b)
 	if strings.Contains(matchPart, "-[") || strings.Contains(matchPart, "]-") {
 		// Extract WHERE clause if present

--- a/pkg/cypher/match.go
+++ b/pkg/cypher/match.go
@@ -406,7 +406,7 @@ func (e *StorageExecutor) executeMatch(ctx context.Context, cypher string) (*Exe
 	// (executeWithoutTransaction) already routes "MATCH ... OPTIONAL MATCH
 	// ..." queries to executeCompoundMatchOptionalMatch before they would ever
 	// reach this function.
-	if (strings.Contains(matchPart, "-[") || strings.Contains(matchPart, "]-")) &&
+	if (containsOutsideStrings(matchPart, "-[") || containsOutsideStrings(matchPart, "]-")) &&
 		findKeywordIndex(matchPart, "OPTIONAL MATCH") >= 0 {
 		return e.executeCompoundMatchOptionalMatch(ctx, originalCypher)
 	}

--- a/pkg/cypher/neo4j_compat_queries_test.go
+++ b/pkg/cypher/neo4j_compat_queries_test.go
@@ -347,6 +347,17 @@ func TestNeo4jCompatChunkOperations(t *testing.T) {
 	})
 
 	t.Run("Delete chunks with OPTIONAL MATCH", func(t *testing.T) {
+		// Plain (non-DETACH) "DELETE r, chunk": r is bound by the embedded
+		// OPTIONAL MATCH and must resolve to the real *storage.Edge so the
+		// non-DETACH residual-relationship guard recognizes it as one of the
+		// edges this statement itself removes (eshu #5147). Previously
+		// executeDelete's internal "MATCH ... RETURN r, chunk" probe ran
+		// through the raw executeMatch path, which mishandled the embedded
+		// "OPTIONAL MATCH" text and resolved r to nil; the guard then
+		// rejected this statement outright. match.go's executeMatch now
+		// routes an embedded OPTIONAL MATCH through
+		// executeCompoundMatchOptionalMatch, so r resolves correctly and
+		// this plain DELETE succeeds.
 		result, err := exec.Execute(ctx, `
 			MATCH (n:Node {id: 'parent-node-id'})
 			OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk)

--- a/pkg/cypher/optional_match_rel_var_probe_test.go
+++ b/pkg/cypher/optional_match_rel_var_probe_test.go
@@ -1,0 +1,260 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ====================================================================================
+// BUG: an OPTIONAL MATCH-bound relationship variable resolves to nil in the
+// raw executeMatch path, even when the OPTIONAL MATCH genuinely matched.
+// ====================================================================================
+// Discovered: eshu #5147 (surfaced while proving the DELETE residual-
+// relationship guard above).
+// Impact: executeDelete/executeSet/executeRemove all build an internal probe
+//         shaped "MATCH ... OPTIONAL MATCH (a)-[r:TYPE]->(b) RETURN <vars>"
+//         and execute it via the low-level e.executeMatch (pkg/cypher/match.go)
+//         instead of the dispatcher (executor_query_routing.go
+//         executeWithoutTransaction, which detects "OPTIONAL MATCH" and calls
+//         executeCompoundMatchOptionalMatch). A bound relationship variable
+//         from the embedded OPTIONAL MATCH projected to nil instead of the
+//         real *storage.Edge, so a plain (non-DETACH) "DELETE r, chunk" could
+//         not recognize r as one of the edges the statement itself removes,
+//         and the new residual-relationship DELETE guard rejected it. The
+//         same probe shape is used by SET/REMOVE, so "SET r.prop = ..." and
+//         "REMOVE r.prop" on an OPTIONAL MATCH-bound relationship silently
+//         no-op'd instead of mutating the real edge.
+// Root Cause: executeMatch's relationship-pattern branch concatenates the
+//         literal "OPTIONAL MATCH ..." text into one pattern string and hands
+//         it to executeMatchWithRelationshipsWithPath ->
+//         parseTraversalPatternStateMachine, which locates the relationship
+//         bracket by scanning forward from the character right after the
+//         FIRST node group's closing paren -- it never explicitly searches
+//         for "-[" or "<-[". The embedded "OPTIONAL MATCH (n)" text between
+//         the two node groups gets folded into the substring handed to
+//         parseRelationshipPattern, which requires that substring (after
+//         stripping a leading arrow) to start with "[". Since the corrupted
+//         substring starts with whitespace instead, that check never fires
+//         and the relationship variable/type/properties are silently
+//         dropped.
+// Fix: executeMatch now detects an embedded "OPTIONAL MATCH" inside a
+//         relationship-pattern matchPart and routes the whole query through
+//         executeCompoundMatchOptionalMatch, the same handler the top-level
+//         dispatcher already uses for "MATCH ... OPTIONAL MATCH ..." queries.
+// ====================================================================================
+
+func setupOptionalMatchRelVarFixture(t *testing.T) (*StorageExecutor, storage.Engine) {
+	t.Helper()
+	base := storage.NewMemoryEngine()
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	store := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+		CREATE (n:Node {id: 'parent-node-id'})
+		CREATE (c:NodeChunk:Node {id: 'chunk-1'})
+		CREATE (o:Node {id: 'no-chunk-node'})
+		CREATE (n)-[:HAS_CHUNK {index: 0}]->(c)
+	`, nil)
+	require.NoError(t, err)
+
+	return exec, store
+}
+
+// TestBug_OptionalMatchRelVarResolvesToRealEdge exercises the raw internal
+// probe path directly (exec.executeMatch), bypassing the top-level
+// dispatcher, to prove the relationship variable bound by an embedded
+// OPTIONAL MATCH resolves to a real *storage.Edge -- nil only when the
+// OPTIONAL MATCH genuinely found no match.
+func TestBug_OptionalMatchRelVarResolvesToRealEdge(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantEdgeNil bool
+		wantNodeNil bool
+	}{
+		{
+			name:        "OPTIONAL MATCH finds the relationship: r resolves to the real edge",
+			query:       `MATCH (n:Node {id: 'parent-node-id'}) OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk) RETURN r, chunk`,
+			wantEdgeNil: false,
+			wantNodeNil: false,
+		},
+		{
+			name:        "OPTIONAL MATCH finds nothing: r and chunk both resolve to nil",
+			query:       `MATCH (n:Node {id: 'no-chunk-node'}) OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk) RETURN r, chunk`,
+			wantEdgeNil: true,
+			wantNodeNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, _ := setupOptionalMatchRelVarFixture(t)
+			ctx := context.Background()
+
+			result, err := exec.executeMatch(ctx, tt.query)
+			require.NoError(t, err)
+			require.Len(t, result.Rows, 1)
+			require.Len(t, result.Rows[0], 2)
+
+			if tt.wantEdgeNil {
+				assert.Nil(t, result.Rows[0][0], "r must be nil when OPTIONAL MATCH found nothing")
+			} else {
+				edge, ok := result.Rows[0][0].(*storage.Edge)
+				require.True(t, ok, "r must resolve to a *storage.Edge, got %T", result.Rows[0][0])
+				require.NotNil(t, edge)
+				assert.Equal(t, "HAS_CHUNK", edge.Type)
+			}
+
+			if tt.wantNodeNil {
+				assert.Nil(t, result.Rows[0][1], "chunk must be nil when OPTIONAL MATCH found nothing")
+			} else {
+				node, ok := result.Rows[0][1].(*storage.Node)
+				require.True(t, ok, "chunk must resolve to a *storage.Node, got %T", result.Rows[0][1])
+				require.NotNil(t, node)
+				assert.Equal(t, "chunk-1", node.Properties["id"])
+			}
+		})
+	}
+}
+
+// TestBug_DeletePlainOptionalMatchRelVar proves the root-cause fix, not a
+// workaround: a plain (non-DETACH) "DELETE r, chunk" against an OPTIONAL
+// MATCH-bound relationship now succeeds, because r resolves to the real edge
+// being deleted and the residual-relationship guard recognizes it as part of
+// this statement's own deletion set.
+func TestBug_DeletePlainOptionalMatchRelVar(t *testing.T) {
+	exec, _ := setupOptionalMatchRelVarFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `
+		MATCH (n:Node {id: 'parent-node-id'})
+		OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk)
+		DELETE r, chunk
+	`, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Stats.NodesDeleted)
+	assert.Equal(t, 1, result.Stats.RelationshipsDeleted)
+
+	countResult, err := exec.Execute(ctx, `MATCH (c:NodeChunk {id: 'chunk-1'}) RETURN count(c)`, nil)
+	require.NoError(t, err)
+	require.Len(t, countResult.Rows, 1)
+	assert.Equal(t, int64(0), countResult.Rows[0][0].(int64), "chunk node must be deleted")
+
+	edgeCountResult, err := exec.Execute(ctx, `MATCH (:Node {id: 'parent-node-id'})-[r:HAS_CHUNK]->() RETURN count(r)`, nil)
+	require.NoError(t, err)
+	require.Len(t, edgeCountResult.Rows, 1)
+	assert.Equal(t, int64(0), edgeCountResult.Rows[0][0].(int64), "HAS_CHUNK edge must be deleted")
+
+	parentResult, err := exec.Execute(ctx, `MATCH (n:Node {id: 'parent-node-id'}) RETURN count(n)`, nil)
+	require.NoError(t, err)
+	require.Len(t, parentResult.Rows, 1)
+	assert.Equal(t, int64(1), parentResult.Rows[0][0].(int64), "parent node itself must survive")
+}
+
+// TestBug_DeletePlainOptionalMatchRelVar_NoMatch proves a real OPTIONAL MATCH
+// miss still leaves nothing to delete (r and chunk are genuinely nil, not a
+// resolution failure), so the DELETE is a harmless no-op rather than an
+// error.
+func TestBug_DeletePlainOptionalMatchRelVar_NoMatch(t *testing.T) {
+	exec, _ := setupOptionalMatchRelVarFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `
+		MATCH (n:Node {id: 'no-chunk-node'})
+		OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk)
+		DELETE r, chunk
+	`, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Stats.NodesDeleted)
+	assert.Equal(t, 0, result.Stats.RelationshipsDeleted)
+
+	parentResult, err := exec.Execute(ctx, `MATCH (n:Node {id: 'no-chunk-node'}) RETURN count(n)`, nil)
+	require.NoError(t, err)
+	require.Len(t, parentResult.Rows, 1)
+	assert.Equal(t, int64(1), parentResult.Rows[0][0].(int64), "node with no chunk must survive")
+}
+
+// TestBug_SetOnOptionalMatchRelVar proves the same probe shape resolves
+// correctly for SET: "MATCH ... OPTIONAL MATCH (a)-[r]->(b) SET r.prop = ..."
+// must mutate the real edge, not silently no-op on a nil relationship
+// variable.
+func TestBug_SetOnOptionalMatchRelVar(t *testing.T) {
+	exec, _ := setupOptionalMatchRelVarFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `
+		MATCH (n:Node {id: 'parent-node-id'})
+		OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk)
+		SET r.reviewed = true
+		RETURN r.reviewed
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	assert.Equal(t, true, result.Rows[0][0], "SET on an OPTIONAL MATCH-bound relationship variable must apply")
+
+	verify, err := exec.Execute(ctx, `MATCH (:Node {id: 'parent-node-id'})-[r:HAS_CHUNK]->() RETURN r.reviewed`, nil)
+	require.NoError(t, err)
+	require.Len(t, verify.Rows, 1)
+	assert.Equal(t, true, verify.Rows[0][0], "the mutation must persist on the real stored edge")
+}
+
+// TestBug_RemoveOnOptionalMatchRelVar proves the same probe shape resolves
+// correctly for REMOVE: "MATCH ... OPTIONAL MATCH (a)-[r]->(b) REMOVE
+// r.prop" must remove the property from the real edge.
+func TestBug_RemoveOnOptionalMatchRelVar(t *testing.T) {
+	exec, _ := setupOptionalMatchRelVarFixture(t)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+		MATCH (:Node {id: 'parent-node-id'})-[r:HAS_CHUNK]->()
+		SET r.temp_flag = true
+	`, nil)
+	require.NoError(t, err)
+
+	result, err := exec.Execute(ctx, `
+		MATCH (n:Node {id: 'parent-node-id'})
+		OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk)
+		REMOVE r.temp_flag
+		RETURN r.temp_flag
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	assert.Nil(t, result.Rows[0][0], "REMOVE on an OPTIONAL MATCH-bound relationship variable must apply")
+
+	verify, err := exec.Execute(ctx, `MATCH (:Node {id: 'parent-node-id'})-[r:HAS_CHUNK]->() RETURN r.temp_flag`, nil)
+	require.NoError(t, err)
+	require.Len(t, verify.Rows, 1)
+	assert.Nil(t, verify.Rows[0][0], "the property removal must persist on the real stored edge")
+}
+
+// TestBug_ChainedSetRemoveOnRelationshipVar exercises applyRemoveToMatchedRows
+// (the helper backing a chained "SET ... REMOVE ..." clause in a single
+// statement) with a relationship variable, proving its *storage.Edge branch
+// removes the property from the real edge rather than silently skipping
+// every non-node value in the row.
+func TestBug_ChainedSetRemoveOnRelationshipVar(t *testing.T) {
+	exec, _ := setupOptionalMatchRelVarFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.Execute(ctx, `
+		MATCH (n:Node {id: 'parent-node-id'})-[r:HAS_CHUNK]->(chunk:NodeChunk)
+		SET chunk.reviewed = true
+		REMOVE r.index
+		RETURN r.index, chunk.reviewed
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	assert.Nil(t, result.Rows[0][0], "chained REMOVE must clear the relationship property")
+	assert.Equal(t, true, result.Rows[0][1], "the chained SET must still apply to the node")
+
+	verify, err := exec.Execute(ctx, `MATCH (:Node {id: 'parent-node-id'})-[r:HAS_CHUNK]->() RETURN r.index`, nil)
+	require.NoError(t, err)
+	require.Len(t, verify.Rows, 1)
+	assert.Nil(t, verify.Rows[0][0], "the property removal must persist on the real stored edge")
+}

--- a/pkg/cypher/pr_regressions_test.go
+++ b/pkg/cypher/pr_regressions_test.go
@@ -1,0 +1,147 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRemoveRelationshipFixture(t *testing.T) *StorageExecutor {
+	t.Helper()
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "remove_rel_scope")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+		CREATE (a:Item {id: 'a', flag: true})
+		CREATE (b:Item {id: 'b', flag: true})
+		CREATE (a)-[:LINK {flag: true, keep: 'edge-only'}]->(b)
+	`, nil)
+	require.NoError(t, err)
+
+	return exec
+}
+
+func setupTypedUndirectedRelationshipFixture(t *testing.T) *StorageExecutor {
+	t.Helper()
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "typed_undirected_rel")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `CREATE (:Item {name: 'orphan'})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		CREATE (c:Item {name: 'contains-start'})
+		CREATE (p:Item {name: 'contains-end'})
+		CREATE (c)-[:CONTAINS]->(p)
+	`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		CREATE (l:Item {name: 'likes-start'})
+		CREATE (m:Item {name: 'likes-end'})
+		CREATE (l)-[:LIKES]->(m)
+	`, nil)
+	require.NoError(t, err)
+
+	return exec
+}
+
+func setupOptionalMatchProbeFixture(t *testing.T) *StorageExecutor {
+	t.Helper()
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "optional_match_probe")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+		CREATE (n:Node {id: 'parent-node-id'})
+		CREATE (c:NodeChunk:Node {id: 'chunk-1'})
+		CREATE (n)-[:HAS_CHUNK {index: 0}]->(c)
+	`, nil)
+	require.NoError(t, err)
+
+	return exec
+}
+
+func itemNames(rows [][]interface{}) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if len(row) == 0 {
+			continue
+		}
+		name, ok := row[0].(string)
+		if ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func TestRegression_RemoveRelationshipPropertyIsScopedToRelationship(t *testing.T) {
+	exec := setupRemoveRelationshipFixture(t)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `MATCH (a:Item {id: 'a'})-[r:LINK]->(b:Item {id: 'b'}) REMOVE r.flag`, nil)
+	require.NoError(t, err)
+
+	result, err := exec.Execute(ctx, `
+		MATCH (a:Item {id: 'a'})-[r:LINK]->(b:Item {id: 'b'})
+		RETURN a.flag, r.flag, b.flag, r.keep
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.Len(t, result.Rows[0], 4)
+	assert.Equal(t, true, result.Rows[0][0], "REMOVE r.flag must not touch the source node")
+	assert.Nil(t, result.Rows[0][1], "REMOVE r.flag must remove the property from the relationship")
+	assert.Equal(t, true, result.Rows[0][2], "REMOVE r.flag must not touch the target node")
+	assert.Equal(t, "edge-only", result.Rows[0][3], "unrelated relationship properties must survive")
+}
+
+func TestRegression_TypedUndirectedRelationshipExistenceRespectsRelationshipType(t *testing.T) {
+	exec := setupTypedUndirectedRelationshipFixture(t)
+	ctx := context.Background()
+
+	t.Run("WHERE typed undirected pattern filters by type", func(t *testing.T) {
+		result, err := exec.Execute(ctx, `MATCH (n:Item) WHERE (n)-[:CONTAINS]-() RETURN n.name ORDER BY n.name`, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"contains-end", "contains-start"}, itemNames(result.Rows))
+	})
+
+	t.Run("EXISTS typed undirected subquery filters by type", func(t *testing.T) {
+		result, err := exec.Execute(ctx, `MATCH (n:Item) WHERE EXISTS { MATCH (n)-[:CONTAINS]-() } RETURN n.name ORDER BY n.name`, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"contains-end", "contains-start"}, itemNames(result.Rows))
+	})
+
+	t.Run("COUNT typed undirected subquery filters by type", func(t *testing.T) {
+		result, err := exec.Execute(ctx, `MATCH (n:Item) WHERE COUNT { MATCH (n)-[:CONTAINS]-() } = 1 RETURN n.name ORDER BY n.name`, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"contains-end", "contains-start"}, itemNames(result.Rows))
+	})
+}
+
+func TestRegression_ExecuteMatchEmbeddedOptionalMatchProjectsRelationshipVariable(t *testing.T) {
+	exec := setupOptionalMatchProbeFixture(t)
+	ctx := context.Background()
+
+	result, err := exec.executeMatch(ctx, `MATCH (n:Node {id: 'parent-node-id'}) OPTIONAL MATCH (n)-[r:HAS_CHUNK]->(chunk:NodeChunk) RETURN r, chunk`)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.Len(t, result.Rows[0], 2)
+
+	edge, ok := result.Rows[0][0].(*storage.Edge)
+	require.True(t, ok, "embedded OPTIONAL MATCH should project the relationship variable as *storage.Edge, got %T", result.Rows[0][0])
+	require.NotNil(t, edge)
+	assert.Equal(t, storage.EdgeID("HAS_CHUNK"), storage.EdgeID(edge.Type), "relationship type should survive the probe path")
+	assert.Equal(t, int64(0), edge.Properties["index"], "relationship properties should survive the probe path")
+
+	node, ok := result.Rows[0][1].(*storage.Node)
+	require.True(t, ok, "embedded OPTIONAL MATCH should project the optional node as *storage.Node, got %T", result.Rows[0][1])
+	require.NotNil(t, node)
+	assert.Equal(t, "chunk-1", node.Properties["id"])
+}

--- a/pkg/cypher/rel_existence_pattern.go
+++ b/pkg/cypher/rel_existence_pattern.go
@@ -1,0 +1,88 @@
+package cypher
+
+import "strings"
+
+// containsRelExistencePattern reports whether a WHERE fragment contains a
+// relationship-existence pattern such as (n)--(), (n)-->(), (n)<--(), or a
+// bracketed relationship pattern like (n)-[r]-() or (n)-[:TYPE]->().
+//
+// The pre-fix gate only recognized bracketed patterns with an explicit
+// arrow (`-[...]->` or `<-[...]-`), so bracket-less patterns
+// ((n)--(), (n)-->(), (n)<--()) and even the bracketed *undirected* form
+// ((n)-[r]-()) fell through to evaluateWhereAsBoolean, whose default branch
+// treats an unrecognized expression as true. That is the root cause of
+// "WHERE NOT (n)--() matches nothing" and "WHERE (n)--() always true".
+//
+// containsRelExistencePattern must not match ordinary arithmetic that
+// happens to contain a hyphen, e.g. "n.a - n.b" or "n.arr[0]-1" -- neither
+// contains "-[" followed by "]-", nor ")--(", ")-->(", or ")<--(".
+func containsRelExistencePattern(s string) bool {
+	if strings.Contains(s, "-[") && strings.Contains(s, "]-") {
+		// Covers "]->", "]-(", and the undirected bracketed "-[r]-" form.
+		return true
+	}
+	return strings.Contains(s, ")--(") || strings.Contains(s, ")-->(") || strings.Contains(s, ")<--(")
+}
+
+// bareRelDirection determines the traversal direction implied by a
+// bracket-less relationship-existence pattern -- e.g. "(n)-->()",
+// "()<--(n)", "(n)--()" -- relative to variable.
+//
+// It returns ok=false when:
+//   - pattern contains a bracketed relationship ("-["), which is handled by
+//     the bracketed-pattern direction detection instead;
+//   - variable's node group (e.g. "(n)" or "(n:Label)") cannot be located
+//     in pattern;
+//   - neither side of the located group is bounded by a recognized
+//     bracket-less arrow ("-->", "<--", or undirected "--").
+//
+// When ok is true, incoming/outgoing describe which adjacency lists the
+// caller should search from variable's perspective: "(n)-->()" is outgoing
+// from n, "(n)<--()" is incoming to n, "()-->(n)" is incoming to n (the
+// arrow points at n), "()<--(n)" is outgoing from n, and the undirected
+// "--" form sets both.
+func bareRelDirection(pattern, variable string) (incoming, outgoing, ok bool) {
+	if strings.Contains(pattern, "-[") {
+		return false, false, false
+	}
+
+	groupStart := strings.Index(pattern, "("+variable+")")
+	var groupEnd int
+	if groupStart >= 0 {
+		groupEnd = groupStart + len(variable) + 2 // len("("+variable+")")
+	} else {
+		idx := strings.Index(pattern, "("+variable+":")
+		if idx < 0 {
+			return false, false, false
+		}
+		closeRel := strings.Index(pattern[idx:], ")")
+		if closeRel < 0 {
+			return false, false, false
+		}
+		groupStart = idx
+		groupEnd = idx + closeRel + 1
+	}
+
+	before := pattern[:groupStart]
+	after := pattern[groupEnd:]
+
+	switch {
+	case strings.HasPrefix(after, "-->"):
+		return false, true, true
+	case strings.HasPrefix(after, "<--"):
+		return true, false, true
+	case strings.HasPrefix(after, "--"):
+		return true, true, true
+	}
+
+	switch {
+	case strings.HasSuffix(before, "-->"):
+		return true, false, true
+	case strings.HasSuffix(before, "<--"):
+		return false, true, true
+	case strings.HasSuffix(before, "--"):
+		return true, true, true
+	}
+
+	return false, false, false
+}

--- a/pkg/cypher/rel_existence_pattern.go
+++ b/pkg/cypher/rel_existence_pattern.go
@@ -2,20 +2,6 @@ package cypher
 
 import "strings"
 
-// containsRelExistencePattern reports whether a WHERE fragment contains a
-// relationship-existence pattern such as (n)--(), (n)-->(), (n)<--(), or a
-// bracketed relationship pattern like (n)-[r]-() or (n)-[:TYPE]->().
-//
-// The pre-fix gate only recognized bracketed patterns with an explicit
-// arrow (`-[...]->` or `<-[...]-`), so bracket-less patterns
-// ((n)--(), (n)-->(), (n)<--()) and even the bracketed *undirected* form
-// ((n)-[r]-()) fell through to evaluateWhereAsBoolean, whose default branch
-// treats an unrecognized expression as true. That is the root cause of
-// "WHERE NOT (n)--() matches nothing" and "WHERE (n)--() always true".
-//
-// containsRelExistencePattern must not match ordinary arithmetic that
-// happens to contain a hyphen, e.g. "n.a - n.b" or "n.arr[0]-1" -- neither
-// contains "-[" followed by "]-", nor ")--(", ")-->(", or ")<--(".
 func containsRelExistencePattern(s string) bool {
 	if strings.Contains(s, "-[") && strings.Contains(s, "]-") {
 		// Covers "]->", "]-(", and the undirected bracketed "-[r]-" form.
@@ -24,23 +10,6 @@ func containsRelExistencePattern(s string) bool {
 	return strings.Contains(s, ")--(") || strings.Contains(s, ")-->(") || strings.Contains(s, ")<--(")
 }
 
-// bareRelDirection determines the traversal direction implied by a
-// bracket-less relationship-existence pattern -- e.g. "(n)-->()",
-// "()<--(n)", "(n)--()" -- relative to variable.
-//
-// It returns ok=false when:
-//   - pattern contains a bracketed relationship ("-["), which is handled by
-//     the bracketed-pattern direction detection instead;
-//   - variable's node group (e.g. "(n)" or "(n:Label)") cannot be located
-//     in pattern;
-//   - neither side of the located group is bounded by a recognized
-//     bracket-less arrow ("-->", "<--", or undirected "--").
-//
-// When ok is true, incoming/outgoing describe which adjacency lists the
-// caller should search from variable's perspective: "(n)-->()" is outgoing
-// from n, "(n)<--()" is incoming to n, "()-->(n)" is incoming to n (the
-// arrow points at n), "()<--(n)" is outgoing from n, and the undirected
-// "--" form sets both.
 func bareRelDirection(pattern, variable string) (incoming, outgoing, ok bool) {
 	if strings.Contains(pattern, "-[") {
 		return false, false, false
@@ -49,7 +18,7 @@ func bareRelDirection(pattern, variable string) (incoming, outgoing, ok bool) {
 	groupStart := strings.Index(pattern, "("+variable+")")
 	var groupEnd int
 	if groupStart >= 0 {
-		groupEnd = groupStart + len(variable) + 2 // len("("+variable+")")
+		groupEnd = groupStart + len(variable) + 2
 	} else {
 		idx := strings.Index(pattern, "("+variable+":")
 		if idx < 0 {

--- a/pkg/cypher/traversal.go
+++ b/pkg/cypher/traversal.go
@@ -2312,8 +2312,11 @@ func (e *StorageExecutor) evaluateWhereOnPath(ctx context.Context, whereClause s
 		return evaluateComparableMembership(leftVal, comparableSet, nonComparable, e.compareEqual)
 	}
 
-	// Handle relationship patterns (n)-[:TYPE]->() or (n)<-[:TYPE]-() before operator check
-	hasRelPattern := (strings.Contains(whereClause, "-[") && (strings.Contains(whereClause, "]->") || strings.Contains(whereClause, "<-")))
+	// Handle relationship patterns (n)-[:TYPE]->() or (n)<-[:TYPE]-() before operator check.
+	// containsRelExistencePattern also recognizes bracket-less patterns
+	// ((n)--(), (n)-->(), (n)<--()) and the bracketed undirected form
+	// ((n)-[r]-()) -- see rel_existence_pattern.go (eshu #5147).
+	hasRelPattern := containsRelExistencePattern(whereClause)
 	if hasRelPattern && pathCtx.nodes != nil {
 		for variable, node := range pathCtx.nodes {
 			if node == nil {

--- a/pkg/cypher/traversal.go
+++ b/pkg/cypher/traversal.go
@@ -2312,10 +2312,8 @@ func (e *StorageExecutor) evaluateWhereOnPath(ctx context.Context, whereClause s
 		return evaluateComparableMembership(leftVal, comparableSet, nonComparable, e.compareEqual)
 	}
 
-	// Handle relationship patterns (n)-[:TYPE]->() or (n)<-[:TYPE]-() before operator check.
-	// containsRelExistencePattern also recognizes bracket-less patterns
-	// ((n)--(), (n)-->(), (n)<--()) and the bracketed undirected form
-	// ((n)-[r]-()) -- see rel_existence_pattern.go (eshu #5147).
+	// Handle relationship-existence patterns before operator checks so arrow
+	// syntax is not misinterpreted as a comparison operator.
 	hasRelPattern := containsRelExistencePattern(whereClause)
 	if hasRelPattern && pathCtx.nodes != nil {
 		for variable, node := range pathCtx.nodes {

--- a/pkg/cypher/where_rel_existence_bugs_test.go
+++ b/pkg/cypher/where_rel_existence_bugs_test.go
@@ -1,0 +1,331 @@
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ====================================================================================
+// BUG: relationship-existence WHERE predicates evaluate incorrectly
+// ====================================================================================
+// Discovered: eshu #5147
+// Impact: WHERE NOT (n)--() matches nothing (always false); WHERE (n)--() is
+//         always true; COUNT { (n)--() } = 0 matches everything (subquery
+//         always returns 0); EXISTS { (n)--() } is always false.
+// Root Cause: the WHERE relationship-pattern gate in
+//         executor_mutations_where_eval.go and traversal.go only recognized
+//         bracketed patterns with an explicit arrow ("-[...]->" or
+//         "<-[...]-"). Bracket-less patterns ((n)--(), (n)-->(), (n)<--())
+//         and the bracketed *undirected* form ((n)-[r]-()) fell through to
+//         evaluateWhereAsBoolean, whose default branch treats an
+//         unrecognized expression as true. Separately, checkSubqueryMatch
+//         and countSubqueryMatches required the subquery body to start with
+//         "MATCH ", so bare "COUNT { (n)--() }" / "EXISTS { (n)--() }"
+//         bodies (no MATCH keyword) always returned 0 / false.
+// ====================================================================================
+
+// setupRelExistenceFixture creates a 3-node fixture used across this file's
+// tables: "orphan" has no relationships; "connected" has an outgoing
+// :CONTAINS relationship to "peer".
+func setupRelExistenceFixture(t *testing.T) (*StorageExecutor, *storage.MemoryEngine) {
+	t.Helper()
+	base := newTestMemoryEngine(t)
+	store := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `CREATE (n:Item {name: 'orphan'})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		CREATE (c:Item {name: 'connected'})
+		CREATE (p:Item {name: 'peer'})
+		CREATE (c)-[:CONTAINS]->(p)
+	`, nil)
+	require.NoError(t, err)
+
+	return exec, base
+}
+
+func namesFromRows(rows [][]interface{}) []string {
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if len(row) == 0 {
+			continue
+		}
+		if s, ok := row[0].(string); ok {
+			names = append(names, s)
+		}
+	}
+	return names
+}
+
+func TestBug_WhereBareRelExistencePattern(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "NOT bare undirected matches only orphan",
+			query: `MATCH (n:Item) WHERE NOT (n)--() RETURN n.name ORDER BY n.name`,
+			want:  []string{"orphan"},
+		},
+		{
+			name:  "positive bare undirected matches connected and peer",
+			query: `MATCH (n:Item) WHERE (n)--() RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected", "peer"},
+		},
+		{
+			name:  "bare outgoing arrow matches only connected",
+			query: `MATCH (n:Item) WHERE (n)-->() RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected"},
+		},
+		{
+			name:  "bare incoming arrow matches only peer",
+			query: `MATCH (n:Item) WHERE (n)<--() RETURN n.name ORDER BY n.name`,
+			want:  []string{"peer"},
+		},
+		{
+			name:  "NOT bare outgoing arrow matches orphan and peer",
+			query: `MATCH (n:Item) WHERE NOT (n)-->() RETURN n.name ORDER BY n.name`,
+			want:  []string{"orphan", "peer"},
+		},
+		{
+			name:  "bracketed undirected -[r]- matches connected and peer",
+			query: `MATCH (n:Item) WHERE (n)-[:CONTAINS]-() RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected", "peer"},
+		},
+		{
+			name:  "labeled variable bare undirected",
+			query: `MATCH (n:Item) WHERE NOT (n:Item)--() RETURN n.name ORDER BY n.name`,
+			want:  []string{"orphan"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, _ := setupRelExistenceFixture(t)
+			result, err := exec.Execute(context.Background(), tt.query, nil)
+			require.NoError(t, err, "query should execute without error")
+			got := namesFromRows(result.Rows)
+			assert.ElementsMatch(t, tt.want, got, "query: %s", tt.query)
+		})
+	}
+}
+
+func TestBug_CountSubqueryBareBody(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "bare COUNT = 0 matches only orphan",
+			query: `MATCH (n:Item) WHERE COUNT { (n)--() } = 0 RETURN n.name ORDER BY n.name`,
+			want:  []string{"orphan"},
+		},
+		{
+			name:  "bare COUNT >= 1 matches connected and peer",
+			query: `MATCH (n:Item) WHERE COUNT { (n)--() } >= 1 RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected", "peer"},
+		},
+		{
+			name:  "bare directed COUNT matches only connected",
+			query: `MATCH (n:Item) WHERE COUNT { (n)-->() } = 1 RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected"},
+		},
+		{
+			name:  "MATCH-prefixed COUNT agrees with bare form",
+			query: `MATCH (n:Item) WHERE COUNT { MATCH (n)-->() } = 1 RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, _ := setupRelExistenceFixture(t)
+			result, err := exec.Execute(context.Background(), tt.query, nil)
+			require.NoError(t, err, "query should execute without error")
+			got := namesFromRows(result.Rows)
+			assert.ElementsMatch(t, tt.want, got, "query: %s", tt.query)
+		})
+	}
+}
+
+func TestBug_ExistsSubqueryBareBody(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "bare EXISTS matches connected and peer",
+			query: `MATCH (n:Item) WHERE EXISTS { (n)--() } RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected", "peer"},
+		},
+		{
+			name:  "bare NOT EXISTS matches only orphan",
+			query: `MATCH (n:Item) WHERE NOT EXISTS { (n)--() } RETURN n.name ORDER BY n.name`,
+			want:  []string{"orphan"},
+		},
+		{
+			name:  "bare directed EXISTS matches only connected",
+			query: `MATCH (n:Item) WHERE EXISTS { (n)-->() } RETURN n.name ORDER BY n.name`,
+			want:  []string{"connected"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, _ := setupRelExistenceFixture(t)
+			result, err := exec.Execute(context.Background(), tt.query, nil)
+			require.NoError(t, err, "query should execute without error")
+			got := namesFromRows(result.Rows)
+			assert.ElementsMatch(t, tt.want, got, "query: %s", tt.query)
+		})
+	}
+}
+
+// ------------------------------------------------------------------------
+// Direct unit tests for the new helpers.
+// ------------------------------------------------------------------------
+
+func TestContainsRelExistencePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{"bare undirected", "(n)--()", true},
+		{"bare outgoing", "(n)-->()", true},
+		{"bare incoming", "(n)<--()", true},
+		{"bracketed outgoing", "(n)-[:TYPE]->()", true},
+		{"bracketed incoming", "(n)<-[:TYPE]-()", true},
+		{"bracketed undirected", "(n)-[r]-()", true},
+		{"bracketed undirected no type", "(n)-[]-()", true},
+		{"negative: property arithmetic", "n.a - n.b", false},
+		{"negative: array index arithmetic", "n.arr[0]-1", false},
+		{"negative: plain comparison", "n.age > 10", false},
+		{"negative: empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, containsRelExistencePattern(tt.pattern))
+		})
+	}
+}
+
+func TestBareRelDirection(t *testing.T) {
+	tests := []struct {
+		name         string
+		pattern      string
+		variable     string
+		wantIncoming bool
+		wantOutgoing bool
+		wantOK       bool
+	}{
+		{"n outgoing prefix: (n)-->()", "(n)-->()", "n", false, true, true},
+		{"n incoming prefix: (n)<--()", "(n)<--()", "n", true, false, true},
+		{"n undirected prefix: (n)--()", "(n)--()", "n", true, true, true},
+		{"n incoming suffix: ()-->(n)", "()-->(n)", "n", true, false, true},
+		{"n outgoing suffix: ()<--(n)", "()<--(n)", "n", false, true, true},
+		{"n undirected suffix: ()--(n)", "()--(n)", "n", true, true, true},
+		{"labeled variable: (n:Item)-->()", "(n:Item)-->()", "n", false, true, true},
+		{"labeled variable suffix: ()<--(n:Item)", "()<--(n:Item)", "n", false, true, true},
+		{"bracketed pattern rejected", "(n)-[:TYPE]->()", "n", false, false, false},
+		{"variable not present", "(m)-->()", "n", false, false, false},
+		{"no arrow at all", "(n)", "n", false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			incoming, outgoing, ok := bareRelDirection(tt.pattern, tt.variable)
+			assert.Equal(t, tt.wantOK, ok, "ok mismatch")
+			if tt.wantOK {
+				assert.Equal(t, tt.wantIncoming, incoming, "incoming mismatch")
+				assert.Equal(t, tt.wantOutgoing, outgoing, "outgoing mismatch")
+			}
+		})
+	}
+}
+
+func TestEvaluateRelationshipPatternInWhere_BareDirected(t *testing.T) {
+	exec, base := setupRelExistenceFixture(t)
+	_ = base
+	ctx := context.Background()
+
+	getNodeByName := func(name string) *storage.Node {
+		result, err := exec.Execute(ctx, `MATCH (n:Item {name: $name}) RETURN n`, map[string]interface{}{"name": name})
+		require.NoError(t, err)
+		require.Len(t, result.Rows, 1)
+		node, ok := result.Rows[0][0].(*storage.Node)
+		require.True(t, ok, "expected *storage.Node, got %T", result.Rows[0][0])
+		return node
+	}
+
+	connected := getNodeByName("connected")
+	orphan := getNodeByName("orphan")
+	peer := getNodeByName("peer")
+
+	assert.True(t, exec.evaluateRelationshipPatternInWhere(connected, "n", "(n)-->()"))
+	assert.False(t, exec.evaluateRelationshipPatternInWhere(orphan, "n", "(n)-->()"))
+	assert.False(t, exec.evaluateRelationshipPatternInWhere(peer, "n", "(n)-->()"))
+
+	assert.True(t, exec.evaluateRelationshipPatternInWhere(peer, "n", "(n)<--()"))
+	assert.False(t, exec.evaluateRelationshipPatternInWhere(connected, "n", "(n)<--()"))
+
+	assert.True(t, exec.evaluateRelationshipPatternInWhere(connected, "n", "(n)--()"))
+	assert.True(t, exec.evaluateRelationshipPatternInWhere(peer, "n", "(n)--()"))
+	assert.False(t, exec.evaluateRelationshipPatternInWhere(orphan, "n", "(n)--()"))
+}
+
+func TestCheckSubqueryMatch_BareBody(t *testing.T) {
+	exec, _ := setupRelExistenceFixture(t)
+	ctx := context.Background()
+
+	getNodeByName := func(name string) *storage.Node {
+		result, err := exec.Execute(ctx, `MATCH (n:Item {name: $name}) RETURN n`, map[string]interface{}{"name": name})
+		require.NoError(t, err)
+		require.Len(t, result.Rows, 1)
+		node, ok := result.Rows[0][0].(*storage.Node)
+		require.True(t, ok)
+		return node
+	}
+
+	connected := getNodeByName("connected")
+	orphan := getNodeByName("orphan")
+
+	assert.True(t, exec.checkSubqueryMatch(ctx, connected, "n", "(n)-->()"), "bare directed body should match connected")
+	assert.False(t, exec.checkSubqueryMatch(ctx, orphan, "n", "(n)-->()"), "bare directed body should not match orphan")
+	assert.True(t, exec.checkSubqueryMatch(ctx, connected, "n", "(n)--()"), "bare undirected body should match connected")
+	assert.False(t, exec.checkSubqueryMatch(ctx, orphan, "n", "(n)--()"), "bare undirected body should not match orphan")
+}
+
+func TestCountSubqueryMatches_BareBody(t *testing.T) {
+	exec, _ := setupRelExistenceFixture(t)
+	ctx := context.Background()
+
+	getNodeByName := func(name string) *storage.Node {
+		result, err := exec.Execute(ctx, `MATCH (n:Item {name: $name}) RETURN n`, map[string]interface{}{"name": name})
+		require.NoError(t, err)
+		require.Len(t, result.Rows, 1)
+		node, ok := result.Rows[0][0].(*storage.Node)
+		require.True(t, ok)
+		return node
+	}
+
+	connected := getNodeByName("connected")
+	orphan := getNodeByName("orphan")
+
+	assert.Equal(t, int64(1), exec.countSubqueryMatches(connected, "n", "(n)-->()"))
+	assert.Equal(t, int64(0), exec.countSubqueryMatches(orphan, "n", "(n)-->()"))
+	assert.Equal(t, int64(1), exec.countSubqueryMatches(connected, "n", "(n)--()"))
+	assert.Equal(t, int64(0), exec.countSubqueryMatches(orphan, "n", "(n)--()"))
+	// MATCH-prefixed body should agree with the bare form.
+	assert.Equal(t, int64(1), exec.countSubqueryMatches(connected, "n", "MATCH (n)-->()"))
+}


### PR DESCRIPTION
## Problem

Three related correctness bugs in the Cypher WHERE/DELETE evaluation cause relationship-existence predicates to be evaluated wrong and let a non-DETACH `DELETE` silently destroy relationships. They were found while an Eshu graph-cleanup job (eshu-hq/eshu#5147) got the wrong answer on every node.

1. **Relationship-existence predicates in `WHERE`/`COUNT`/`EXISTS` are mis-evaluated for common pattern shapes.** The gate that decides whether a `WHERE` fragment is a relationship pattern required a bracket *and* an explicit arrow (`-[` plus `]->`/`<-`). So the bracket-less forms `(n)--()`, `(n)-->()`, `(n)<--()`, and the bracketed-undirected `(n)-[r]-()` fell through to a fallback that treats the fragment as a plain expression and returns true. The result: `WHERE NOT (n)--()` matches **nothing** (the negation of always-true), `WHERE (n)--()` matches **everything**, and `COUNT { (n)--() } = 0` is a tautology that matches every node regardless of its edges. A cleanup that deletes "nodes with no relationships" using these predicates therefore either deletes nothing or deletes connected nodes.

2. **A relationship variable bound by an embedded `OPTIONAL MATCH` resolves to `nil`.** The mutation paths (`executeDelete`/`executeSet`/`executeRemove`) build an internal `MATCH ... OPTIONAL MATCH (a)-[r:T]->(b) RETURN ...` probe and run it through the low-level `executeMatch`. `parseTraversalPatternStateMachine` locates the relationship bracket by scanning forward from the first node group's closing paren instead of searching for `-[`, so the literal `OPTIONAL MATCH (n)` text between the two patterns corrupts the substring handed to `parseRelationshipPattern`, and the relationship variable/type/properties are silently dropped — `r` comes back `nil` even when the `OPTIONAL MATCH` genuinely matched. (A second, independent gap surfaced here: `executeRemove` had no `*storage.Edge` support at all and duplicated rows when binding two or more node variables.)

3. **A non-DETACH `DELETE` of a connected node silently cascade-deletes its relationships.** `DeleteNode` removes a node and all its edges, and the generic delete path never checked for residual relationships, so `DELETE n` behaved like `DETACH DELETE n` and destroyed edges the caller never named — and didn't even count them.

## Fix

1. `containsRelExistencePattern` / `bareRelDirection` (new `rel_existence_pattern.go`) classify bracket-less and bracketed-undirected patterns and hand them to the existing relationship evaluator, which already resolves direction correctly. Wired into both `evaluateWhere` and `evaluateWhereOnPath`, and into the `COUNT`/`EXISTS` subquery paths.
2. `executeMatch` routes a query whose `matchPart` contains a relationship pattern **and** an embedded `OPTIONAL MATCH` through `executeCompoundMatchOptionalMatch` — the same handler the top-level dispatcher already uses — so the relationship variable resolves to the real edge (`nil` only when the `OPTIONAL MATCH` genuinely didn't match). `executeRemove`/`applyRemoveToMatchedRows` gain `*storage.Edge` support and one-row-per-match handling, mirroring the proven `SET` path.
3. The generic delete path now validates before it mutates: for a non-DETACH `DELETE` it errors (openCypher / Neo4j semantics — `Cannot delete node, because it still has relationships`) unless those relationships are themselves being deleted in the same statement. This is a **behavior change**, documented in `CHANGELOG.md` with a one-line migration note (use `DETACH DELETE`).

## Proof

- Failing-first regression tests for every case (table-driven): bare/directed/undirected rel-existence in `WHERE`, `COUNT`/`EXISTS` bare bodies, `OPTIONAL MATCH` rel-var resolution via the raw probe path (real-match and genuine-no-match), `SET`/`REMOVE` on an `OPTIONAL MATCH` relationship, and non-DETACH `DELETE` of a connected node erroring while `DETACH DELETE` succeeds.
- The Neo4j compatibility suite stays 100% green, including the previously-masked `Delete_chunks_with_OPTIONAL_MATCH` case, now restored to a plain `DELETE r, chunk` as the green proof that the root cause is fixed, not worked around.
- Full `pkg/cypher` + `pkg/bolt` suites green; race-clean on the changed surface; total coverage held at 90.2%.

Local build note: this box can't link the llama libs, so the suites were run with `-tags nolocalllm`; CI hydrates the libs and runs the full build + coverage.
