### PR TITLE
fix(cypher): support every traversal-seeded OPTIONAL MATCH + aggregate shape by mirroring Neo4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   row per matched row regardless of how many node/relationship variables are
   in scope. The same fix applies to a chained `SET ... REMOVE ...` clause in a
   single statement.
+- **Traversal-seeded `OPTIONAL MATCH` projections are now evaluated instead of
+  echoed as literal expression text.**
+  A read query whose primary `MATCH` contains a relationship pattern followed
+  by one or more trailing `OPTIONAL MATCH` clauses (no intervening `WITH`)
+  previously resolved its `RETURN` items with a string resolver that only
+  understood `var.prop` and bare variables. Every other expression came back
+  as its own source text: `RETURN type(rel)` returned the literal string
+  `"type(rel)"`, `coalesce(...)`/`labels(...)`/`head(...)` returned their
+  source text, aggregates like `count(f)` returned the string `"count(f)"`,
+  the primary MATCH's relationship variable was dropped entirely (so
+  `rel.weight` returned `"rel.weight"`), chained second-level `OPTIONAL MATCH`
+  clauses were silently swallowed (their bindings projected as literal text),
+  and per-clause `WHERE` predicates were ignored. The path now executes the
+  seed `MATCH` with relationship variables bound, left-outer joins every
+  chained `OPTIONAL MATCH` clause in either direction (seeding from whichever
+  endpoint is bound), evaluates projections through the real expression
+  evaluator (with a fast path for plain `var.prop`/bare-variable items),
+  routes aggregate projections through implicit-grouping aggregation with
+  Cypher null semantics, and applies `ORDER BY`/`SKIP`/`LIMIT`. An
+  `OPTIONAL MATCH` clause that references no previously bound variable now
+  fails loud instead of returning an empty result.
 - **Bolt explicit transactions now bind top-level `UNWIND` rows before
   routing to mutation handlers.**
   `session.ExecuteWrite` queries shaped as `UNWIND ... MATCH ... DELETE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   endpoint is bound), evaluates projections through the real expression
   evaluator (with a fast path for plain `var.prop`/bare-variable items),
   routes aggregate projections through implicit-grouping aggregation with
-  Cypher null semantics, and applies `ORDER BY`/`SKIP`/`LIMIT`. An
-  `OPTIONAL MATCH` clause that references no previously bound variable now
-  fails loud instead of returning an empty result.
+  Cypher null semantics, and applies `ORDER BY`/`SKIP`/`LIMIT`. The clause
+  semantics mirror Neo4j's runtime operators: a connected single-hop clause
+  behaves like `OptionalExpandAll` (null seeds propagate null bindings), and
+  every other shape — a disconnected pattern sharing no variable with earlier
+  clauses, a single-node pattern, a multi-hop chain, or a pre-bound
+  relationship variable — is evaluated with `Apply` + `Optional` semantics:
+  matches extend the row, and a row with no match is preserved once with
+  newly-introduced variables bound to null. No valid shape is rejected.
+  Aggregation follows Neo4j's model end to end: implicit grouping by the
+  non-aggregate items, identity values over empty ungrouped input, `stdev`/
+  `stdevp` per Neo4j's `StdevFunction`, and `RETURN` items that contain
+  aggregates inside larger expressions (e.g. `count(x) + 1`,
+  `coalesce(sum(w), 0)`) are isolated and substituted exactly like Neo4j's
+  `isolateAggregation` rewrite.
 - **Bolt explicit transactions now bind top-level `UNWIND` rows before
   routing to mutation handlers.**
   `session.ExecuteWrite` queries shaped as `UNWIND ... MATCH ... DELETE`

--- a/pkg/cypher/benchmark_optional_match_traversal_bench_test.go
+++ b/pkg/cypher/benchmark_optional_match_traversal_bench_test.go
@@ -1,0 +1,113 @@
+package cypher
+
+// Benchmarks for the traversal-seeded OPTIONAL MATCH projection path
+// (executeTraversalSeededOptionalMatch). These cover the query shape whose
+// projection was previously corrupted (function-call expressions echoed as
+// literal text): a relationship-bound MATCH followed by trailing OPTIONAL
+// MATCH clauses with function-call projections in RETURN.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+// seedTraversalOptionalBenchGraph creates classCount source classes, each
+// inheriting from 2 targets, every class contained in a file, and each file
+// contained in a repository — the Eshu entity-context handler shape.
+func seedTraversalOptionalBenchGraph(b *testing.B, exec *StorageExecutor, ctx context.Context, classCount int) {
+	b.Helper()
+	for i := 0; i < classCount; i++ {
+		_, err := exec.Execute(ctx, fmt.Sprintf(`
+			CREATE (c:BenchClass {uid:"cls:src%[1]d", name:"Src%[1]d", language:"python"})
+			CREATE (d:BenchClass {uid:"cls:base%[1]d", name:"Base%[1]d"})
+			CREATE (m:BenchClass {uid:"cls:mixin%[1]d", name:"Mixin%[1]d"})
+			CREATE (f:BenchFile {uid:"file:f%[1]d", relative_path:"pkg/f%[1]d.py", language:"python"})
+			CREATE (r:BenchRepo {id:"repo:r%[1]d", name:"repo%[1]d"})
+			CREATE (c)-[:INHERITS {weight: %[1]d}]->(d)
+			CREATE (c)-[:INHERITS {weight: %[1]d}]->(m)
+			CREATE (f)-[:CONTAINS]->(c)
+			CREATE (f)-[:CONTAINS]->(d)
+			CREATE (f)-[:CONTAINS]->(m)
+			CREATE (r)-[:REPO_CONTAINS]->(f)
+		`, i), nil)
+		if err != nil {
+			b.Fatalf("seed failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkTraversalOptionalMatch_SingleSeedChained is the exact
+// relationship-context handler shape: one anchored source, four chained
+// OPTIONAL MATCH clauses, function-call projections.
+func BenchmarkTraversalOptionalMatch_SingleSeedChained(b *testing.B) {
+	base := storage.NewMemoryEngine()
+	store := storage.NewNamespacedEngine(base, "bench")
+	exec := NewStorageExecutor(store)
+	// Disable the query result cache so every iteration measures real
+	// routing, join, and projection work instead of a cache hit.
+	exec.cache = nil
+	ctx := context.Background()
+	seedTraversalOptionalBenchGraph(b, exec, ctx, 50)
+
+	query := `
+		MATCH (e:BenchClass {uid:"cls:src25"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (e)<-[:CONTAINS]-(sourceFile:BenchFile)
+		OPTIONAL MATCH (sourceRepo:BenchRepo)-[:REPO_CONTAINS]->(sourceFile)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(targetFile:BenchFile)
+		OPTIONAL MATCH (targetRepo:BenchRepo)-[:REPO_CONTAINS]->(targetFile)
+		RETURN type(rel) AS type,
+		       coalesce(e.id, e.uid) AS source_id,
+		       target.name AS target_name,
+		       coalesce(target.id, target.uid) AS target_id,
+		       targetFile.relative_path AS target_file,
+		       targetRepo.id AS target_repo`
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := exec.Execute(ctx, query, nil)
+		if err != nil {
+			b.Fatalf("execute failed: %v", err)
+		}
+		if len(res.Rows) == 0 {
+			b.Fatal("expected rows")
+		}
+	}
+}
+
+// BenchmarkTraversalOptionalMatch_FanOutProjection stresses per-row projection
+// cost: every class row (150 relationship rows over 50 sources) flows through
+// the OPTIONAL MATCH join and the function-call projection.
+func BenchmarkTraversalOptionalMatch_FanOutProjection(b *testing.B) {
+	base := storage.NewMemoryEngine()
+	store := storage.NewNamespacedEngine(base, "bench")
+	exec := NewStorageExecutor(store)
+	// Disable the query result cache so every iteration measures real
+	// routing, join, and projection work instead of a cache hit.
+	exec.cache = nil
+	ctx := context.Background()
+	seedTraversalOptionalBenchGraph(b, exec, ctx, 50)
+
+	query := `
+		MATCH (e:BenchClass)-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:BenchFile)
+		RETURN type(rel) AS type,
+		       coalesce(target.id, target.uid) AS target_id,
+		       target.name AS target_name,
+		       tf.relative_path AS target_file`
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := exec.Execute(ctx, query, nil)
+		if err != nil {
+			b.Fatalf("execute failed: %v", err)
+		}
+		if len(res.Rows) == 0 {
+			b.Fatal("expected rows")
+		}
+	}
+}

--- a/pkg/cypher/bug_optional_match_function_projection_test.go
+++ b/pkg/cypher/bug_optional_match_function_projection_test.go
@@ -293,3 +293,136 @@ func TestFix_TrailingOptionalMatch_GroupedAggregate(t *testing.T) {
 	require.EqualValues(t, int64(2), row["fileCount"],
 		"Dog is contained in two files; count(tf) must aggregate both joined rows")
 }
+
+// TestSupport_DisconnectedSingleNodeOptionalMatch proves an OPTIONAL MATCH
+// whose pattern shares no variable with earlier clauses is supported with
+// Neo4j's Apply + Optional semantics (OptionalPipe null-fills newly
+// introduced variables; matches cross-join), never rejected.
+func TestSupport_DisconnectedSingleNodeOptionalMatch(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	// Matching case: one OMRepo exists; every left row joins with it.
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo)
+		RETURN type(rel) AS relType, target.name AS targetName, repo.id AS repoId
+	`, nil)
+	require.NoError(t, err, "a disconnected OPTIONAL MATCH is a valid shape and must not error")
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "INHERITS", row["relType"])
+	require.Equal(t, "Dog", row["targetName"])
+	require.Equal(t, "repo:1", row["repoId"], "the independent OMRepo match must bind")
+
+	// Null-fill case: no OMGhost nodes exist; left rows preserved, ghost null.
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (ghost:OMGhost)
+		RETURN target.name AS targetName, ghost.id AS ghostId
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1, "left row must be preserved when the disconnected pattern matches nothing")
+	row = rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["targetName"])
+	require.Nil(t, row["ghostId"], "unmatched disconnected pattern must null-fill its variables")
+}
+
+// TestSupport_DisconnectedRelationshipOptionalMatch proves a disconnected
+// RELATIONSHIP pattern joins independently (cross product with matches,
+// null-fill with none).
+func TestSupport_DisconnectedRelationshipOptionalMatch(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo)-[rc:REPO_CONTAINS]->(anyFile:OMFile)
+		RETURN target.name AS targetName, repo.id AS repoId, type(rc) AS rcType, anyFile.relative_path AS filePath
+	`, nil)
+	require.NoError(t, err, "a disconnected relationship OPTIONAL MATCH must not error")
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["targetName"])
+	require.Equal(t, "repo:1", row["repoId"])
+	require.Equal(t, "REPO_CONTAINS", row["rcType"])
+	require.Equal(t, "svc.py", row["filePath"])
+}
+
+// TestSupport_BoundSingleNodeOptionalMatchIsRowPreserving proves that an
+// OPTIONAL MATCH over an already-bound variable with no new variables
+// preserves rows whether or not the pattern holds (nothing new to null).
+func TestSupport_BoundSingleNodeOptionalMatchIsRowPreserving(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target:OMNoSuchLabel)
+		RETURN target.name AS targetName
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1, "row must be preserved even though the optional pattern cannot hold")
+	require.Equal(t, "Dog", res.Rows[0][0], "the pre-bound variable keeps its binding")
+}
+
+// TestSupport_MultiHopChainOptionalMatch proves a single OPTIONAL MATCH
+// clause with a multi-hop chain binds all its variables via the general
+// Apply + Optional path.
+func TestSupport_MultiHopChainOptionalMatch(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)<-[:REPO_CONTAINS]-(repo:OMRepo)
+		RETURN target.name AS targetName, tf.relative_path AS filePath, repo.id AS repoId
+	`, nil)
+	require.NoError(t, err, "a multi-hop OPTIONAL MATCH chain must not error")
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["targetName"])
+	require.Equal(t, "svc.py", row["filePath"])
+	require.Equal(t, "repo:1", row["repoId"], "both hops of the chain must bind in one clause")
+}
+
+// TestSupport_MixedAggregateExpression proves a RETURN item that CONTAINS an
+// aggregate without BEING one evaluates per Neo4j's isolateAggregation
+// rewrite (aggregate isolated, outer expression applied to the result).
+func TestSupport_MixedAggregateExpression(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS targetName, count(tf) + 1 AS bumped, coalesce(sum(rel.weight), 0) AS weightSum
+	`, nil)
+	require.NoError(t, err, "an expression containing an aggregate must not error")
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["targetName"])
+	require.EqualValues(t, int64(2), row["bumped"], "count(tf)=1 plus 1 must evaluate to 2")
+	require.EqualValues(t, int64(2), row["weightSum"], "sum(rel.weight) over the single INHERITS {weight:2} row")
+}
+
+// TestSupport_StdevAggregate proves stdev/stdevp follow Neo4j's StdevFunction
+// contract (0.0 for a single value; sample vs population divisors).
+func TestSupport_StdevAggregate(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	_, err := exec.Execute(ctx, `CREATE (x:OMClass {uid:"cls:Extra", name:"Extra"})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		MATCH (c:OMClass {uid:"cls:ServiceDog"})
+		MATCH (x:OMClass {uid:"cls:Extra"})
+		CREATE (c)-[:INHERITS {weight: 6}]->(x)
+	`, nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN stdev(rel.weight) AS sdev, stdevp(rel.weight) AS sdevp
+	`, nil)
+	require.NoError(t, err, "stdev/stdevp must be supported, not rejected")
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	// weights 2 and 6: sample stdev = sqrt(8) ~= 2.828, population = 2.
+	require.InDelta(t, 2.8284, row["sdev"].(float64), 0.001)
+	require.InDelta(t, 2.0, row["sdevp"].(float64), 0.001)
+}

--- a/pkg/cypher/bug_optional_match_function_projection_test.go
+++ b/pkg/cypher/bug_optional_match_function_projection_test.go
@@ -1,0 +1,295 @@
+package cypher
+
+// Regression tests for silent projection corruption in
+// executeCompoundMatchOptionalMatch's traversal branch (clauses.go).
+//
+// When the primary MATCH contains a relationship pattern and the query has one
+// or more trailing OPTIONAL MATCH clauses (no WITH), the RETURN projection is
+// evaluated by resolveReturnExprFromVarMap, which only understands "var.prop"
+// and bare variable references. Every other expression falls through to
+// parseValue, which returns the raw expression TEXT as the column value:
+//
+//	RETURN type(rel)              -> the literal string "type(rel)"
+//	RETURN coalesce(t.id, t.uid)  -> the literal string "coalesce(t.id, t.uid)"
+//	RETURN labels(t)              -> the literal string "labels(t)"
+//	RETURN count(f)               -> the literal string "count(f)"
+//	RETURN rel.weight             -> the literal string "rel.weight"
+//	                                 (rel is dropped from the seed MATCH:
+//	                                 extractNodeVariables skips rel vars)
+//
+// Plain properties of nodes bound by the primary MATCH and by the FIRST
+// OPTIONAL MATCH survive; everything else is corrupted silently. Verified live
+// over Bolt against image pr261 (1492458), branch HEAD 7cc8895b, and main
+// f5fbdb4e — all identical.
+//
+// The same query WITHOUT the trailing OPTIONAL MATCH evaluates every one of
+// these expressions correctly (see the control test at the bottom).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func newOptProjExecutor(t *testing.T) (*StorageExecutor, context.Context) {
+	t.Helper()
+	base := newTestMemoryEngine(t)
+	ns := storage.NewNamespacedEngine(base, "test")
+	exec := NewStorageExecutor(ns)
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, `
+		CREATE (c:OMClass {uid:"cls:ServiceDog", name:"ServiceDog", language:"python"})
+		CREATE (d:OMClass {uid:"cls:Dog", name:"Dog"})
+		CREATE (f:OMFile {uid:"file:svc", relative_path:"svc.py", language:"python"})
+		CREATE (r:OMRepo {id:"repo:1", name:"repo1"})
+		CREATE (c)-[:INHERITS {weight: 2}]->(d)
+		CREATE (f)-[:CONTAINS]->(c)
+		CREATE (f)-[:CONTAINS]->(d)
+		CREATE (r)-[:REPO_CONTAINS]->(f)
+	`, nil)
+	require.NoError(t, err)
+	return exec, ctx
+}
+
+// rowMap converts one result row into a column-name -> value map.
+func rowMap(t *testing.T, res *ExecuteResult, i int) map[string]interface{} {
+	t.Helper()
+	require.Greater(t, len(res.Rows), i)
+	m := make(map[string]interface{}, len(res.Columns))
+	for c, col := range res.Columns {
+		m[col] = res.Rows[i][c]
+	}
+	return m
+}
+
+// TestBug_TrailingOptionalMatch_FunctionProjectionCorrupted captures the core
+// defect: function-call expressions in RETURN come back as their literal
+// source text when a trailing OPTIONAL MATCH follows a relationship-bound
+// MATCH.
+func TestBug_TrailingOptionalMatch_FunctionProjectionCorrupted(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN type(rel) AS relType,
+		       coalesce(target.id, target.uid) AS targetId,
+		       labels(target) AS targetLabels,
+		       target.name AS targetName,
+		       tf.relative_path AS filePath
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+
+	// Sanity: the plain properties that DO survive today.
+	require.Equal(t, "Dog", row["targetName"])
+	require.Equal(t, "svc.py", row["filePath"])
+
+	// The actual defect: these must be evaluated, not echoed as source text.
+	require.Equal(t, "INHERITS", row["relType"],
+		"type(rel) must be evaluated, not returned as literal expression text")
+	require.Equal(t, "cls:Dog", row["targetId"],
+		"coalesce(target.id, target.uid) must be evaluated, not returned as literal expression text")
+	require.Equal(t, []interface{}{"OMClass"}, row["targetLabels"],
+		"labels(target) must be evaluated, not returned as literal expression text")
+}
+
+// TestBug_TrailingOptionalMatch_RelVarDropped captures the second facet: the
+// primary MATCH's relationship variable is not carried into the projection
+// scope (extractNodeVariables drops it from the seed MATCH), so rel.prop and
+// the bare rel variable corrupt too.
+func TestBug_TrailingOptionalMatch_RelVarDropped(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN rel.weight AS w, target.name AS targetName
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+
+	require.Equal(t, "Dog", row["targetName"])
+	require.EqualValues(t, int64(2), row["w"],
+		"rel.weight must resolve the primary MATCH relationship property, not the literal string \"rel.weight\"")
+}
+
+// TestBug_TrailingOptionalMatch_AggregateCorrupted captures the third facet:
+// aggregation functions after the traversal-seeded OPTIONAL MATCH are echoed
+// as literal text instead of aggregating (the traversal branch never routes to
+// the aggregation path).
+func TestBug_TrailingOptionalMatch_AggregateCorrupted(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS targetName, count(tf) AS fileCount
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+
+	require.Equal(t, "Dog", row["targetName"])
+	require.EqualValues(t, int64(1), row["fileCount"],
+		"count(tf) must aggregate, not return the literal string \"count(tf)\"")
+}
+
+// TestBug_TrailingOptionalMatch_ChainedOptionalBindingUnbound captures the
+// fourth facet: a variable bound by a SECOND, chained OPTIONAL MATCH is never
+// bound (only the first OPTIONAL pattern is parsed), so its property
+// projection leaks literal text instead of the value (or null).
+func TestBug_TrailingOptionalMatch_ChainedOptionalBindingUnbound(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		OPTIONAL MATCH (repo:OMRepo)-[:REPO_CONTAINS]->(tf)
+		RETURN target.name AS targetName, repo.id AS repoId
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+
+	require.Equal(t, "Dog", row["targetName"])
+	require.Equal(t, "repo:1", row["repoId"],
+		"repo.id (bound by the chained second OPTIONAL MATCH) must resolve to the repo id, not the literal string \"repo.id\"")
+}
+
+// TestControl_NoOptionalMatch_FunctionProjectionCorrect proves the identical
+// RETURN evaluates correctly WITHOUT the trailing OPTIONAL MATCH — isolating
+// the corruption to the traversal-seeded OPTIONAL MATCH projection path.
+func TestControl_NoOptionalMatch_FunctionProjectionCorrect(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		RETURN type(rel) AS relType,
+		       coalesce(target.id, target.uid) AS targetId,
+		       labels(target) AS targetLabels,
+		       target.name AS targetName
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+
+	require.Equal(t, "INHERITS", row["relType"])
+	require.Equal(t, "cls:Dog", row["targetId"])
+	require.Equal(t, []interface{}{"OMClass"}, row["targetLabels"])
+	require.Equal(t, "Dog", row["targetName"])
+}
+
+// TestFix_TrailingOptionalMatch_WhereOnOptionalClause proves the per-clause
+// WHERE predicate is applied (the pre-fix traversal branch silently ignored
+// it).
+func TestFix_TrailingOptionalMatch_WhereOnOptionalClause(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile) WHERE tf.language = "go"
+		RETURN target.name AS targetName, tf.relative_path AS filePath
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["targetName"])
+	require.Nil(t, row["filePath"],
+		"WHERE tf.language = go must reject the python file and leave the optional binding null")
+}
+
+// TestFix_TrailingOptionalMatch_UnmatchedOptionalYieldsNullRow proves left
+// outer join semantics: a target with no CONTAINS file still produces a row
+// with null optional bindings, and functions on main-MATCH bindings evaluate.
+func TestFix_TrailingOptionalMatch_UnmatchedOptionalYieldsNullRow(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	_, err := exec.Execute(ctx, `
+		CREATE (o:OMClass {uid:"cls:Orphan", name:"Orphan"})
+		WITH o MATCH (c:OMClass {uid:"cls:ServiceDog"}) CREATE (c)-[:INHERITS]->(o)
+	`, nil)
+	if err != nil {
+		// Fallback seeding without WITH if the CREATE...WITH shape is unsupported.
+		_, err = exec.Execute(ctx, `CREATE (o:OMClass {uid:"cls:Orphan", name:"Orphan"})`, nil)
+		require.NoError(t, err)
+		_, err = exec.Execute(ctx, `
+			MATCH (c:OMClass {uid:"cls:ServiceDog"})
+			MATCH (o:OMClass {uid:"cls:Orphan"})
+			CREATE (c)-[:INHERITS]->(o)
+		`, nil)
+		require.NoError(t, err)
+	}
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN type(rel) AS relType, target.name AS targetName, tf.relative_path AS filePath
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 2, "one row per INHERITS target (Dog matched, Orphan unmatched)")
+	byName := map[string]map[string]interface{}{}
+	for i := range res.Rows {
+		row := rowMap(t, res, i)
+		byName[row["targetName"].(string)] = row
+	}
+	require.Equal(t, "INHERITS", byName["Dog"]["relType"])
+	require.Equal(t, "svc.py", byName["Dog"]["filePath"])
+	require.Equal(t, "INHERITS", byName["Orphan"]["relType"],
+		"type(rel) must evaluate even on the row whose OPTIONAL MATCH found nothing")
+	require.Nil(t, byName["Orphan"]["filePath"])
+}
+
+// TestFix_TrailingOptionalMatch_OrderByLimit proves ORDER BY and LIMIT apply
+// to the traversal-seeded OPTIONAL MATCH projection.
+func TestFix_TrailingOptionalMatch_OrderByLimit(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	_, err := exec.Execute(ctx, `CREATE (m:OMClass {uid:"cls:Mixin", name:"AMixin"})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		MATCH (c:OMClass {uid:"cls:ServiceDog"})
+		MATCH (m:OMClass {uid:"cls:Mixin"})
+		CREATE (c)-[:INHERITS]->(m)
+	`, nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS targetName ORDER BY targetName LIMIT 1
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, "AMixin", res.Rows[0][0],
+		"ORDER BY targetName ascending must sort AMixin before Dog, LIMIT 1 keeps it")
+}
+
+// TestFix_TrailingOptionalMatch_GroupedAggregate proves implicit grouping:
+// count(tf) grouped by target name with correct per-group counts.
+func TestFix_TrailingOptionalMatch_GroupedAggregate(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	_, err := exec.Execute(ctx, `CREATE (f2:OMFile {uid:"file:extra", relative_path:"extra.py"})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `
+		MATCH (d:OMClass {uid:"cls:Dog"})
+		MATCH (f2:OMFile {uid:"file:extra"})
+		CREATE (f2)-[:CONTAINS]->(d)
+	`, nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS targetName, count(tf) AS fileCount
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["targetName"])
+	require.EqualValues(t, int64(2), row["fileCount"],
+		"Dog is contained in two files; count(tf) must aggregate both joined rows")
+}

--- a/pkg/cypher/clauses.go
+++ b/pkg/cypher/clauses.go
@@ -3628,110 +3628,12 @@ func (e *StorageExecutor) executeCompoundMatchOptionalMatch(ctx context.Context,
 		strings.Contains(nodePatternStr, "<-") ||
 		strings.Contains(nodePatternStr, "-[")
 	if hasTraversal {
-		// Build a standalone MATCH query for the initial section and execute it.
-		// The result provides all bound variables (including traversal endpoints)
-		// that will be used as seeds for the OPTIONAL MATCH.
-		// Extract node variable names from the pattern for an explicit RETURN clause
-		// since RETURN * doesn't expand variables in the traversal executor.
-		patternVars := extractNodeVariables(nodePatternStr)
-		returnVars := strings.Join(patternVars, ", ")
-		if returnVars == "" {
-			returnVars = "*"
-		}
-		matchQuery := "MATCH " + initialSection + " RETURN " + returnVars
-		matchResult, matchErr := e.executeMatch(ctx, matchQuery)
-		if matchErr != nil {
-			return nil, fmt.Errorf("failed to execute initial traversal MATCH: %w", matchErr)
-		}
-
-		// Determine the variable that the OPTIONAL MATCH references (the
-		// source variable of the optional relationship pattern).
-		optRelPattern := e.parseOptionalRelPattern(ctx, optMatchPattern)
-		sourceVar := optRelPattern.sourceVar
-
-		// Find the column index for the source variable in the MATCH result.
-		sourceColIdx := -1
-		for ci, col := range matchResult.Columns {
-			if col == sourceVar {
-				sourceColIdx = ci
-				break
-			}
-		}
-		if sourceColIdx < 0 {
-			// Fallback: variable not found in result columns — cannot perform
-			// the OPTIONAL MATCH seed. Return empty result.
-			return &ExecuteResult{
-				Columns: []string{},
-				Rows:    [][]interface{}{},
-			}, nil
-		}
-
-		// Build joined rows by evaluating the OPTIONAL MATCH for each seed row.
-		type multiVarRow struct {
-			values  map[string]interface{} // variable -> node for all MATCH columns
-			related []optionalRelResult
-		}
-		var mvRows []multiVarRow
-		for _, row := range matchResult.Rows {
-			vals := make(map[string]interface{}, len(matchResult.Columns))
-			for ci, col := range matchResult.Columns {
-				vals[col] = row[ci]
-			}
-			seedNode, _ := vals[sourceVar].(*storage.Node)
-			var related []optionalRelResult
-			if seedNode != nil {
-				related = e.findOptionalRelatedNodes(ctx, seedNode, optMatchPattern, optRelPattern)
-			}
-			mvRows = append(mvRows, multiVarRow{values: vals, related: related})
-		}
-
-		// Evaluate RETURN clause against the joined rows.
-		returnPart := restOfQuery
-		if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(returnPart)), "RETURN") {
-			// restOfQuery might start with WITH; try to find RETURN inside it
-			retIdx := findKeywordIndex(restOfQuery, "RETURN")
-			if retIdx >= 0 {
-				returnPart = strings.TrimSpace(restOfQuery[retIdx:])
-			}
-		}
-		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(returnPart)), "RETURN") {
-			returnExpr := strings.TrimSpace(returnPart[6:])
-			returnItems := e.parseReturnItems(returnExpr)
-			result := &ExecuteResult{
-				Columns: make([]string, len(returnItems)),
-				Rows:    [][]interface{}{},
-			}
-			for i, item := range returnItems {
-				if item.alias != "" {
-					result.Columns[i] = item.alias
-				} else {
-					result.Columns[i] = item.expr
-				}
-			}
-			targetVar := optRelPattern.targetVar
-			for _, mvr := range mvRows {
-				if len(mvr.related) == 0 {
-					// Left outer join: no match → null for optional variables
-					outRow := make([]interface{}, len(returnItems))
-					for i, item := range returnItems {
-						outRow[i] = e.resolveReturnExprFromVarMap(ctx, item.expr, mvr.values, targetVar, optRelPattern.relVar, nil, nil)
-					}
-					result.Rows = append(result.Rows, outRow)
-				} else {
-					for _, rel := range mvr.related {
-						outRow := make([]interface{}, len(returnItems))
-						for i, item := range returnItems {
-							outRow[i] = e.resolveReturnExprFromVarMap(ctx, item.expr, mvr.values, targetVar, optRelPattern.relVar, rel.node, rel.edge)
-						}
-						result.Rows = append(result.Rows, outRow)
-					}
-				}
-			}
-			return result, nil
-		}
-
-		// No RETURN found — shouldn't happen for well-formed queries.
-		return &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}}, nil
+		// Traversal-seeded OPTIONAL MATCH: execute the initial MATCH (binding
+		// node AND relationship variables), left-outer join every chained
+		// OPTIONAL MATCH clause, then project through the real expression
+		// evaluator. See optional_match_traversal.go.
+		return e.executeTraversalSeededOptionalMatch(ctx, initialSection, nodePatternStr,
+			strings.TrimSpace(remainingAfterOptMatch[:optMatchEndIdx]), restOfQuery)
 	}
 
 	nodePattern := e.parseNodePattern(ctx, nodePatternStr)

--- a/pkg/cypher/optional_match_traversal.go
+++ b/pkg/cypher/optional_match_traversal.go
@@ -260,15 +260,41 @@ func (e *StorageExecutor) executeTraversalSeededOptionalMatch(ctx context.Contex
 }
 
 // applyTraversalOptionalClause left-outer-joins one OPTIONAL MATCH clause
-// against every row. The bound endpoint seeds the traversal; the unbound
-// endpoint (and the relationship variable, when named) is bound on each row.
-// When both endpoints are already bound the clause acts as a filter that binds
-// only the relationship variable. A row whose seed is null (an earlier
-// OPTIONAL MATCH miss) propagates null bindings, matching Cypher semantics.
+// against every row, routing by pattern shape (mirroring how Neo4j's planner
+// picks OptionalExpandAll for a connected single hop and Apply + Optional for
+// everything else):
+//
+//   - single node group, no relationship: applySingleNodeOptionalClause;
+//   - one hop with a bound endpoint and an unbound (or absent) relationship
+//     variable: the seeded expansion below (OptionalExpandAllPipe semantics —
+//     the bound endpoint seeds the traversal, the unbound endpoint and
+//     relationship variable bind per match, both-endpoints-bound acts as a
+//     relationship filter, and a null seed propagates null bindings);
+//   - everything else (disconnected patterns, multi-hop chains, bound
+//     relationship variables): applyGeneralOptionalClause, the Apply +
+//     Optional contract. No valid shape is rejected.
 func (e *StorageExecutor) applyTraversalOptionalClause(ctx context.Context, rows []traversalOptRow, clause optionalMatchClause) ([]traversalOptRow, error) {
+	if len(rows) == 0 {
+		return rows, nil
+	}
+	nodeGroups, brackets := scanOptionalPatternShape(clause.pattern)
+	if nodeGroups == 1 && brackets == 0 {
+		return e.applySingleNodeOptionalClause(ctx, rows, clause)
+	}
+	if nodeGroups != 2 || brackets != 1 {
+		return e.applyGeneralOptionalClause(ctx, rows, clause)
+	}
 	eps, err := e.parseOptionalClauseEndpoints(ctx, clause.pattern)
 	if err != nil {
-		return nil, err
+		return e.applyGeneralOptionalClause(ctx, rows, clause)
+	}
+	_, srcSeedable := rows[0].nodes[eps.source.variable]
+	_, tgtSeedable := rows[0].nodes[eps.target.variable]
+	_, relBound := rows[0].rels[eps.relVar]
+	if (!srcSeedable && !tgtSeedable) || (eps.relVar != "" && relBound) {
+		// Disconnected one-hop pattern or a pre-bound relationship variable:
+		// evaluate with the general Apply + Optional path.
+		return e.applyGeneralOptionalClause(ctx, rows, clause)
 	}
 
 	out := make([]traversalOptRow, 0, len(rows))
@@ -279,8 +305,7 @@ func (e *StorageExecutor) applyTraversalOptionalClause(ctx context.Context, rows
 		var seed *storage.Node
 		var pattern optionalRelPattern
 		newNodeVar := ""
-		switch {
-		case srcBound:
+		if srcBound {
 			seed = srcNode
 			pattern = optionalRelPattern{
 				sourceVar:    eps.source.variable,
@@ -294,7 +319,7 @@ func (e *StorageExecutor) applyTraversalOptionalClause(ctx context.Context, rows
 			if !tgtBound {
 				newNodeVar = eps.target.variable
 			}
-		case tgtBound:
+		} else {
 			seed = tgtNode
 			pattern = optionalRelPattern{
 				sourceVar:    eps.target.variable,
@@ -306,10 +331,6 @@ func (e *StorageExecutor) applyTraversalOptionalClause(ctx context.Context, rows
 				direction:    invertOptionalDirection(eps.direction),
 			}
 			newNodeVar = eps.source.variable
-		default:
-			return nil, fmt.Errorf(
-				"unsupported OPTIONAL MATCH: pattern %q references no variable bound by an earlier clause",
-				truncateQuery(clause.pattern, 60))
 		}
 
 		if seed == nil {
@@ -362,7 +383,7 @@ func (e *StorageExecutor) projectTraversalOptionalRows(ctx context.Context, rows
 		}
 	}
 
-	if rowHasAggregate(items) {
+	if traversalItemsContainAggregate(items) {
 		aggRows, err := e.aggregateTraversalOptionalRows(ctx, rows, items)
 		if err != nil {
 			return nil, err

--- a/pkg/cypher/optional_match_traversal.go
+++ b/pkg/cypher/optional_match_traversal.go
@@ -1,0 +1,525 @@
+package cypher
+
+// Traversal-seeded OPTIONAL MATCH execution.
+//
+// executeCompoundMatchOptionalMatch routes here when the primary MATCH clause
+// contains a relationship pattern (a traversal) and one or more OPTIONAL MATCH
+// clauses follow it without an intervening WITH. Historically this branch
+// resolved the RETURN projection with resolveReturnExprFromVarMap, which only
+// understood "var.prop" and bare variables — every other expression (type(),
+// coalesce(), labels(), aggregates, properties of second-level OPTIONAL
+// bindings, and the primary MATCH's relationship variable) leaked back to the
+// client as its literal source text. This file replaces that path with:
+//
+//  1. a seed MATCH that binds relationship variables as well as node variables,
+//  2. an iterative left-outer join across EVERY chained OPTIONAL MATCH clause
+//     (binding whichever endpoint is not yet bound, in either direction), and
+//  3. projection through the real expression evaluator
+//     (evaluateExpressionWithContext), with implicit-grouping aggregation and
+//     ORDER BY / SKIP / LIMIT handling that mirrors buildJoinedResult.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+// traversalOptRow is one joined row in the traversal-seeded OPTIONAL MATCH
+// pipeline. Every bound variable maps to its node or relationship; a variable
+// bound to nil records an OPTIONAL MATCH that found no counterpart (Cypher
+// null), which downstream projection must distinguish from "never bound".
+type traversalOptRow struct {
+	nodes map[string]*storage.Node
+	rels  map[string]*storage.Edge
+}
+
+// optionalMatchClause is a single OPTIONAL MATCH clause: its relationship
+// pattern and the optional trailing WHERE predicate.
+type optionalMatchClause struct {
+	pattern string
+	where   string
+}
+
+// optionalClauseEndpoints is the fully parsed form of one OPTIONAL MATCH
+// relationship pattern: both endpoint node patterns (variable, labels,
+// properties), the relationship variable/type, and the direction relative to
+// the source (left) endpoint.
+type optionalClauseEndpoints struct {
+	source    nodePatternInfo
+	target    nodePatternInfo
+	relVar    string
+	relType   string
+	direction string // "out", "in", or "both", relative to source
+}
+
+// splitOptionalMatchClauses splits the text that follows the first
+// "OPTIONAL MATCH" keyword (already sliced to end before WITH/RETURN) into
+// individual clauses. Each clause's own WHERE predicate is separated from its
+// pattern. The first clause has no leading "OPTIONAL MATCH" keyword because
+// the caller consumed it.
+func splitOptionalMatchClauses(section string) []optionalMatchClause {
+	var clauses []optionalMatchClause
+	rest := strings.TrimSpace(section)
+	for rest != "" {
+		clauseText := rest
+		next := findMultiWordKeywordIndex(rest, "OPTIONAL", "MATCH")
+		if next > 0 {
+			clauseText = strings.TrimSpace(rest[:next])
+			after := rest[next:]
+			mIdx := findKeywordIndex(after, "MATCH")
+			rest = strings.TrimSpace(after[mIdx+len("MATCH"):])
+		} else {
+			rest = ""
+		}
+		clause := optionalMatchClause{pattern: clauseText}
+		if wIdx := findKeywordIndex(clauseText, "WHERE"); wIdx > 0 {
+			clause.where = strings.TrimSpace(clauseText[wIdx+len("WHERE"):])
+			clause.pattern = strings.TrimSpace(clauseText[:wIdx])
+		}
+		if clause.pattern != "" {
+			clauses = append(clauses, clause)
+		}
+	}
+	return clauses
+}
+
+// extractRelationshipVariables extracts relationship variable names from a
+// MATCH pattern, e.g. "rel" from "(a)-[rel:INHERITS]->(b)". Anonymous
+// relationships ("[:TYPE]", "[*1..2]") contribute nothing.
+func extractRelationshipVariables(matchClause string) []string {
+	var vars []string
+	for i := 0; i < len(matchClause); i++ {
+		if matchClause[i] != '[' {
+			continue
+		}
+		j := i + 1
+		for j < len(matchClause) && isWhitespace(matchClause[j]) {
+			j++
+		}
+		name, next, ok := scanIdentifierToken(matchClause, j)
+		if !ok {
+			continue
+		}
+		for next < len(matchClause) && isWhitespace(matchClause[next]) {
+			next++
+		}
+		if next < len(matchClause) &&
+			(matchClause[next] == ':' || matchClause[next] == ']' || matchClause[next] == '*') {
+			vars = append(vars, name)
+		}
+	}
+	return vars
+}
+
+// parseOptionalClauseEndpoints parses one OPTIONAL MATCH relationship pattern
+// into both endpoint node patterns plus relationship variable, type, and
+// direction. It returns an error for patterns without two node endpoints.
+func (e *StorageExecutor) parseOptionalClauseEndpoints(ctx context.Context, pattern string) (optionalClauseEndpoints, error) {
+	eps := optionalClauseEndpoints{direction: "both"}
+	if strings.Contains(pattern, "<-") {
+		eps.direction = "in"
+	} else if strings.Contains(pattern, "->") {
+		eps.direction = "out"
+	}
+
+	openIdx := strings.Index(pattern, "(")
+	if openIdx < 0 {
+		return eps, fmt.Errorf("optional match pattern %q has no node endpoint", truncateQuery(pattern, 60))
+	}
+	closeIdx := strings.Index(pattern[openIdx:], ")")
+	if closeIdx <= 0 {
+		return eps, fmt.Errorf("optional match pattern %q has an unterminated node endpoint", truncateQuery(pattern, 60))
+	}
+	eps.source = e.parseNodePattern(ctx, pattern[openIdx:openIdx+closeIdx+1])
+
+	if brIdx := strings.Index(pattern, "["); brIdx >= 0 {
+		brEnd := strings.Index(pattern[brIdx:], "]")
+		if brEnd > 0 {
+			relStr := pattern[brIdx+1 : brIdx+brEnd]
+			if colonIdx := strings.Index(relStr, ":"); colonIdx >= 0 {
+				eps.relVar = strings.TrimSpace(relStr[:colonIdx])
+				relType := strings.TrimSpace(relStr[colonIdx+1:])
+				if propIdx := strings.Index(relType, "{"); propIdx >= 0 {
+					relType = strings.TrimSpace(relType[:propIdx])
+				}
+				if starIdx := strings.Index(relType, "*"); starIdx >= 0 {
+					relType = strings.TrimSpace(relType[:starIdx])
+				}
+				eps.relType = relType
+			} else if starIdx := strings.Index(relStr, "*"); starIdx >= 0 {
+				eps.relVar = strings.TrimSpace(relStr[:starIdx])
+			} else {
+				eps.relVar = strings.TrimSpace(relStr)
+			}
+		}
+	}
+
+	rest := pattern[openIdx+closeIdx+1:]
+	if relEnd := strings.Index(rest, "]"); relEnd >= 0 {
+		rest = rest[relEnd+1:]
+	}
+	tOpen := strings.Index(rest, "(")
+	if tOpen < 0 {
+		return eps, fmt.Errorf("optional match pattern %q has no target endpoint", truncateQuery(pattern, 60))
+	}
+	tClose := strings.Index(rest[tOpen:], ")")
+	if tClose <= 0 {
+		return eps, fmt.Errorf("optional match pattern %q has an unterminated target endpoint", truncateQuery(pattern, 60))
+	}
+	eps.target = e.parseNodePattern(ctx, rest[tOpen:tOpen+tClose+1])
+	return eps, nil
+}
+
+// invertOptionalDirection flips a traversal direction for seeding a join from
+// the pattern's target endpoint instead of its source endpoint.
+func invertOptionalDirection(direction string) string {
+	switch direction {
+	case "out":
+		return "in"
+	case "in":
+		return "out"
+	default:
+		return direction
+	}
+}
+
+// extendTraversalRow returns a copy of row with an additional node binding
+// (when nodeVar is non-empty) and relationship binding (when relVar is
+// non-empty). Rows are copied because a single input row can fan out into
+// multiple joined rows.
+func extendTraversalRow(row traversalOptRow, nodeVar string, node *storage.Node, relVar string, edge *storage.Edge) traversalOptRow {
+	out := traversalOptRow{
+		nodes: make(map[string]*storage.Node, len(row.nodes)+1),
+		rels:  make(map[string]*storage.Edge, len(row.rels)+1),
+	}
+	for k, v := range row.nodes {
+		out.nodes[k] = v
+	}
+	for k, v := range row.rels {
+		out.rels[k] = v
+	}
+	if nodeVar != "" {
+		out.nodes[nodeVar] = node
+	}
+	if relVar != "" {
+		out.rels[relVar] = edge
+	}
+	return out
+}
+
+// executeTraversalSeededOptionalMatch executes a
+// "MATCH <traversal> OPTIONAL MATCH ... [OPTIONAL MATCH ...] RETURN ..." query.
+// initialSection is everything between MATCH and the first OPTIONAL MATCH
+// (pattern plus optional WHERE), nodePatternStr is the bare pattern,
+// optSection is the raw text of all OPTIONAL MATCH clauses, and restOfQuery
+// begins at the first WITH/RETURN after them.
+func (e *StorageExecutor) executeTraversalSeededOptionalMatch(ctx context.Context, initialSection, nodePatternStr, optSection, restOfQuery string) (*ExecuteResult, error) {
+	returnVars := strings.Join(append(extractNodeVariables(nodePatternStr), extractRelationshipVariables(nodePatternStr)...), ", ")
+	if returnVars == "" {
+		returnVars = "*"
+	}
+	matchQuery := "MATCH " + initialSection + " RETURN " + returnVars
+	matchResult, err := e.executeMatch(ctx, matchQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute initial traversal MATCH: %w", err)
+	}
+
+	rows := make([]traversalOptRow, 0, len(matchResult.Rows))
+	for _, r := range matchResult.Rows {
+		row := traversalOptRow{
+			nodes: make(map[string]*storage.Node, len(matchResult.Columns)),
+			rels:  make(map[string]*storage.Edge),
+		}
+		for ci, col := range matchResult.Columns {
+			if ci >= len(r) {
+				break
+			}
+			switch v := r[ci].(type) {
+			case *storage.Node:
+				row.nodes[col] = v
+			case *storage.Edge:
+				row.rels[col] = v
+			case nil:
+				row.nodes[col] = nil
+			}
+		}
+		rows = append(rows, row)
+	}
+
+	for _, clause := range splitOptionalMatchClauses(optSection) {
+		rows, err = e.applyTraversalOptionalClause(ctx, rows, clause)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return e.projectTraversalOptionalRows(ctx, rows, restOfQuery)
+}
+
+// applyTraversalOptionalClause left-outer-joins one OPTIONAL MATCH clause
+// against every row. The bound endpoint seeds the traversal; the unbound
+// endpoint (and the relationship variable, when named) is bound on each row.
+// When both endpoints are already bound the clause acts as a filter that binds
+// only the relationship variable. A row whose seed is null (an earlier
+// OPTIONAL MATCH miss) propagates null bindings, matching Cypher semantics.
+func (e *StorageExecutor) applyTraversalOptionalClause(ctx context.Context, rows []traversalOptRow, clause optionalMatchClause) ([]traversalOptRow, error) {
+	eps, err := e.parseOptionalClauseEndpoints(ctx, clause.pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]traversalOptRow, 0, len(rows))
+	for _, row := range rows {
+		srcNode, srcBound := row.nodes[eps.source.variable]
+		tgtNode, tgtBound := row.nodes[eps.target.variable]
+
+		var seed *storage.Node
+		var pattern optionalRelPattern
+		newNodeVar := ""
+		switch {
+		case srcBound:
+			seed = srcNode
+			pattern = optionalRelPattern{
+				sourceVar:    eps.source.variable,
+				relVar:       eps.relVar,
+				relType:      eps.relType,
+				targetVar:    eps.target.variable,
+				targetLabels: eps.target.labels,
+				targetProps:  eps.target.properties,
+				direction:    eps.direction,
+			}
+			if !tgtBound {
+				newNodeVar = eps.target.variable
+			}
+		case tgtBound:
+			seed = tgtNode
+			pattern = optionalRelPattern{
+				sourceVar:    eps.target.variable,
+				relVar:       eps.relVar,
+				relType:      eps.relType,
+				targetVar:    eps.source.variable,
+				targetLabels: eps.source.labels,
+				targetProps:  eps.source.properties,
+				direction:    invertOptionalDirection(eps.direction),
+			}
+			newNodeVar = eps.source.variable
+		default:
+			return nil, fmt.Errorf(
+				"unsupported OPTIONAL MATCH: pattern %q references no variable bound by an earlier clause",
+				truncateQuery(clause.pattern, 60))
+		}
+
+		if seed == nil {
+			out = append(out, extendTraversalRow(row, newNodeVar, nil, eps.relVar, nil))
+			continue
+		}
+
+		matched := false
+		for _, rel := range e.findOptionalRelatedNodes(ctx, seed, clause.pattern, pattern) {
+			if srcBound && tgtBound {
+				if rel.node == nil || tgtNode == nil || rel.node.ID != tgtNode.ID {
+					continue
+				}
+			}
+			cand := extendTraversalRow(row, newNodeVar, rel.node, eps.relVar, rel.edge)
+			if clause.where != "" {
+				passes, ok := e.evaluateExpressionWithContext(ctx, clause.where, cand.nodes, cand.rels).(bool)
+				if !ok || !passes {
+					continue
+				}
+			}
+			out = append(out, cand)
+			matched = true
+		}
+		if !matched {
+			out = append(out, extendTraversalRow(row, newNodeVar, nil, eps.relVar, nil))
+		}
+	}
+	return out, nil
+}
+
+// projectTraversalOptionalRows evaluates the RETURN clause of restOfQuery
+// against the joined rows using the real expression evaluator, routing
+// aggregate projections through implicit-grouping aggregation, then applies
+// ORDER BY / SKIP / LIMIT.
+func (e *StorageExecutor) projectTraversalOptionalRows(ctx context.Context, rows []traversalOptRow, restOfQuery string) (*ExecuteResult, error) {
+	returnIdx := findKeywordIndex(restOfQuery, "RETURN")
+	if returnIdx < 0 {
+		return &ExecuteResult{Columns: []string{}, Rows: [][]interface{}{}}, nil
+	}
+	returnClause := strings.TrimSpace(restOfQuery[returnIdx+len("RETURN"):])
+	items := e.parseReturnItems(stripTrailingReturnClauses(returnClause))
+
+	result := &ExecuteResult{Columns: make([]string, len(items))}
+	for i, item := range items {
+		if item.alias != "" {
+			result.Columns[i] = item.alias
+		} else {
+			result.Columns[i] = item.expr
+		}
+	}
+
+	if rowHasAggregate(items) {
+		aggRows, err := e.aggregateTraversalOptionalRows(ctx, rows, items)
+		if err != nil {
+			return nil, err
+		}
+		result.Rows = aggRows
+	} else {
+		result.Rows = make([][]interface{}, 0, len(rows))
+		for _, row := range rows {
+			outRow := make([]interface{}, len(items))
+			for i, item := range items {
+				outRow[i] = e.evalTraversalProjection(ctx, item.expr, row)
+			}
+			result.Rows = append(result.Rows, outRow)
+		}
+	}
+
+	e.applyTraversalReturnModifiers(result, returnClause)
+	return result, nil
+}
+
+// evalTraversalProjection evaluates one projection expression against a joined
+// row: the "var.prop" / bare-variable fast path first, then the full
+// expression evaluator for everything else (functions, coalesce, CASE, ...).
+func (e *StorageExecutor) evalTraversalProjection(ctx context.Context, expr string, row traversalOptRow) interface{} {
+	if v, ok := fastTraversalExprValue(expr, row); ok {
+		return v
+	}
+	return e.evaluateExpressionWithContext(ctx, expr, row.nodes, row.rels)
+}
+
+// isSimpleTraversalIdentifier reports whether s is a bare Cypher identifier
+// (letters, digits, underscores; not starting with a digit). Used to gate the
+// projection fast path so any richer expression falls back to the full
+// evaluator.
+func isSimpleTraversalIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// fastTraversalExprValue resolves the two hot projection shapes — "var.prop"
+// and a bare bound variable — without walking the full expression evaluator's
+// dispatch chain. It replicates evaluateExpressionWithContext's semantics for
+// exactly those shapes (nil bindings project as null, has_embedding reads
+// EmbedMeta, single-"value" pseudo-nodes unwrap to their scalar) and reports
+// ok=false for everything else so the caller falls back to the evaluator.
+func fastTraversalExprValue(expr string, row traversalOptRow) (interface{}, bool) {
+	expr = strings.TrimSpace(expr)
+
+	if dotIdx := strings.IndexByte(expr, '.'); dotIdx > 0 {
+		varName := expr[:dotIdx]
+		propName := expr[dotIdx+1:]
+		if !isSimpleTraversalIdentifier(varName) || !isSimpleTraversalIdentifier(propName) {
+			return nil, false
+		}
+		if node, ok := row.nodes[varName]; ok {
+			if node == nil {
+				return nil, true
+			}
+			if propName == "has_embedding" {
+				if node.EmbedMeta != nil {
+					if val, ok := node.EmbedMeta["has_embedding"]; ok {
+						return val, true
+					}
+				}
+				return len(node.ChunkEmbeddings) > 0 && len(node.ChunkEmbeddings[0]) > 0, true
+			}
+			return node.Properties[propName], true
+		}
+		if rel, ok := row.rels[varName]; ok {
+			if rel == nil {
+				return nil, true
+			}
+			return rel.Properties[propName], true
+		}
+		return nil, false
+	}
+
+	if !isSimpleTraversalIdentifier(expr) {
+		return nil, false
+	}
+	if node, ok := row.nodes[expr]; ok {
+		if node == nil {
+			return nil, true
+		}
+		// Scalar wrapper pseudo-node (YIELD variables): unwrap single "value".
+		if len(node.Properties) == 1 {
+			if val, hasValue := node.Properties["value"]; hasValue {
+				return val, true
+			}
+		}
+		return node, true
+	}
+	if rel, ok := row.rels[expr]; ok {
+		if rel == nil {
+			return nil, true
+		}
+		return rel, true
+	}
+	return nil, false
+}
+
+// applyTraversalReturnModifiers applies ORDER BY, SKIP, and LIMIT from the
+// RETURN clause tail, mirroring buildJoinedResult's handling.
+func (e *StorageExecutor) applyTraversalReturnModifiers(result *ExecuteResult, returnClause string) {
+	if orderByIdx := findMultiWordKeywordIndex(returnClause, "ORDER", "BY"); orderByIdx >= 0 {
+		orderPart := returnClause[orderByIdx:]
+		if mIdx := findKeywordIndex(orderPart, "BY"); mIdx >= 0 {
+			orderPart = orderPart[mIdx+len("BY"):]
+		}
+		endIdx := len(orderPart)
+		for _, kw := range []string{"SKIP", "LIMIT"} {
+			if idx := findKeywordIndex(orderPart, kw); idx >= 0 && idx < endIdx {
+				endIdx = idx
+			}
+		}
+		result.Rows = e.orderResultRows(result.Rows, result.Columns, strings.TrimSpace(orderPart[:endIdx]))
+	}
+
+	skip := 0
+	if skipIdx := findKeywordIndex(returnClause, "SKIP"); skipIdx >= 0 {
+		if fields := strings.Fields(returnClause[skipIdx+len("SKIP"):]); len(fields) > 0 {
+			if s, err := strconv.Atoi(fields[0]); err == nil {
+				skip = s
+			}
+		}
+	}
+	limit := -1
+	if limitIdx := findKeywordIndex(returnClause, "LIMIT"); limitIdx >= 0 {
+		if fields := strings.Fields(returnClause[limitIdx+len("LIMIT"):]); len(fields) > 0 {
+			if l, err := strconv.Atoi(fields[0]); err == nil {
+				limit = l
+			}
+		}
+	}
+	if skip > 0 || limit >= 0 {
+		start := skip
+		if start > len(result.Rows) {
+			start = len(result.Rows)
+		}
+		end := len(result.Rows)
+		if limit >= 0 && start+limit < end {
+			end = start + limit
+		}
+		result.Rows = result.Rows[start:end]
+	}
+}

--- a/pkg/cypher/optional_match_traversal.go
+++ b/pkg/cypher/optional_match_traversal.go
@@ -369,11 +369,17 @@ func (e *StorageExecutor) projectTraversalOptionalRows(ctx context.Context, rows
 		}
 		result.Rows = aggRows
 	} else {
+		// Compile each projection item once; per row only the compiled
+		// closures run (see optional_match_traversal_compile.go).
+		projectors := make([]compiledTraversalProjection, len(items))
+		for i, item := range items {
+			projectors[i] = e.compileTraversalProjection(ctx, item.expr)
+		}
 		result.Rows = make([][]interface{}, 0, len(rows))
 		for _, row := range rows {
 			outRow := make([]interface{}, len(items))
-			for i, item := range items {
-				outRow[i] = e.evalTraversalProjection(ctx, item.expr, row)
+			for i := range items {
+				outRow[i] = projectors[i](row)
 			}
 			result.Rows = append(result.Rows, outRow)
 		}
@@ -381,16 +387,6 @@ func (e *StorageExecutor) projectTraversalOptionalRows(ctx context.Context, rows
 
 	e.applyTraversalReturnModifiers(result, returnClause)
 	return result, nil
-}
-
-// evalTraversalProjection evaluates one projection expression against a joined
-// row: the "var.prop" / bare-variable fast path first, then the full
-// expression evaluator for everything else (functions, coalesce, CASE, ...).
-func (e *StorageExecutor) evalTraversalProjection(ctx context.Context, expr string, row traversalOptRow) interface{} {
-	if v, ok := fastTraversalExprValue(expr, row); ok {
-		return v
-	}
-	return e.evaluateExpressionWithContext(ctx, expr, row.nodes, row.rels)
 }
 
 // isSimpleTraversalIdentifier reports whether s is a bare Cypher identifier

--- a/pkg/cypher/optional_match_traversal_agg.go
+++ b/pkg/cypher/optional_match_traversal_agg.go
@@ -82,16 +82,28 @@ func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, ro
 		}
 	}
 
+	// Compile group-key expressions and aggregate arguments once; the row loop
+	// below runs only the compiled closures.
+	projectors := make([]compiledTraversalProjection, len(items))
+	for i, item := range items {
+		switch {
+		case specs[i] == nil:
+			projectors[i] = e.compileTraversalProjection(ctx, item.expr)
+		case !specs[i].star:
+			projectors[i] = e.compileTraversalProjection(ctx, specs[i].inner)
+		}
+	}
+
 	groups := make(map[string]*traversalAggGroup)
 	var order []string
 	for _, row := range rows {
 		keyParts := make([]string, 0, len(items))
 		groupVals := make([]interface{}, len(items))
-		for i, item := range items {
+		for i := range items {
 			if specs[i] != nil {
 				continue
 			}
-			v := e.evalTraversalProjection(ctx, item.expr, row)
+			v := projectors[i](row)
 			groupVals[i] = v
 			keyParts = append(keyParts, joinedValueKey(v))
 		}
@@ -111,7 +123,7 @@ func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, ro
 			if spec == nil || spec.star {
 				continue
 			}
-			v := e.evalTraversalProjection(ctx, spec.inner, row)
+			v := projectors[i](row)
 			if v == nil {
 				continue // Cypher aggregates skip nulls
 			}

--- a/pkg/cypher/optional_match_traversal_agg.go
+++ b/pkg/cypher/optional_match_traversal_agg.go
@@ -1,0 +1,235 @@
+package cypher
+
+// Implicit-grouping aggregation for the traversal-seeded OPTIONAL MATCH
+// pipeline (see optional_match_traversal.go). Non-aggregate RETURN items form
+// the grouping key (Cypher implicit grouping); aggregate items accumulate per
+// group with standard Cypher null handling (aggregates skip nulls; count(*)
+// counts rows).
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// traversalAggSpec is one parsed aggregate RETURN item.
+type traversalAggSpec struct {
+	fn       string // lower-case: count, sum, avg, min, max, collect
+	inner    string // argument expression text ("" when star)
+	distinct bool
+	star     bool // count(*)
+}
+
+// parseTraversalAggregateCall parses a top-level aggregate call such as
+// "count(DISTINCT f.path)" or "collect(t.name)". It rejects shapes it cannot
+// evaluate faithfully (trailing operators, stdev/stdevp) with an explicit
+// error so the query fails loudly instead of corrupting.
+func parseTraversalAggregateCall(expr string) (traversalAggSpec, error) {
+	spec := traversalAggSpec{}
+	trimmed := strings.TrimSpace(expr)
+	lower := strings.ToLower(trimmed)
+	for _, fn := range []string{"count", "sum", "avg", "min", "max", "collect"} {
+		if strings.HasPrefix(lower, fn+"(") || strings.HasPrefix(lower, fn+" (") {
+			spec.fn = fn
+			break
+		}
+	}
+	if spec.fn == "" {
+		return spec, fmt.Errorf("unsupported aggregate expression %q in OPTIONAL MATCH projection", trimmed)
+	}
+	open := strings.Index(trimmed, "(")
+	if open < 0 || !strings.HasSuffix(trimmed, ")") {
+		return spec, fmt.Errorf("unsupported aggregate expression %q in OPTIONAL MATCH projection", trimmed)
+	}
+	inner := strings.TrimSpace(trimmed[open+1 : len(trimmed)-1])
+	if spec.fn == "count" && inner == "*" {
+		spec.star = true
+		return spec, nil
+	}
+	if len(inner) >= len("DISTINCT ") && strings.EqualFold(inner[:len("DISTINCT")], "DISTINCT") && inner[len("DISTINCT")] == ' ' {
+		spec.distinct = true
+		inner = strings.TrimSpace(inner[len("DISTINCT"):])
+	}
+	if inner == "" {
+		return spec, fmt.Errorf("empty aggregate argument in %q", trimmed)
+	}
+	spec.inner = inner
+	return spec, nil
+}
+
+// traversalAggGroup accumulates one implicit group.
+type traversalAggGroup struct {
+	groupVals []interface{}   // evaluated non-aggregate item values by item index
+	values    [][]interface{} // accumulated non-null argument values by item index
+	seen      []map[string]bool
+	rowCount  int64
+}
+
+// aggregateTraversalOptionalRows evaluates a RETURN projection containing
+// aggregates over the joined rows, grouping by the non-aggregate items.
+func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, rows []traversalOptRow, items []returnItem) ([][]interface{}, error) {
+	specs := make([]*traversalAggSpec, len(items))
+	hasGroupKeys := false
+	for i, item := range items {
+		if isAggregateExpression(item.expr) {
+			spec, err := parseTraversalAggregateCall(item.expr)
+			if err != nil {
+				return nil, err
+			}
+			specs[i] = &spec
+		} else {
+			hasGroupKeys = true
+		}
+	}
+
+	groups := make(map[string]*traversalAggGroup)
+	var order []string
+	for _, row := range rows {
+		keyParts := make([]string, 0, len(items))
+		groupVals := make([]interface{}, len(items))
+		for i, item := range items {
+			if specs[i] != nil {
+				continue
+			}
+			v := e.evalTraversalProjection(ctx, item.expr, row)
+			groupVals[i] = v
+			keyParts = append(keyParts, joinedValueKey(v))
+		}
+		key := strings.Join(keyParts, "|")
+		group := groups[key]
+		if group == nil {
+			group = &traversalAggGroup{
+				groupVals: groupVals,
+				values:    make([][]interface{}, len(items)),
+				seen:      make([]map[string]bool, len(items)),
+			}
+			groups[key] = group
+			order = append(order, key)
+		}
+		group.rowCount++
+		for i, spec := range specs {
+			if spec == nil || spec.star {
+				continue
+			}
+			v := e.evalTraversalProjection(ctx, spec.inner, row)
+			if v == nil {
+				continue // Cypher aggregates skip nulls
+			}
+			if spec.distinct {
+				if group.seen[i] == nil {
+					group.seen[i] = make(map[string]bool)
+				}
+				k := joinedValueKey(v)
+				if group.seen[i][k] {
+					continue
+				}
+				group.seen[i][k] = true
+			}
+			group.values[i] = append(group.values[i], v)
+		}
+	}
+
+	if len(groups) == 0 {
+		if hasGroupKeys {
+			return [][]interface{}{}, nil
+		}
+		// Aggregation over an empty row set with no grouping keys yields one
+		// row of aggregate identities (count -> 0, collect -> [], ...).
+		out := make([]interface{}, len(items))
+		for i, item := range items {
+			out[i] = aggregateIdentity(item.expr)
+		}
+		return [][]interface{}{out}, nil
+	}
+
+	outRows := make([][]interface{}, 0, len(groups))
+	for _, key := range order {
+		group := groups[key]
+		outRow := make([]interface{}, len(items))
+		for i := range items {
+			if specs[i] == nil {
+				outRow[i] = group.groupVals[i]
+				continue
+			}
+			outRow[i] = e.finalizeTraversalAggregate(*specs[i], group.values[i], group.rowCount)
+		}
+		outRows = append(outRows, outRow)
+	}
+	return outRows, nil
+}
+
+// finalizeTraversalAggregate reduces one aggregate item's accumulated non-null
+// values (already deduplicated when DISTINCT) into the final value, following
+// Cypher semantics: count(*) counts rows, count(x) counts non-null values,
+// sum of an empty set is 0, avg/min/max of an empty set are null.
+func (e *StorageExecutor) finalizeTraversalAggregate(spec traversalAggSpec, vals []interface{}, rowCount int64) interface{} {
+	switch spec.fn {
+	case "count":
+		if spec.star {
+			return rowCount
+		}
+		return int64(len(vals))
+	case "collect":
+		if vals == nil {
+			return []interface{}{}
+		}
+		return vals
+	case "sum":
+		return sumTraversalAggregateValues(vals)
+	case "avg":
+		if len(vals) == 0 {
+			return nil
+		}
+		total := 0.0
+		for _, v := range vals {
+			f, ok := toFloat64(v)
+			if !ok {
+				return nil
+			}
+			total += f
+		}
+		return total / float64(len(vals))
+	case "min", "max":
+		if len(vals) == 0 {
+			return nil
+		}
+		best := vals[0]
+		for _, v := range vals[1:] {
+			cmp := e.compareOrderValues(v, best)
+			if (spec.fn == "min" && cmp < 0) || (spec.fn == "max" && cmp > 0) {
+				best = v
+			}
+		}
+		return best
+	}
+	return nil
+}
+
+// sumTraversalAggregateValues sums values, keeping int64 when every input is
+// an integer (Neo4j-compatible) and falling back to float64 otherwise.
+func sumTraversalAggregateValues(vals []interface{}) interface{} {
+	allInts := true
+	var intSum int64
+	var floatSum float64
+	for _, v := range vals {
+		switch n := v.(type) {
+		case int64:
+			intSum += n
+			floatSum += float64(n)
+		case int:
+			intSum += int64(n)
+			floatSum += float64(n)
+		default:
+			allInts = false
+			f, ok := toFloat64(v)
+			if !ok {
+				return nil
+			}
+			floatSum += f
+		}
+	}
+	if allInts {
+		return intSum
+	}
+	return floatSum
+}

--- a/pkg/cypher/optional_match_traversal_agg.go
+++ b/pkg/cypher/optional_match_traversal_agg.go
@@ -1,96 +1,269 @@
 package cypher
 
 // Implicit-grouping aggregation for the traversal-seeded OPTIONAL MATCH
-// pipeline (see optional_match_traversal.go). Non-aggregate RETURN items form
-// the grouping key (Cypher implicit grouping); aggregate items accumulate per
-// group with standard Cypher null handling (aggregates skip nulls; count(*)
-// counts rows).
+// pipeline (see optional_match_traversal.go), mirroring Neo4j's aggregation
+// model:
+//
+//   - EagerAggregationPipe.scala + GroupingAggTable/NonGroupingAggTable:
+//     non-aggregate RETURN items are the grouping key; aggregate expressions
+//     accumulate per group; aggregation over an empty ungrouped input yields
+//     one row of identity values (count -> 0, collect -> [], sum -> 0,
+//     avg/min/max/stdev -> null).
+//   - isolateAggregation.scala (front-end): a RETURN item that CONTAINS
+//     aggregates without BEING one (e.g. "count(x) + 1", "{c: count(*)}") is
+//     handled by isolating each aggregate subexpression, aggregating it per
+//     group, and then evaluating the outer expression with the aggregate
+//     results substituted — the same rewrite Neo4j performs into an
+//     intermediate WITH clause.
+//   - StdevFunction.scala: stdev/stdevp — null on empty input, 0.0 for a
+//     single value, else sqrt(M2/(n-1)) (sample) or sqrt(M2/n) (population).
+//
+// Aggregates skip null arguments; count(*) counts rows; DISTINCT deduplicates
+// by value identity. No aggregate shape is rejected: the only error kept is
+// an empty argument list (e.g. "count()"), which Neo4j itself rejects at
+// compile time ("Insufficient parameters for function 'count'").
 
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
 )
 
-// traversalAggSpec is one parsed aggregate RETURN item.
+// traversalAggFnNames are the aggregate functions the traversal pipeline
+// accumulates, matching the executor-wide aggregateFnNames set. stdevp is
+// listed before stdev so prefix scanning matches the longer name first.
+var traversalAggFnNames = []string{"collect", "count", "sum", "avg", "min", "max", "stdevp", "stdev"}
+
+// traversalAggSpec is one parsed aggregate call.
 type traversalAggSpec struct {
-	fn       string // lower-case: count, sum, avg, min, max, collect
+	fn       string // lower-case name from traversalAggFnNames
 	inner    string // argument expression text ("" when star)
 	distinct bool
 	star     bool // count(*)
 }
 
-// parseTraversalAggregateCall parses a top-level aggregate call such as
-// "count(DISTINCT f.path)" or "collect(t.name)". It rejects shapes it cannot
-// evaluate faithfully (trailing operators, stdev/stdevp) with an explicit
-// error so the query fails loudly instead of corrupting.
+// aggregateSpan is one aggregate call located inside a larger expression.
+type aggregateSpan struct {
+	start, end int // expr[start:end] is the full call text
+}
+
+// findAggregateSpans locates the outermost aggregate calls in expr: an
+// aggregate function name at a word boundary, outside quoted strings,
+// followed by a balanced parenthesized argument list. Scanning resumes after
+// each span, so aggregates nested inside another aggregate's arguments are
+// not reported separately.
+func findAggregateSpans(expr string) []aggregateSpan {
+	var spans []aggregateSpan
+	lower := strings.ToLower(expr)
+	i := 0
+	for i < len(lower) {
+		c := lower[i]
+		if c == '\'' || c == '"' || c == '`' {
+			j := i + 1
+			for j < len(lower) && (lower[j] != c || lower[j-1] == '\\') {
+				j++
+			}
+			i = j + 1
+			continue
+		}
+		matched := false
+		for _, fn := range traversalAggFnNames {
+			if !strings.HasPrefix(lower[i:], fn) {
+				continue
+			}
+			if i > 0 && isIdentByte(lower[i-1]) {
+				continue
+			}
+			j := i + len(fn)
+			for j < len(lower) && isWhitespace(lower[j]) {
+				j++
+			}
+			if j >= len(lower) || lower[j] != '(' {
+				continue
+			}
+			depth := 0
+			end := -1
+			for k := j; k < len(lower) && end < 0; k++ {
+				switch lower[k] {
+				case '(':
+					depth++
+				case ')':
+					depth--
+					if depth == 0 {
+						end = k + 1
+					}
+				}
+			}
+			if end < 0 {
+				continue
+			}
+			spans = append(spans, aggregateSpan{start: i, end: end})
+			i = end
+			matched = true
+			break
+		}
+		if !matched {
+			i++
+		}
+	}
+	return spans
+}
+
+// traversalItemsContainAggregate reports whether any RETURN item contains an
+// aggregate call (whether or not the whole item is one).
+func traversalItemsContainAggregate(items []returnItem) bool {
+	for _, item := range items {
+		if len(findAggregateSpans(item.expr)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// parseTraversalAggregateCall parses one whole aggregate call such as
+// "count(DISTINCT f.path)". The only rejected form is an empty argument list,
+// which Neo4j itself rejects at compile time.
 func parseTraversalAggregateCall(expr string) (traversalAggSpec, error) {
 	spec := traversalAggSpec{}
 	trimmed := strings.TrimSpace(expr)
-	lower := strings.ToLower(trimmed)
-	for _, fn := range []string{"count", "sum", "avg", "min", "max", "collect"} {
-		if strings.HasPrefix(lower, fn+"(") || strings.HasPrefix(lower, fn+" (") {
+	open := strings.Index(trimmed, "(")
+	if open <= 0 || !strings.HasSuffix(trimmed, ")") {
+		return spec, fmt.Errorf("not a whole aggregate call: %q", trimmed)
+	}
+	name := strings.ToLower(strings.TrimSpace(trimmed[:open]))
+	for _, fn := range traversalAggFnNames {
+		if name == fn {
 			spec.fn = fn
 			break
 		}
 	}
 	if spec.fn == "" {
-		return spec, fmt.Errorf("unsupported aggregate expression %q in OPTIONAL MATCH projection", trimmed)
-	}
-	open := strings.Index(trimmed, "(")
-	if open < 0 || !strings.HasSuffix(trimmed, ")") {
-		return spec, fmt.Errorf("unsupported aggregate expression %q in OPTIONAL MATCH projection", trimmed)
+		return spec, fmt.Errorf("not a whole aggregate call: %q", trimmed)
 	}
 	inner := strings.TrimSpace(trimmed[open+1 : len(trimmed)-1])
 	if spec.fn == "count" && inner == "*" {
 		spec.star = true
 		return spec, nil
 	}
-	if len(inner) >= len("DISTINCT ") && strings.EqualFold(inner[:len("DISTINCT")], "DISTINCT") && inner[len("DISTINCT")] == ' ' {
+	if len(inner) > len("DISTINCT") && strings.EqualFold(inner[:len("DISTINCT")], "DISTINCT") && inner[len("DISTINCT")] == ' ' {
 		spec.distinct = true
 		inner = strings.TrimSpace(inner[len("DISTINCT"):])
 	}
 	if inner == "" {
-		return spec, fmt.Errorf("empty aggregate argument in %q", trimmed)
+		return spec, fmt.Errorf("insufficient parameters for function '%s'", spec.fn)
 	}
 	spec.inner = inner
 	return spec, nil
 }
 
+// traversalAggItem is one classified RETURN item.
+type traversalAggItem struct {
+	grouping  bool
+	spec      *traversalAggSpec // whole-item aggregate
+	rewritten string            // mixed item: expr with spans replaced by placeholders
+	specs     []traversalAggSpec
+	compiled  []compiledTraversalProjection // per-spec inner projections
+	groupFn   compiledTraversalProjection   // grouping item projection
+}
+
+// traversalAggPlaceholder returns the synthetic variable name substituted for
+// the n-th aggregate span of a mixed item (isolateAggregation's x1/x2 rewrite).
+func traversalAggPlaceholder(n int) string {
+	return fmt.Sprintf("__nornic_agg_%d", n)
+}
+
+// classifyTraversalAggItems splits RETURN items into grouping keys, whole
+// aggregates, and mixed expressions, pre-compiling every per-row projection.
+func (e *StorageExecutor) classifyTraversalAggItems(ctx context.Context, items []returnItem) ([]traversalAggItem, error) {
+	classified := make([]traversalAggItem, len(items))
+	for i, item := range items {
+		expr := strings.TrimSpace(item.expr)
+		spans := findAggregateSpans(expr)
+		switch {
+		case len(spans) == 0:
+			classified[i] = traversalAggItem{grouping: true, groupFn: e.compileTraversalProjection(ctx, expr)}
+		case len(spans) == 1 && spans[0].start == 0 && spans[0].end == len(expr):
+			spec, err := parseTraversalAggregateCall(expr)
+			if err != nil {
+				return nil, err
+			}
+			ti := traversalAggItem{spec: &spec}
+			if !spec.star {
+				ti.compiled = []compiledTraversalProjection{e.compileTraversalProjection(ctx, spec.inner)}
+			}
+			classified[i] = ti
+		default:
+			// Mixed expression: isolate each aggregate span (isolateAggregation).
+			var sb strings.Builder
+			var specs []traversalAggSpec
+			var compiled []compiledTraversalProjection
+			last := 0
+			for n, span := range spans {
+				spec, err := parseTraversalAggregateCall(expr[span.start:span.end])
+				if err != nil {
+					return nil, err
+				}
+				sb.WriteString(expr[last:span.start])
+				sb.WriteString(traversalAggPlaceholder(n))
+				last = span.end
+				specs = append(specs, spec)
+				if spec.star {
+					compiled = append(compiled, nil)
+				} else {
+					compiled = append(compiled, e.compileTraversalProjection(ctx, spec.inner))
+				}
+			}
+			sb.WriteString(expr[last:])
+			classified[i] = traversalAggItem{rewritten: sb.String(), specs: specs, compiled: compiled}
+		}
+	}
+	return classified, nil
+}
+
+// traversalAggAccum accumulates one aggregate call's values within one group.
+type traversalAggAccum struct {
+	values []interface{}
+	seen   map[string]bool
+}
+
+func (a *traversalAggAccum) add(v interface{}, distinct bool) {
+	if v == nil {
+		return // Cypher aggregates skip nulls
+	}
+	if distinct {
+		if a.seen == nil {
+			a.seen = make(map[string]bool)
+		}
+		key := joinedValueKey(v)
+		if a.seen[key] {
+			return
+		}
+		a.seen[key] = true
+	}
+	a.values = append(a.values, v)
+}
+
 // traversalAggGroup accumulates one implicit group.
 type traversalAggGroup struct {
-	groupVals []interface{}   // evaluated non-aggregate item values by item index
-	values    [][]interface{} // accumulated non-null argument values by item index
-	seen      []map[string]bool
+	groupVals []interface{}         // evaluated grouping values by item index
+	accums    [][]traversalAggAccum // per item, per aggregate span
 	rowCount  int64
 }
 
 // aggregateTraversalOptionalRows evaluates a RETURN projection containing
 // aggregates over the joined rows, grouping by the non-aggregate items.
 func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, rows []traversalOptRow, items []returnItem) ([][]interface{}, error) {
-	specs := make([]*traversalAggSpec, len(items))
-	hasGroupKeys := false
-	for i, item := range items {
-		if isAggregateExpression(item.expr) {
-			spec, err := parseTraversalAggregateCall(item.expr)
-			if err != nil {
-				return nil, err
-			}
-			specs[i] = &spec
-		} else {
-			hasGroupKeys = true
-		}
+	classified, err := e.classifyTraversalAggItems(ctx, items)
+	if err != nil {
+		return nil, err
 	}
-
-	// Compile group-key expressions and aggregate arguments once; the row loop
-	// below runs only the compiled closures.
-	projectors := make([]compiledTraversalProjection, len(items))
-	for i, item := range items {
-		switch {
-		case specs[i] == nil:
-			projectors[i] = e.compileTraversalProjection(ctx, item.expr)
-		case !specs[i].star:
-			projectors[i] = e.compileTraversalProjection(ctx, specs[i].inner)
+	hasGroupKeys := false
+	for _, ti := range classified {
+		if ti.grouping {
+			hasGroupKeys = true
 		}
 	}
 
@@ -99,45 +272,44 @@ func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, ro
 	for _, row := range rows {
 		keyParts := make([]string, 0, len(items))
 		groupVals := make([]interface{}, len(items))
-		for i := range items {
-			if specs[i] != nil {
+		for i, ti := range classified {
+			if !ti.grouping {
 				continue
 			}
-			v := projectors[i](row)
+			v := ti.groupFn(row)
 			groupVals[i] = v
 			keyParts = append(keyParts, joinedValueKey(v))
 		}
 		key := strings.Join(keyParts, "|")
 		group := groups[key]
 		if group == nil {
-			group = &traversalAggGroup{
-				groupVals: groupVals,
-				values:    make([][]interface{}, len(items)),
-				seen:      make([]map[string]bool, len(items)),
+			group = &traversalAggGroup{groupVals: groupVals, accums: make([][]traversalAggAccum, len(items))}
+			for i, ti := range classified {
+				switch {
+				case ti.spec != nil:
+					group.accums[i] = make([]traversalAggAccum, 1)
+				case ti.rewritten != "":
+					group.accums[i] = make([]traversalAggAccum, len(ti.specs))
+				}
 			}
 			groups[key] = group
 			order = append(order, key)
 		}
 		group.rowCount++
-		for i, spec := range specs {
-			if spec == nil || spec.star {
-				continue
-			}
-			v := projectors[i](row)
-			if v == nil {
-				continue // Cypher aggregates skip nulls
-			}
-			if spec.distinct {
-				if group.seen[i] == nil {
-					group.seen[i] = make(map[string]bool)
+		for i, ti := range classified {
+			switch {
+			case ti.spec != nil:
+				if !ti.spec.star {
+					group.accums[i][0].add(ti.compiled[0](row), ti.spec.distinct)
 				}
-				k := joinedValueKey(v)
-				if group.seen[i][k] {
-					continue
+			case ti.rewritten != "":
+				for n, spec := range ti.specs {
+					if spec.star {
+						continue
+					}
+					group.accums[i][n].add(ti.compiled[n](row), spec.distinct)
 				}
-				group.seen[i][k] = true
 			}
-			group.values[i] = append(group.values[i], v)
 		}
 	}
 
@@ -145,11 +317,16 @@ func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, ro
 		if hasGroupKeys {
 			return [][]interface{}{}, nil
 		}
-		// Aggregation over an empty row set with no grouping keys yields one
-		// row of aggregate identities (count -> 0, collect -> [], ...).
+		// Aggregation over an empty ungrouped input: one row of identities
+		// (NonGroupingAggTable semantics).
 		out := make([]interface{}, len(items))
-		for i, item := range items {
-			out[i] = aggregateIdentity(item.expr)
+		for i, ti := range classified {
+			switch {
+			case ti.spec != nil:
+				out[i] = e.finalizeTraversalAggregate(*ti.spec, nil, 0)
+			case ti.rewritten != "":
+				out[i] = e.evaluateMixedAggregate(ctx, ti, nil, 0)
+			}
 		}
 		return [][]interface{}{out}, nil
 	}
@@ -158,22 +335,43 @@ func (e *StorageExecutor) aggregateTraversalOptionalRows(ctx context.Context, ro
 	for _, key := range order {
 		group := groups[key]
 		outRow := make([]interface{}, len(items))
-		for i := range items {
-			if specs[i] == nil {
+		for i, ti := range classified {
+			switch {
+			case ti.grouping:
 				outRow[i] = group.groupVals[i]
-				continue
+			case ti.spec != nil:
+				outRow[i] = e.finalizeTraversalAggregate(*ti.spec, group.accums[i][0].values, group.rowCount)
+			default:
+				outRow[i] = e.evaluateMixedAggregate(ctx, ti, group.accums[i], group.rowCount)
 			}
-			outRow[i] = e.finalizeTraversalAggregate(*specs[i], group.values[i], group.rowCount)
 		}
 		outRows = append(outRows, outRow)
 	}
 	return outRows, nil
 }
 
-// finalizeTraversalAggregate reduces one aggregate item's accumulated non-null
-// values (already deduplicated when DISTINCT) into the final value, following
-// Cypher semantics: count(*) counts rows, count(x) counts non-null values,
-// sum of an empty set is 0, avg/min/max of an empty set are null.
+// evaluateMixedAggregate finalizes each aggregate span of a mixed item, then
+// evaluates the rewritten outer expression with the results substituted via
+// single-"value" pseudo-nodes (the executor's scalar-wrapper convention) —
+// the runtime equivalent of isolateAggregation's WITH x1, x2 ... rewrite.
+func (e *StorageExecutor) evaluateMixedAggregate(ctx context.Context, ti traversalAggItem, accums []traversalAggAccum, rowCount int64) interface{} {
+	nodes := make(map[string]*storage.Node, len(ti.specs))
+	for n, spec := range ti.specs {
+		var vals []interface{}
+		if accums != nil {
+			vals = accums[n].values
+		}
+		result := e.finalizeTraversalAggregate(spec, vals, rowCount)
+		nodes[traversalAggPlaceholder(n)] = &storage.Node{Properties: map[string]interface{}{"value": result}}
+	}
+	return e.evaluateExpressionWithContext(ctx, ti.rewritten, nodes, nil)
+}
+
+// finalizeTraversalAggregate reduces one aggregate call's accumulated
+// non-null values (already deduplicated when DISTINCT) into the final value:
+// count(*) counts rows, count(x) counts non-null values, sum of an empty set
+// is 0, avg/min/max of an empty set are null, and stdev/stdevp follow
+// Neo4j's StdevFunction (null on empty, 0.0 for a single value).
 func (e *StorageExecutor) finalizeTraversalAggregate(spec traversalAggSpec, vals []interface{}, rowCount int64) interface{} {
 	switch spec.fn {
 	case "count":
@@ -213,8 +411,39 @@ func (e *StorageExecutor) finalizeTraversalAggregate(spec traversalAggSpec, vals
 			}
 		}
 		return best
+	case "stdev", "stdevp":
+		return stdevTraversalAggregateValues(vals, spec.fn == "stdevp")
 	}
 	return nil
+}
+
+// stdevTraversalAggregateValues implements Neo4j's StdevFunction contract via
+// Welford's online algorithm: null when no numeric values, 0.0 for a single
+// value, sqrt(M2/(n-1)) for the sample deviation, sqrt(M2/n) for population.
+func stdevTraversalAggregateValues(vals []interface{}, population bool) interface{} {
+	count := 0
+	movingAvg := 0.0
+	m2 := 0.0
+	for _, v := range vals {
+		f, ok := toFloat64(v)
+		if !ok {
+			continue
+		}
+		count++
+		next := movingAvg + (f-movingAvg)/float64(count)
+		m2 += (f - movingAvg) * (f - next)
+		movingAvg = next
+	}
+	if count == 0 {
+		return nil
+	}
+	if count < 2 {
+		return 0.0
+	}
+	if population {
+		return math.Sqrt(m2 / float64(count))
+	}
+	return math.Sqrt(m2 / float64(count-1))
 }
 
 // sumTraversalAggregateValues sums values, keeping int64 when every input is

--- a/pkg/cypher/optional_match_traversal_compile.go
+++ b/pkg/cypher/optional_match_traversal_compile.go
@@ -1,0 +1,166 @@
+package cypher
+
+// Per-item projection pre-compilation for the traversal-seeded OPTIONAL MATCH
+// pipeline (see optional_match_traversal.go), following the compiled-WHERE
+// precedent in binding_where_compile.go: parse each RETURN item once, then
+// evaluate the compiled form per row instead of re-walking the string
+// evaluator's dispatch chain for every row.
+//
+// Compilation is a pure optimization and MUST NOT change behavior. Every
+// compiled shape replicates the exact branch the full evaluator
+// (evaluateExpressionWithContextFull) would take for that expression:
+//
+//   - literals reproduce evaluateExpressionFastLeaf (quoted strings, booleans,
+//     null, int-then-float numbers),
+//   - bare variables and var.prop reproduce the fast-leaf / props-literals
+//     branch via fastTraversalExprValue (including has_embedding and the
+//     single-"value" scalar-wrapper pseudo-node),
+//   - whole-expression function calls reproduce the registered-function
+//     dispatch (functions_eval_functions.go): same parseFunctionCallWS /
+//     splitFunctionArgs inputs, same cypherfn.Context construction, same
+//     found/err handling, and a full-evaluator fallback when the registry
+//     does not know the function.
+//
+// A function call is only compiled when the full evaluator would provably
+// reach the registered-function dispatch for it: parseFunctionCallWS must
+// match the whole expression (which rules out param refs, quoted strings,
+// numbers, parenthesized expressions, map literals, and trailing operators or
+// indexing), hasTopLevelExpressionOperator must be false, and it must not be
+// a CASE expression. Anything else — and any argument that does not compile —
+// falls back to the full evaluator, preserving semantics exactly.
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	cypherfn "github.com/orneryd/nornicdb/pkg/cypher/fn"
+)
+
+// compiledTraversalProjection evaluates one pre-parsed projection expression
+// against a joined row.
+type compiledTraversalProjection func(row traversalOptRow) interface{}
+
+// compileTraversalProjection compiles expr into a per-row evaluator. It always
+// succeeds: expressions outside the compilable subset return a closure over
+// the full expression evaluator, which is the exact pre-compilation behavior.
+func (e *StorageExecutor) compileTraversalProjection(ctx context.Context, expr string) compiledTraversalProjection {
+	if fn, ok := e.tryCompileTraversalExpr(ctx, expr); ok {
+		return fn
+	}
+	captured := expr
+	return func(row traversalOptRow) interface{} {
+		return e.evaluateExpressionWithContext(ctx, captured, row.nodes, row.rels)
+	}
+}
+
+// tryCompileTraversalExpr compiles the supported expression shapes. ok=false
+// means the caller must evaluate the expression with the full evaluator.
+func (e *StorageExecutor) tryCompileTraversalExpr(ctx context.Context, expr string) (compiledTraversalProjection, bool) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return nil, false
+	}
+
+	// Literals — replicate evaluateExpressionFastLeaf's order and results.
+	if isWholeCypherQuotedString(expr) {
+		if decoded, ok := decodeCypherQuotedString(expr); ok {
+			return func(traversalOptRow) interface{} { return decoded }, true
+		}
+	}
+	if equalFoldASCII(expr, "true") {
+		return func(traversalOptRow) interface{} { return true }, true
+	}
+	if equalFoldASCII(expr, "false") {
+		return func(traversalOptRow) interface{} { return false }, true
+	}
+	if equalFoldASCII(expr, "null") {
+		// fastLeaf declines null and the props/literals branch resolves it to
+		// nil; the compiled result is identical.
+		return func(traversalOptRow) interface{} { return nil }, true
+	}
+	if exprCanBeNumber(expr) {
+		if num, err := strconv.ParseInt(expr, 10, 64); err == nil {
+			return func(traversalOptRow) interface{} { return num }, true
+		}
+		if num, err := strconv.ParseFloat(expr, 64); err == nil {
+			return func(traversalOptRow) interface{} { return num }, true
+		}
+	}
+
+	// Bare variable / var.prop — fastTraversalExprValue already replicates the
+	// evaluator's semantics for these shapes; compilation pins the shape so the
+	// per-row work is only map lookups. A row where the variable is unbound
+	// falls back to the full evaluator, preserving pre-compilation behavior.
+	if isCompilableTraversalVarExpr(expr) {
+		captured := expr
+		return func(row traversalOptRow) interface{} {
+			if v, ok := fastTraversalExprValue(captured, row); ok {
+				return v
+			}
+			return e.evaluateExpressionWithContext(ctx, captured, row.nodes, row.rels)
+		}, true
+	}
+
+	return e.tryCompileTraversalFunctionCall(ctx, expr)
+}
+
+// isCompilableTraversalVarExpr reports whether expr is a bare identifier or a
+// simple ident.ident property access — the shapes fastTraversalExprValue
+// resolves.
+func isCompilableTraversalVarExpr(expr string) bool {
+	if dotIdx := strings.IndexByte(expr, '.'); dotIdx > 0 {
+		return isSimpleTraversalIdentifier(expr[:dotIdx]) && isSimpleTraversalIdentifier(expr[dotIdx+1:])
+	}
+	return isSimpleTraversalIdentifier(expr)
+}
+
+// tryCompileTraversalFunctionCall compiles a whole-expression function call
+// into a closure over the registered-function dispatch. Argument strings are
+// pre-split once; arguments that themselves compile are evaluated through
+// their compiled form when the function requests lazy evaluation via
+// Context.Eval, and everything else routes through the full evaluator.
+func (e *StorageExecutor) tryCompileTraversalFunctionCall(ctx context.Context, expr string) (compiledTraversalProjection, bool) {
+	name, inner, ok := parseFunctionCallWS(expr)
+	if !ok {
+		return nil, false
+	}
+	// Guarantee the full evaluator would reach the registered-function
+	// dispatch for this expression (see file comment for the branch analysis).
+	if hasTopLevelExpressionOperator(expr) || isCaseExpression(expr) {
+		return nil, false
+	}
+
+	args := e.splitFunctionArgs(inner)
+	compiledArgs := make(map[string]compiledTraversalProjection, len(args))
+	for _, arg := range args {
+		if argFn, ok := e.tryCompileTraversalExpr(ctx, arg); ok {
+			compiledArgs[strings.TrimSpace(arg)] = argFn
+		}
+	}
+
+	captured := expr
+	return func(row traversalOptRow) interface{} {
+		fnCtx := cypherfn.Context{
+			Nodes: row.nodes,
+			Rels:  row.rels,
+			Eval: func(argExpr string) (interface{}, error) {
+				if argFn, ok := compiledArgs[strings.TrimSpace(argExpr)]; ok {
+					return argFn(row), nil
+				}
+				return e.evaluateExpressionWithContext(ctx, argExpr, row.nodes, row.rels), nil
+			},
+			Now: time.Now,
+		}
+		if v, found, err := cypherfn.EvaluateFunction(name, args, fnCtx); found {
+			if err != nil {
+				return nil
+			}
+			return v
+		}
+		// Function not in the registry (e.g. length(), exists()): defer to the
+		// full evaluator's legacy branches.
+		return e.evaluateExpressionWithContext(ctx, captured, row.nodes, row.rels)
+	}, true
+}

--- a/pkg/cypher/optional_match_traversal_general.go
+++ b/pkg/cypher/optional_match_traversal_general.go
@@ -1,0 +1,289 @@
+package cypher
+
+// General (non-seeded) OPTIONAL MATCH clause evaluation for the
+// traversal-seeded pipeline, mirroring Neo4j's Apply + Optional operator
+// semantics (community/cypher/interpreted-runtime/.../pipes/ApplyPipe.scala
+// and OptionalPipe.scala): for every left row the clause pattern is matched;
+// rows that match extend the left row with the pattern's new bindings, and a
+// left row with no match is preserved once with every newly-introduced
+// variable bound to null. A clause is never rejected for not sharing a
+// variable with earlier clauses — a disconnected pattern is a valid
+// cartesian-style optional join in Neo4j, and a pattern whose only variables
+// are already bound simply preserves rows (there is nothing new to null).
+//
+// The single-hop seeded path in optional_match_traversal.go (mirroring
+// OptionalExpandAllPipe.scala) remains the fast path; this file handles
+// everything else: disconnected patterns, single-node patterns, multi-hop
+// chains, and patterns whose relationship variable is already bound.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+)
+
+// scanOptionalPatternShape counts top-level node groups '(' and relationship
+// bracket sections '[' outside quoted strings. Used to route a clause to the
+// seeded single-hop fast path (2 groups, 1 bracket) or the general path.
+func scanOptionalPatternShape(pattern string) (nodeGroups, brackets int) {
+	var inQuote bool
+	var quoteChar byte
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if inQuote {
+			if c == quoteChar && (i == 0 || pattern[i-1] != '\\') {
+				inQuote = false
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			inQuote = true
+			quoteChar = c
+		case '(':
+			nodeGroups++
+		case '[':
+			brackets++
+		}
+	}
+	return nodeGroups, brackets
+}
+
+// firstParenGroup returns the first parenthesized node group of pattern,
+// including the parentheses, or "" when none exists.
+func firstParenGroup(pattern string) string {
+	open := strings.Index(pattern, "(")
+	if open < 0 {
+		return ""
+	}
+	closeIdx := strings.Index(pattern[open:], ")")
+	if closeIdx <= 0 {
+		return ""
+	}
+	return pattern[open : open+closeIdx+1]
+}
+
+// traversalAnonVar names the synthetic variable injected into an anonymous
+// leading node group so a pattern with no named variables can still be
+// enumerated (the synthetic binding is invisible to RETURN).
+const traversalAnonVar = "__nornic_opt_anon"
+
+// ensureLeadingNodeNamed injects a synthetic variable into the pattern's first
+// node group when the pattern has no named variables at all, so the pattern
+// can be executed and its match multiplicity preserved.
+func ensureLeadingNodeNamed(pattern string) string {
+	if len(extractNodeVariables(pattern)) > 0 || len(extractRelationshipVariables(pattern)) > 0 {
+		return pattern
+	}
+	open := strings.Index(pattern, "(")
+	if open < 0 {
+		return pattern
+	}
+	return pattern[:open+1] + traversalAnonVar + pattern[open+1:]
+}
+
+// extendTraversalRowMulti returns a copy of row with additional node and
+// relationship bindings.
+func extendTraversalRowMulti(row traversalOptRow, nodeBinds map[string]*storage.Node, relBinds map[string]*storage.Edge) traversalOptRow {
+	out := traversalOptRow{
+		nodes: make(map[string]*storage.Node, len(row.nodes)+len(nodeBinds)),
+		rels:  make(map[string]*storage.Edge, len(row.rels)+len(relBinds)),
+	}
+	for k, v := range row.nodes {
+		out.nodes[k] = v
+	}
+	for k, v := range row.rels {
+		out.rels[k] = v
+	}
+	for k, v := range nodeBinds {
+		out.nodes[k] = v
+	}
+	for k, v := range relBinds {
+		out.rels[k] = v
+	}
+	return out
+}
+
+// applySingleNodeOptionalClause handles OPTIONAL MATCH (x[:Label {props}]).
+// A bound variable introduces no new bindings, so every row is preserved
+// unchanged whether or not the pattern holds (Neo4j nulls only NEWLY
+// introduced variables — with none, the optional match is a row-preserving
+// no-op). An unbound variable is an independent node scan: each row joins
+// with every matching node, or carries a null binding when nothing matches.
+func (e *StorageExecutor) applySingleNodeOptionalClause(ctx context.Context, rows []traversalOptRow, clause optionalMatchClause) ([]traversalOptRow, error) {
+	group := firstParenGroup(clause.pattern)
+	if group == "" {
+		return rows, nil
+	}
+	np := e.parseNodePattern(ctx, group)
+	varName := np.variable
+	if varName == "" {
+		varName = traversalAnonVar
+	} else if _, bound := rows[0].nodes[varName]; bound {
+		return rows, nil
+	}
+
+	candidates, err := e.loadNodesWithTemporalViewport(ctx, np.labels)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]*storage.Node, 0, len(candidates))
+	for _, node := range candidates {
+		match := true
+		for k, expected := range np.properties {
+			actual, ok := node.Properties[k]
+			if !ok || !e.compareEqual(actual, expected) {
+				match = false
+				break
+			}
+		}
+		if match {
+			filtered = append(filtered, node)
+		}
+	}
+
+	out := make([]traversalOptRow, 0, len(rows))
+	for _, row := range rows {
+		matched := false
+		for _, node := range filtered {
+			cand := extendTraversalRow(row, varName, node, "", nil)
+			if clause.where != "" {
+				passes, ok := e.evaluateExpressionWithContext(ctx, clause.where, cand.nodes, cand.rels).(bool)
+				if !ok || !passes {
+					continue
+				}
+			}
+			out = append(out, cand)
+			matched = true
+		}
+		if !matched {
+			out = append(out, extendTraversalRow(row, varName, nil, "", nil))
+		}
+	}
+	return out, nil
+}
+
+// applyGeneralOptionalClause handles every clause shape the seeded single-hop
+// fast path does not: disconnected patterns, multi-hop chains, and patterns
+// whose relationship variable is already bound. The pattern is enumerated once
+// as an independent MATCH; each left row joins with the candidates whose
+// shared-variable bindings agree by identity, and left rows with no agreeing
+// candidate are preserved with null bindings for the new variables — the
+// Apply + Optional contract.
+func (e *StorageExecutor) applyGeneralOptionalClause(ctx context.Context, rows []traversalOptRow, clause optionalMatchClause) ([]traversalOptRow, error) {
+	if len(rows) == 0 {
+		return rows, nil
+	}
+	pattern := ensureLeadingNodeNamed(clause.pattern)
+	nodeVars := extractNodeVariables(pattern)
+	relVars := extractRelationshipVariables(pattern)
+	allVars := append(append([]string{}, nodeVars...), relVars...)
+	if len(allVars) == 0 {
+		return rows, nil
+	}
+
+	matchResult, err := e.executeMatch(ctx, "MATCH "+pattern+" RETURN "+strings.Join(allVars, ", "))
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]traversalOptRow, 0, len(matchResult.Rows))
+	for _, r := range matchResult.Rows {
+		cand := traversalOptRow{
+			nodes: make(map[string]*storage.Node, len(matchResult.Columns)),
+			rels:  make(map[string]*storage.Edge),
+		}
+		for ci, col := range matchResult.Columns {
+			if ci >= len(r) {
+				break
+			}
+			switch v := r[ci].(type) {
+			case *storage.Node:
+				cand.nodes[col] = v
+			case *storage.Edge:
+				cand.rels[col] = v
+			}
+		}
+		candidates = append(candidates, cand)
+	}
+
+	// Split the pattern variables into shared (already bound on the left) and
+	// new, using the uniform binding keys of the first row.
+	var sharedNodeVars, newNodeVars, sharedRelVars, newRelVars []string
+	for _, v := range nodeVars {
+		if _, bound := rows[0].nodes[v]; bound {
+			sharedNodeVars = append(sharedNodeVars, v)
+		} else {
+			newNodeVars = append(newNodeVars, v)
+		}
+	}
+	for _, v := range relVars {
+		if _, bound := rows[0].rels[v]; bound {
+			sharedRelVars = append(sharedRelVars, v)
+		} else {
+			newRelVars = append(newRelVars, v)
+		}
+	}
+
+	nullBindsNodes := make(map[string]*storage.Node, len(newNodeVars))
+	for _, v := range newNodeVars {
+		nullBindsNodes[v] = nil
+	}
+	nullBindsRels := make(map[string]*storage.Edge, len(newRelVars))
+	for _, v := range newRelVars {
+		nullBindsRels[v] = nil
+	}
+
+	out := make([]traversalOptRow, 0, len(rows))
+	for _, row := range rows {
+		matched := false
+		for _, cand := range candidates {
+			if !candidateAgreesWithRow(row, cand, sharedNodeVars, sharedRelVars) {
+				continue
+			}
+			nodeBinds := make(map[string]*storage.Node, len(newNodeVars))
+			for _, v := range newNodeVars {
+				nodeBinds[v] = cand.nodes[v]
+			}
+			relBinds := make(map[string]*storage.Edge, len(newRelVars))
+			for _, v := range newRelVars {
+				relBinds[v] = cand.rels[v]
+			}
+			merged := extendTraversalRowMulti(row, nodeBinds, relBinds)
+			if clause.where != "" {
+				passes, ok := e.evaluateExpressionWithContext(ctx, clause.where, merged.nodes, merged.rels).(bool)
+				if !ok || !passes {
+					continue
+				}
+			}
+			out = append(out, merged)
+			matched = true
+		}
+		if !matched {
+			out = append(out, extendTraversalRowMulti(row, nullBindsNodes, nullBindsRels))
+		}
+	}
+	return out, nil
+}
+
+// candidateAgreesWithRow reports whether a candidate's bindings for the shared
+// variables match the left row's bindings by identity. A left binding that is
+// null (an earlier optional miss) can never agree — mirroring
+// OptionalExpandAllPipe's null-source behavior, the row then null-fills.
+func candidateAgreesWithRow(row, cand traversalOptRow, sharedNodeVars, sharedRelVars []string) bool {
+	for _, v := range sharedNodeVars {
+		left := row.nodes[v]
+		right := cand.nodes[v]
+		if left == nil || right == nil || left.ID != right.ID {
+			return false
+		}
+	}
+	for _, v := range sharedRelVars {
+		left := row.rels[v]
+		right := cand.rels[v]
+		if left == nil || right == nil || left.ID != right.ID {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cypher/optional_match_traversal_units_test.go
+++ b/pkg/cypher/optional_match_traversal_units_test.go
@@ -1,0 +1,647 @@
+package cypher
+
+// Unit and behavior tests for the traversal-seeded OPTIONAL MATCH pipeline
+// helpers (optional_match_traversal*.go): pattern parsing, shape routing,
+// projection fast paths and compilation, aggregation accumulation and
+// finalization, and the runtime edge branches of the general Apply + Optional
+// path. Assertions mirror Neo4j semantics (see the Neo4j operator citations
+// in the implementation files).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func newUnitExecutor(t *testing.T) (*StorageExecutor, context.Context) {
+	t.Helper()
+	base := newTestMemoryEngine(t)
+	ns := storage.NewNamespacedEngine(base, "test")
+	return NewStorageExecutor(ns), context.Background()
+}
+
+func TestExtractRelationshipVariables_Shapes(t *testing.T) {
+	require.Equal(t, []string{"r"}, extractRelationshipVariables("(a)-[r]->(b)"), "bare variable")
+	require.Equal(t, []string{"r"}, extractRelationshipVariables("(a)-[r:T]->(b)"), "typed variable")
+	require.Equal(t, []string{"r"}, extractRelationshipVariables("(a)-[r*1..3]->(b)"), "variable-length variable")
+	require.Empty(t, extractRelationshipVariables("(a)-[:T]->(b)"), "anonymous typed relationship")
+	require.Empty(t, extractRelationshipVariables("(a)-[*2]->(b)"), "anonymous variable-length")
+	require.Equal(t, []string{"r1", "r2"}, extractRelationshipVariables("(a)-[r1:X]->(b)<-[r2:Y]-(c)"), "chain")
+}
+
+func TestInvertOptionalDirection(t *testing.T) {
+	require.Equal(t, "in", invertOptionalDirection("out"))
+	require.Equal(t, "out", invertOptionalDirection("in"))
+	require.Equal(t, "both", invertOptionalDirection("both"))
+}
+
+func TestIsSimpleTraversalIdentifier(t *testing.T) {
+	require.True(t, isSimpleTraversalIdentifier("abc"))
+	require.True(t, isSimpleTraversalIdentifier("_a1"))
+	require.False(t, isSimpleTraversalIdentifier(""))
+	require.False(t, isSimpleTraversalIdentifier("9a"), "digit first")
+	require.False(t, isSimpleTraversalIdentifier("a-b"), "operator char")
+}
+
+func TestParseOptionalClauseEndpoints_ErrorsAndRelForms(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+
+	_, err := exec.parseOptionalClauseEndpoints(ctx, "no parens here")
+	require.Error(t, err, "no node endpoint")
+	_, err = exec.parseOptionalClauseEndpoints(ctx, "(a")
+	require.Error(t, err, "unterminated source endpoint")
+	_, err = exec.parseOptionalClauseEndpoints(ctx, "(a)-[r:T]->")
+	require.Error(t, err, "no target endpoint")
+	_, err = exec.parseOptionalClauseEndpoints(ctx, "(a)-[r:T]->(b")
+	require.Error(t, err, "unterminated target endpoint")
+
+	eps, err := exec.parseOptionalClauseEndpoints(ctx, "(a)-[r:T {w:1}]->(b)")
+	require.NoError(t, err)
+	require.Equal(t, "T", eps.relType, "props stripped from relationship type")
+
+	eps, err = exec.parseOptionalClauseEndpoints(ctx, "(a)-[r:T*1..2]->(b)")
+	require.NoError(t, err)
+	require.Equal(t, "T", eps.relType, "variable-length hops stripped from type")
+
+	eps, err = exec.parseOptionalClauseEndpoints(ctx, "(a)-[r*1..2]->(b)")
+	require.NoError(t, err)
+	require.Equal(t, "r", eps.relVar, "variable-length without type keeps the variable")
+	require.Empty(t, eps.relType)
+
+	eps, err = exec.parseOptionalClauseEndpoints(ctx, "(a)-[r]->(b)")
+	require.NoError(t, err)
+	require.Equal(t, "r", eps.relVar, "bare relationship variable")
+
+	eps, err = exec.parseOptionalClauseEndpoints(ctx, "(a)<-[:T]-(b)")
+	require.NoError(t, err)
+	require.Equal(t, "in", eps.direction)
+}
+
+func TestExtendTraversalRow_NoNewBindings(t *testing.T) {
+	n := &storage.Node{ID: "n1"}
+	row := traversalOptRow{nodes: map[string]*storage.Node{"a": n}, rels: map[string]*storage.Edge{}}
+	out := extendTraversalRow(row, "", nil, "", nil)
+	require.Equal(t, n, out.nodes["a"], "copy preserves existing bindings")
+	require.Len(t, out.nodes, 1, "no new bindings added")
+}
+
+func TestFastTraversalExprValue_AllShapes(t *testing.T) {
+	node := &storage.Node{ID: "n1", Properties: map[string]interface{}{"name": "Ada"}}
+	embedded := &storage.Node{ID: "n2", Properties: map[string]interface{}{}, EmbedMeta: map[string]any{"has_embedding": true}}
+	chunked := &storage.Node{ID: "n3", Properties: map[string]interface{}{}, ChunkEmbeddings: [][]float32{{0.5}}}
+	scalar := &storage.Node{ID: "n4", Properties: map[string]interface{}{"value": int64(7)}}
+	edge := &storage.Edge{ID: "e1", Type: "REL", Properties: map[string]interface{}{"w": int64(2)}}
+	row := traversalOptRow{
+		nodes: map[string]*storage.Node{"n": node, "emb": embedded, "chk": chunked, "sc": scalar, "nilNode": nil},
+		rels:  map[string]*storage.Edge{"r": edge, "nilRel": nil},
+	}
+
+	v, ok := fastTraversalExprValue("n.name", row)
+	require.True(t, ok)
+	require.Equal(t, "Ada", v)
+
+	v, ok = fastTraversalExprValue("n.missing", row)
+	require.True(t, ok)
+	require.Nil(t, v, "missing property projects null")
+
+	v, ok = fastTraversalExprValue("nilNode.name", row)
+	require.True(t, ok)
+	require.Nil(t, v, "null binding projects null")
+
+	v, ok = fastTraversalExprValue("emb.has_embedding", row)
+	require.True(t, ok)
+	require.Equal(t, true, v, "has_embedding reads EmbedMeta")
+
+	v, ok = fastTraversalExprValue("chk.has_embedding", row)
+	require.True(t, ok)
+	require.Equal(t, true, v, "has_embedding falls back to chunk embeddings")
+
+	v, ok = fastTraversalExprValue("r.w", row)
+	require.True(t, ok)
+	require.EqualValues(t, 2, v)
+
+	v, ok = fastTraversalExprValue("r.missing", row)
+	require.True(t, ok)
+	require.Nil(t, v)
+
+	v, ok = fastTraversalExprValue("nilRel.w", row)
+	require.True(t, ok)
+	require.Nil(t, v)
+
+	_, ok = fastTraversalExprValue("unbound.x", row)
+	require.False(t, ok, "unbound variable falls back to the evaluator")
+
+	_, ok = fastTraversalExprValue("1a.b", row)
+	require.False(t, ok, "invalid identifier falls back")
+
+	v, ok = fastTraversalExprValue("n", row)
+	require.True(t, ok)
+	require.Equal(t, node, v, "bare node variable returns the node")
+
+	v, ok = fastTraversalExprValue("nilNode", row)
+	require.True(t, ok)
+	require.Nil(t, v)
+
+	v, ok = fastTraversalExprValue("sc", row)
+	require.True(t, ok)
+	require.EqualValues(t, 7, v, "single-value pseudo-node unwraps to its scalar")
+
+	v, ok = fastTraversalExprValue("r", row)
+	require.True(t, ok)
+	require.Equal(t, edge, v, "bare relationship variable returns the edge")
+
+	v, ok = fastTraversalExprValue("nilRel", row)
+	require.True(t, ok)
+	require.Nil(t, v)
+
+	_, ok = fastTraversalExprValue("unboundVar", row)
+	require.False(t, ok)
+
+	_, ok = fastTraversalExprValue("a+b", row)
+	require.False(t, ok, "non-identifier falls back")
+}
+
+func TestScanOptionalPatternShape_QuoteAware(t *testing.T) {
+	groups, brackets := scanOptionalPatternShape(`(a)-[r:T {p:'([('}]->(b)`)
+	require.Equal(t, 2, groups, "parens inside quoted strings are not node groups")
+	require.Equal(t, 1, brackets, "brackets inside quoted strings are not rel sections")
+
+	groups, brackets = scanOptionalPatternShape(`(a {s:"x(\"y["})`)
+	require.Equal(t, 1, groups)
+	require.Equal(t, 0, brackets)
+}
+
+func TestFirstParenGroup(t *testing.T) {
+	require.Equal(t, "(a:L)", firstParenGroup("(a:L)-[r]->(b)"))
+	require.Equal(t, "", firstParenGroup("no group"))
+	require.Equal(t, "", firstParenGroup("(unterminated"))
+}
+
+func TestEnsureLeadingNodeNamed(t *testing.T) {
+	require.Equal(t, "(a:L)-[:T]->(b)", ensureLeadingNodeNamed("(a:L)-[:T]->(b)"), "named pattern unchanged")
+	require.Equal(t, "("+traversalAnonVar+":L)-[:T]->(:M)", ensureLeadingNodeNamed("(:L)-[:T]->(:M)"), "anonymous pattern gets a synthetic variable")
+	require.Equal(t, "no parens", ensureLeadingNodeNamed("no parens"), "patterns without a node group pass through")
+}
+
+func TestCandidateAgreesWithRow(t *testing.T) {
+	n1 := &storage.Node{ID: "n1"}
+	n2 := &storage.Node{ID: "n2"}
+	e1 := &storage.Edge{ID: "e1"}
+	e2 := &storage.Edge{ID: "e2"}
+	row := traversalOptRow{nodes: map[string]*storage.Node{"a": n1, "nilA": nil}, rels: map[string]*storage.Edge{"r": e1}}
+
+	require.True(t, candidateAgreesWithRow(row, traversalOptRow{nodes: map[string]*storage.Node{"a": n1}, rels: map[string]*storage.Edge{"r": e1}}, []string{"a"}, []string{"r"}))
+	require.False(t, candidateAgreesWithRow(row, traversalOptRow{nodes: map[string]*storage.Node{"a": n2}}, []string{"a"}, nil), "different node identity")
+	require.False(t, candidateAgreesWithRow(row, traversalOptRow{nodes: map[string]*storage.Node{"a": n1}}, []string{"nilA"}, nil), "null left binding never agrees")
+	require.False(t, candidateAgreesWithRow(row, traversalOptRow{nodes: map[string]*storage.Node{"a": n1}, rels: map[string]*storage.Edge{"r": e2}}, []string{"a"}, []string{"r"}), "different rel identity")
+}
+
+func TestFindAggregateSpans_Boundaries(t *testing.T) {
+	require.Empty(t, findAggregateSpans("discount(x)"), "word boundary: discount is not count")
+	require.Empty(t, findAggregateSpans(`'count(x)'`), "aggregates inside string literals are ignored")
+	require.Empty(t, findAggregateSpans("count(x"), "unbalanced call is not a span")
+	require.Len(t, findAggregateSpans("count (x)"), 1, "whitespace before parens tolerated")
+	require.Len(t, findAggregateSpans("count(sum(x))"), 1, "nested aggregate reported as one outer span")
+	require.Len(t, findAggregateSpans("{c: count(*), s: sum(x)}"), 2, "aggregates inside map literals located")
+
+	spans := findAggregateSpans("1 + count(x)")
+	require.Len(t, spans, 1)
+	require.Equal(t, "count(x)", "1 + count(x)"[spans[0].start:spans[0].end])
+}
+
+func TestParseTraversalAggregateCall_Forms(t *testing.T) {
+	_, err := parseTraversalAggregateCall("notacall")
+	require.Error(t, err)
+	_, err = parseTraversalAggregateCall("bogus(x)")
+	require.Error(t, err, "not an aggregate name")
+	_, err = parseTraversalAggregateCall("count(x) + 1")
+	require.Error(t, err, "trailing content is not a whole call")
+	_, err = parseTraversalAggregateCall("count()")
+	require.Error(t, err, "empty argument list is Neo4j's own compile-time rejection")
+
+	spec, err := parseTraversalAggregateCall("count(*)")
+	require.NoError(t, err)
+	require.True(t, spec.star)
+
+	spec, err = parseTraversalAggregateCall("sum(DISTINCT x.v)")
+	require.NoError(t, err)
+	require.True(t, spec.distinct)
+	require.Equal(t, "x.v", spec.inner)
+
+	spec, err = parseTraversalAggregateCall("stdevp(x.v)")
+	require.NoError(t, err)
+	require.Equal(t, "stdevp", spec.fn)
+}
+
+func TestTraversalAggAccum_NullAndDistinct(t *testing.T) {
+	var a traversalAggAccum
+	a.add(nil, false)
+	require.Empty(t, a.values, "aggregates skip nulls")
+	a.add("x", true)
+	a.add("x", true)
+	a.add("y", true)
+	require.Len(t, a.values, 2, "DISTINCT deduplicates")
+}
+
+func TestFinalizeTraversalAggregate_AllFunctions(t *testing.T) {
+	exec, _ := newUnitExecutor(t)
+	fin := func(fn string, vals []interface{}, star bool, rows int64) interface{} {
+		return exec.finalizeTraversalAggregate(traversalAggSpec{fn: fn, star: star}, vals, rows)
+	}
+
+	require.EqualValues(t, 3, fin("count", nil, true, 3), "count(*) counts rows")
+	require.EqualValues(t, 2, fin("count", []interface{}{"a", "b"}, false, 9))
+	require.Equal(t, []interface{}{}, fin("collect", nil, false, 0), "collect identity is []")
+	require.Equal(t, []interface{}{"a"}, fin("collect", []interface{}{"a"}, false, 1))
+	require.EqualValues(t, 5, fin("sum", []interface{}{int64(2), int(3)}, false, 2))
+	require.EqualValues(t, 0, fin("sum", nil, false, 0), "sum identity is 0")
+	require.Equal(t, 5.5, fin("sum", []interface{}{int64(2), 3.5}, false, 2), "mixed types sum as float")
+	require.Nil(t, fin("sum", []interface{}{"abc"}, false, 1), "non-numeric sum is null")
+	require.Nil(t, fin("avg", nil, false, 0), "avg identity is null")
+	require.Equal(t, 2.5, fin("avg", []interface{}{int64(2), int64(3)}, false, 2))
+	require.Nil(t, fin("avg", []interface{}{"abc"}, false, 1))
+	require.Nil(t, fin("min", nil, false, 0))
+	require.EqualValues(t, 2, fin("min", []interface{}{int64(3), int64(2), int64(5)}, false, 3))
+	require.EqualValues(t, 5, fin("max", []interface{}{int64(3), int64(2), int64(5)}, false, 3))
+	require.Nil(t, fin("stdev", nil, false, 0), "stdev of empty input is null")
+	require.Equal(t, 0.0, fin("stdev", []interface{}{int64(4)}, false, 1), "stdev of one value is 0.0")
+	require.Nil(t, fin("unknownagg", nil, false, 0), "unknown function reduces to null")
+}
+
+func TestStdevTraversalAggregateValues_Contract(t *testing.T) {
+	require.Nil(t, stdevTraversalAggregateValues(nil, false), "no values: null (StdevFunction count==0)")
+	require.Nil(t, stdevTraversalAggregateValues([]interface{}{"x"}, false), "non-numeric values are skipped")
+	require.Equal(t, 0.0, stdevTraversalAggregateValues([]interface{}{int64(9)}, false), "single value: 0.0")
+	require.InDelta(t, 2.8284, stdevTraversalAggregateValues([]interface{}{int64(2), int64(6)}, false).(float64), 0.001, "sample divisor n-1")
+	require.InDelta(t, 2.0, stdevTraversalAggregateValues([]interface{}{int64(2), int64(6)}, true).(float64), 0.001, "population divisor n")
+}
+
+func TestTryCompileTraversalExpr_LiteralsAndFallbacks(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+	empty := traversalOptRow{nodes: map[string]*storage.Node{}, rels: map[string]*storage.Edge{}}
+
+	eval := func(expr string) interface{} {
+		return exec.compileTraversalProjection(ctx, expr)(empty)
+	}
+	require.Equal(t, "lit", eval("'lit'"))
+	require.Equal(t, "dq", eval(`"dq"`))
+	require.Equal(t, true, eval("true"))
+	require.Equal(t, false, eval("FALSE"))
+	require.Nil(t, eval("null"))
+	require.EqualValues(t, 42, eval("42"))
+	require.Equal(t, 3.5, eval("3.5"))
+
+	_, ok := exec.tryCompileTraversalExpr(ctx, "")
+	require.False(t, ok, "empty expression is not compilable")
+	_, ok = exec.tryCompileTraversalExpr(ctx, "a + b")
+	require.False(t, ok, "operator expressions fall back to the evaluator")
+	_, ok = exec.tryCompileTraversalFunctionCall(ctx, "(x)")
+	require.False(t, ok, "not a call")
+	_, ok = exec.tryCompileTraversalExpr(ctx, "CASE WHEN a THEN 1 ELSE 2 END")
+	require.False(t, ok, "CASE expressions are left to the evaluator")
+}
+
+// TestTraversalProjection_LiteralAndComplexItems exercises the projection
+// paths end to end: literal items, operator items, CASE items, an
+// evaluator-fallback function, and an uncompilable coalesce argument.
+func TestTraversalProjection_LiteralAndComplexItems(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN 'lit' AS s, 42 AS i, true AS b, null AS nl,
+		       CASE WHEN target.name = "Dog" THEN 1 ELSE 0 END AS flag,
+		       exists(target.name) AS ex,
+		       coalesce(CASE WHEN target.name = "X" THEN 1 ELSE null END, 99) AS bump
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "lit", row["s"])
+	require.EqualValues(t, 42, row["i"])
+	require.Equal(t, true, row["b"])
+	require.Nil(t, row["nl"])
+	require.EqualValues(t, 1, row["flag"], "CASE items evaluate through the evaluator fallback")
+	require.Equal(t, true, row["ex"], "registry-miss functions defer to the legacy evaluator")
+	require.EqualValues(t, 99, row["bump"], "uncompilable coalesce argument evaluates per row")
+}
+
+// TestTraversalOptionalMatch_NoReturnClause: a compound optional-match query
+// without RETURN produces an empty result rather than an error.
+func TestTraversalOptionalMatch_NoReturnClause(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+	`, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Rows)
+}
+
+// TestTraversalOptionalMatch_EmptySeed: an empty primary MATCH yields zero
+// rows through every downstream clause.
+func TestTraversalOptionalMatch_EmptySeed(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:NoSuch"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo)
+		RETURN target.name AS n, repo.id AS r
+	`, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Rows)
+}
+
+// TestTraversalOptionalMatch_SkipModifier: SKIP applies after projection,
+// including a SKIP past the end of the row set.
+func TestTraversalOptionalMatch_SkipModifier(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS n ORDER BY n SKIP 1 LIMIT 5
+	`, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Rows, "one Dog row, skipped past")
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS n SKIP 9
+	`, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Rows, "SKIP past the end clamps to empty")
+}
+
+// TestTraversalOptionalMatch_BothEndpointsBoundFilter: a clause whose both
+// endpoints are already bound acts as a relationship filter between them.
+func TestTraversalOptionalMatch_BothEndpointsBoundFilter(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (e)<-[:CONTAINS]-(sourceFile:OMFile)
+		OPTIONAL MATCH (sourceFile)-[cr:CONTAINS]->(target)
+		RETURN target.name AS n, sourceFile.relative_path AS p, type(cr) AS crType
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["n"])
+	require.Equal(t, "svc.py", row["p"])
+	require.Equal(t, "CONTAINS", row["crType"], "both-bound clause binds the relationship variable")
+}
+
+// TestTraversalOptionalMatch_PreBoundRelVarRoutesGeneral: re-using a bound
+// relationship variable in a later OPTIONAL MATCH is valid and joins by
+// relationship identity.
+func TestTraversalOptionalMatch_PreBoundRelVarRoutesGeneral(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (src:OMClass)-[rel]->(dst:OMClass)
+		RETURN target.name AS n, src.uid AS srcUid, dst.name AS dstName
+	`, nil)
+	require.NoError(t, err, "re-using a bound relationship variable must not error")
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["n"])
+	require.Equal(t, "cls:ServiceDog", row["srcUid"], "identity join recovers the endpoints of the bound relationship")
+	require.Equal(t, "Dog", row["dstName"])
+}
+
+// TestTraversalOptionalMatch_DisconnectedRelNullFill: a disconnected
+// relationship pattern with no matches null-fills node AND relationship
+// variables while preserving left rows.
+func TestTraversalOptionalMatch_DisconnectedRelNullFill(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (g:OMGhost)-[gr:GHOST_REL]->(h:OMGhost)
+		RETURN target.name AS n, g.id AS gid, type(gr) AS grType
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["n"])
+	require.Nil(t, row["gid"])
+	require.Nil(t, row["grType"], "unmatched relationship variable projects null")
+}
+
+// TestTraversalOptionalMatch_GeneralPathWhere: WHERE on a disconnected clause
+// referencing outer variables filters candidates per row; a predicate that
+// rejects everything null-fills.
+func TestTraversalOptionalMatch_GeneralPathWhere(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo)-[rc:REPO_CONTAINS]->(f:OMFile) WHERE f.language = e.language
+		RETURN target.name AS n, repo.id AS repoId
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, "repo:1", rowMap(t, res, 0)["repoId"], "outer-variable WHERE passes for matching language")
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo)-[rc:REPO_CONTAINS]->(f:OMFile) WHERE f.language = "go"
+		RETURN target.name AS n, repo.id AS repoId
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.Nil(t, rowMap(t, res, 0)["repoId"], "WHERE rejecting all candidates null-fills")
+}
+
+// TestSingleNodeOptionalClause_Variants: property filters, WHERE, and
+// anonymous single-node patterns.
+func TestSingleNodeOptionalClause_Variants(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo {id:"repo:1"})
+		RETURN repo.name AS rn
+	`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "repo1", res.Rows[0][0], "property-filtered scan binds")
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo {id:"nope"})
+		RETURN repo.name AS rn
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.Nil(t, res.Rows[0][0], "non-matching properties null-fill")
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo) WHERE repo.name = "repo1"
+		RETURN repo.id AS ri
+	`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "repo:1", res.Rows[0][0], "WHERE on the scanned node applies")
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (repo:OMRepo) WHERE repo.name = "other"
+		RETURN repo.id AS ri
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.Nil(t, res.Rows[0][0], "WHERE rejecting the scan null-fills")
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (:OMRepo)
+		RETURN target.name AS n
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1, "anonymous single-node pattern preserves multiplicity via one match")
+	require.Equal(t, "Dog", res.Rows[0][0])
+}
+
+// TestTraversalAggregate_ShapeVariants: grouped count(*), DISTINCT, mixed
+// expressions with count(*), and empty-input identities.
+func TestTraversalAggregate_ShapeVariants(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS n, count(*) AS rows, count(DISTINCT tf.language) AS langs
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.EqualValues(t, 1, row["rows"])
+	require.EqualValues(t, 1, row["langs"])
+
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN count(*) + 1 AS bumpedRows
+	`, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, res.Rows[0][0], "count(*) inside a larger expression")
+
+	// Empty ungrouped input: identity values flow through mixed expressions.
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:NoSuch"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN count(tf) + 1 AS c, collect(tf.relative_path) AS paths, avg(rel.weight) AS a
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1, "ungrouped aggregation over empty input yields one identity row")
+	row = rowMap(t, res, 0)
+	require.EqualValues(t, 1, row["c"], "count identity 0 + 1")
+	require.Equal(t, []interface{}{}, row["paths"])
+	require.Nil(t, row["a"])
+
+	// Empty input WITH grouping keys: zero rows.
+	res, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:NoSuch"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN target.name AS n, count(tf) AS c
+	`, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Rows, "grouped aggregation over empty input yields zero rows")
+}
+
+// TestTraversalAggregate_EmptyArgumentErrors: count() is the one genuinely
+// rejected form — Neo4j itself refuses it at compile time.
+func TestTraversalAggregate_EmptyArgumentErrors(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+
+	_, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN count() AS c
+	`, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient parameters")
+
+	_, err = exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(tf:OMFile)
+		RETURN count() + 1 AS c
+	`, nil)
+	require.Error(t, err, "empty argument inside a mixed expression is rejected the same way")
+}
+
+func TestExtractRelationshipVariables_Whitespace(t *testing.T) {
+	require.Equal(t, []string{"r"}, extractRelationshipVariables("(a)-[ r :T ]->(b)"), "whitespace around the variable is tolerated")
+	require.Empty(t, extractRelationshipVariables("(a)-[ :T ]->(b)"), "whitespace before an anonymous type yields no variable")
+}
+
+// TestTraversalOptionalMatch_NullSeedPropagatesThroughChain: a variable
+// null-bound by an earlier optional miss seeds a later clause; the later
+// clause propagates nulls instead of erroring or dropping the row
+// (OptionalExpandAllPipe's NO_VALUE source behavior).
+func TestTraversalOptionalMatch_NullSeedPropagatesThroughChain(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (e:OMClass {uid:"cls:ServiceDog"})-[rel:INHERITS]->(target)
+		OPTIONAL MATCH (target)<-[:CONTAINS]-(ghost:OMGhostFile)
+		OPTIONAL MATCH (ghost)<-[:REPO_CONTAINS]-(r2:OMRepo)
+		RETURN target.name AS n, ghost.uid AS g, r2.id AS r2id
+	`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	row := rowMap(t, res, 0)
+	require.Equal(t, "Dog", row["n"])
+	require.Nil(t, row["g"], "first optional missed: ghost is null")
+	require.Nil(t, row["r2id"], "null seed propagates null bindings through the chained clause")
+}
+
+// TestTraversalOptionalMatch_AnonymousSeedPattern: a fully anonymous primary
+// traversal still supports trailing OPTIONAL MATCH clauses.
+func TestTraversalOptionalMatch_AnonymousSeedPattern(t *testing.T) {
+	exec, ctx := newOptProjExecutor(t)
+	res, err := exec.Execute(ctx, `
+		MATCH (:OMClass {uid:"cls:ServiceDog"})-[:INHERITS]->(:OMClass)
+		OPTIONAL MATCH (repo:OMRepo)
+		RETURN repo.id AS ri
+	`, nil)
+	require.NoError(t, err, "anonymous seed patterns must not error")
+	// The seed executes as RETURN * (no named variables); the engine yields
+	// one seed row here, and the disconnected optional binds on it.
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, "repo:1", res.Rows[0][0])
+}
+
+func TestFindAggregateSpans_NameWithoutCall(t *testing.T) {
+	require.Empty(t, findAggregateSpans("a + count"), "an aggregate name with no argument list is not a span")
+	require.Empty(t, findAggregateSpans("count"), "a bare trailing aggregate name is not a span")
+}
+
+func TestApplySingleNodeOptionalClause_NoParenGroup(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+	rows := []traversalOptRow{{nodes: map[string]*storage.Node{"a": {ID: "n1"}}, rels: map[string]*storage.Edge{}}}
+	out, err := exec.applySingleNodeOptionalClause(ctx, rows, optionalMatchClause{pattern: "garbage"})
+	require.NoError(t, err)
+	require.Equal(t, rows, out, "a pattern without a node group passes rows through")
+}
+
+func TestApplyGeneralOptionalClause_EdgeInputs(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+
+	out, err := exec.applyGeneralOptionalClause(ctx, nil, optionalMatchClause{pattern: "(x:L)-[:T]->(y:M)"})
+	require.NoError(t, err)
+	require.Empty(t, out, "no left rows: nothing to join")
+
+	rows := []traversalOptRow{{nodes: map[string]*storage.Node{"a": {ID: "n1"}}, rels: map[string]*storage.Edge{}}}
+	out, err = exec.applyGeneralOptionalClause(ctx, rows, optionalMatchClause{pattern: "novars"})
+	require.NoError(t, err)
+	require.Equal(t, rows, out, "a pattern with no variables and no node group passes rows through")
+}
+
+func TestCompiledVarProjection_UnboundFallsBackToEvaluator(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+	row := traversalOptRow{nodes: map[string]*storage.Node{}, rels: map[string]*storage.Edge{}}
+	compiled := exec.compileTraversalProjection(ctx, "zzz.prop")(row)
+	direct := exec.evaluateExpressionWithContext(ctx, "zzz.prop", row.nodes, row.rels)
+	require.Equal(t, direct, compiled,
+		"an unbound variable projection must produce exactly the full evaluator's result")
+}

--- a/pkg/cypher/optional_match_traversal_units_test.go
+++ b/pkg/cypher/optional_match_traversal_units_test.go
@@ -645,3 +645,87 @@ func TestCompiledVarProjection_UnboundFallsBackToEvaluator(t *testing.T) {
 	require.Equal(t, direct, compiled,
 		"an unbound variable projection must produce exactly the full evaluator's result")
 }
+
+// TestSupport_DisconnectedOptionalBareVarReturn pins the exact review shape
+// "MATCH (a)-[r]->(b) OPTIONAL MATCH (x:X) RETURN a, x": a trailing OPTIONAL
+// MATCH with no previously bound variable is a legal disconnected optional
+// pattern (Neo4j plans it as Apply + Optional; OptionalPipe.scala null-fills
+// when the pattern has no matches). Bare-variable projections return real
+// node entities.
+func TestSupport_DisconnectedOptionalBareVarReturn(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+	_, err := exec.Execute(ctx, `CREATE (a:PN {name:"a"})-[:T {n:1}]->(b:PN {name:"b"})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `CREATE (x:XX {name:"only-x"})`, nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `MATCH (a:PN {name:"a"})-[r]->(b) OPTIONAL MATCH (x:XX) RETURN a, x`, nil)
+	require.NoError(t, err, "a disconnected OPTIONAL MATCH must never be rejected")
+	require.Len(t, res.Rows, 1)
+	aNode, ok := res.Rows[0][0].(*storage.Node)
+	require.True(t, ok, "bare a projects the node entity")
+	require.Equal(t, "a", aNode.Properties["name"])
+	xNode, ok := res.Rows[0][1].(*storage.Node)
+	require.True(t, ok, "bare x projects the independently matched node entity")
+	require.Equal(t, "only-x", xNode.Properties["name"])
+
+	// And the null-fill side: no OMNever nodes exist.
+	res, err = exec.Execute(ctx, `MATCH (a:PN {name:"a"})-[r]->(b) OPTIONAL MATCH (x:OMNever) RETURN a, x`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1, "left row preserved")
+	require.Nil(t, res.Rows[0][1], "unmatched disconnected variable is null")
+}
+
+// TestSupport_ReboundRelVariableIsIdentityConstraint pins the parallel-edge
+// invariant the executor already enforces for chained MATCH
+// (multi_match_relationship_binding_bug_test.go: "same relationship variable
+// only counts rows for the same edge" / "rejects rows that would overwrite
+// the bound edge") on the traversal OPTIONAL MATCH path. Neo4j's planner
+// makes the same choice: a pattern relationship whose variable is already in
+// availableSymbols is planned as ProjectEndpoints over the bound edge, never
+// as a fresh expansion (cypher-planner .../idp/expandSolverStep.scala,
+// plansForNodeConnection). With two parallel :T edges between a and b,
+// re-referencing r must yield one row per originally bound edge and must not
+// overwrite r.
+func TestSupport_ReboundRelVariableIsIdentityConstraint(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+	_, err := exec.Execute(ctx, `CREATE (a:PN {name:"a"})-[:T {n:1}]->(b:PN {name:"b"})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `MATCH (a:PN {name:"a"}) MATCH (b:PN {name:"b"}) CREATE (a)-[:T {n:2}]->(b)`, nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `MATCH (a:PN)-[r:T]->(b:PN) OPTIONAL MATCH (a)-[r]->(b) RETURN count(*) AS c`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.EqualValues(t, 2, res.Rows[0][0],
+		"one row per originally bound edge — re-referencing r must not fan out across parallel edges")
+
+	res, err = exec.Execute(ctx, `MATCH (a:PN)-[r:T {n:1}]->(b:PN) OPTIONAL MATCH (a)-[r]->(b) RETURN r.n AS n`, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1)
+	require.EqualValues(t, 1, res.Rows[0][0],
+		"r keeps its original edge binding — the n:2 parallel edge must not overwrite it")
+}
+
+// TestSupport_StdevMixedCaseAggregate: aggregate names are case-insensitive
+// on the traversal OPTIONAL MATCH path, matching the executor-wide registry
+// (aggregateFnNames in clauses.go).
+func TestSupport_StdevMixedCaseAggregate(t *testing.T) {
+	exec, ctx := newUnitExecutor(t)
+	_, err := exec.Execute(ctx, `CREATE (a:PN {name:"a"})-[:T {n:1}]->(b:PN {name:"b"})`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `MATCH (a:PN {name:"a"}) MATCH (b:PN {name:"b"}) CREATE (a)-[:T {n:2}]->(b)`, nil)
+	require.NoError(t, err)
+	_, err = exec.Execute(ctx, `CREATE (x:XX {name:"only-x"})`, nil)
+	require.NoError(t, err)
+
+	res, err := exec.Execute(ctx, `
+		MATCH (a:PN {name:"a"})-[r:T]->(b)
+		OPTIONAL MATCH (x:XX)
+		RETURN stDev(r.n) AS s, STDEVP(r.n) AS sp
+	`, nil)
+	require.NoError(t, err, "mixed-case stDev/STDEVP must be supported like the rest of the executor")
+	require.Len(t, res.Rows, 1)
+	require.InDelta(t, 0.70710678, res.Rows[0][0].(float64), 1e-6, "sample stdev of {1,2}")
+	require.InDelta(t, 0.5, res.Rows[0][1].(float64), 1e-6, "population stdev of {1,2}")
+}


### PR DESCRIPTION
## What's broken

Do a `MATCH` that binds a relationship, then a trailing `OPTIONAL MATCH` with no `WITH` between them, and the `RETURN` comes back wrong. `type(rel)` comes back as the literal string `"type(rel)"`, the `rel` variable never binds, chained `OPTIONAL MATCH` clauses get dropped, and aggregates don't evaluate. So a query like "give me this class's INHERITS edges plus the file each one lives in" silently returns garbage for the computed columns.

My first pass at this failed loud on the shapes it didn't handle, which was the wrong call. This version supports every valid shape by doing what Neo4j does. I pulled the Neo4j source (`community/cypher`) and copied the real semantics instead of guessing.

## Behavior, before and after

| Shape | Before | After |
|---|---|---|
| `type(rel)`, `coalesce(...)`, `head(labels(...))` after a trailing OPTIONAL MATCH | returned as literal text (`"type(rel)"`) | evaluated |
| bare `rel` / `rel.prop` | literal text (`"rel"`) | bound to the real edge |
| chained 2nd+ OPTIONAL MATCH | silently swallowed | applied |
| disconnected OPTIONAL MATCH — `MATCH (a)-[r]->(b) OPTIONAL MATCH (x:X) RETURN a, x` | rejected (fail-loud) | supported: left-outer join, null-fill on no match |
| rebound rel var on parallel edges — `MATCH (a)-[r:T]->(b) OPTIONAL MATCH (a)-[r]->(b) RETURN count(*)` | fanned out over parallel edges, overwrote `r` | identity constraint: one row per originally bound edge (`count(*)=2`, no overwrite) |
| aggregates — `stDev`, `STDEVP`, `count(tf)+1`, `coalesce(sum(w),0)` | errored / narrowed set | full executor registry, case-insensitive |

## How it works now

The Neo4j operators I mirrored (`community/cypher/`):

- `OptionalPipe` / `ApplyPipe` / `OptionalExpandAllPipe` — for each left row, run the inner pattern; on no match keep the row and null the new variables. This is the general Apply+Optional path that handles disconnected, multi-hop, and pre-bound-rel-var shapes.
- A rel var already in scope is an identity constraint, not a fresh expansion — same as `planSingleProjectEndpoints` in `expandSolverStep.scala`, and the same invariant NornicDB already asserts at `multi_match_relationship_binding_bug_test.go:364-375`.
- `EagerAggregationPipe` + the front-end `isolateAggregation` rewrite for mixed aggregate expressions, and `StdevFunction` (Welford) for `stdev`/`stdevp`.

The only thing that still errors is `count()` with no argument, which Neo4j rejects at parse time too. The old fail-loud-multiclause commit is dropped; this branch is rebased onto `main`.

## Performance

Kept the pre-compilation pass from the earlier tuning. Wall-clock had too much machine noise to trust, so these are the deterministic alloc counts (3-way interleaved, cache-off, precompiled binaries):

| Shape | corrupt `main` | pre-support | support |
|---|---|---|---|
| SingleSeedChained allocs/op | 2241 / 154.9KB | 2352 / 166.3KB | 2353 / 166.3KB |
| FanOutProjection allocs/op | 6459 / 549.4KB | 6175 / 588.2KB | 6175 / 588.2KB (below corrupt baseline) |

The support rework adds nothing measurable over the pre-compilation pipeline, and fan-out still allocates less than the original corrupt path.

## Tests

The four corruption cases go red without the fix and green with it, plus a control, the fix-behavior tests, and named regression tests for each shape the maintainer flagged — `TestSupport_DisconnectedOptionalBareVarReturn`, `TestSupport_ReboundRelVariableIsIdentityConstraint`, `TestSupport_StdevMixedCaseAggregate`. Full `pkg/cypher` and `pkg/bolt` are green, coverage is 90.3% (the four pipeline files 96.6-100%), and I rebuilt the binary and re-checked it live over Bolt.
