### PR TITLE
fix(cypher): evaluate label tests and function calls in a WITH-attached WHERE

### DIFF
--- a/pkg/cypher/match_rows.go
+++ b/pkg/cypher/match_rows.go
@@ -205,9 +205,8 @@ func (e *StorageExecutor) evaluateWithWhereCondition(ctx context.Context, whereC
 	// operands by locating a dot, and the dot inside `coalesce(a.name, 'X')`
 	// makes them look up a variable named "coalesce(a".
 	if strings.Contains(whereClause, "(") {
-		nodeCtx, edgeCtx := withWhereValueContext(values)
-		return evaluateExpressionBoolWithContext(e, ctx,
-			substituteWithWhereLabelTests(whereClause, values), nodeCtx, edgeCtx)
+		return e.evaluateWhereOnComputedRow(ctx,
+			substituteWithWhereLabelTests(whereClause, values), values)
 	}
 
 	// Handle IS NULL / IS NOT NULL

--- a/pkg/cypher/match_rows.go
+++ b/pkg/cypher/match_rows.go
@@ -306,10 +306,9 @@ func parseWithWhereLabelTest(whereClause string) (string, []string, bool) {
 	if !withWhereIsLabelTest(whereClause) {
 		return "", nil, false
 	}
+	// withWhereIsLabelTest has already established there is at least one colon
+	// with a non-empty segment either side, so Split yields two or more parts.
 	parts := strings.Split(strings.TrimSpace(whereClause), ":")
-	if len(parts) < 2 {
-		return "", nil, false
-	}
 	variable := strings.TrimSpace(parts[0])
 	labels := make([]string, 0, len(parts)-1)
 	for _, part := range parts[1:] {

--- a/pkg/cypher/match_rows.go
+++ b/pkg/cypher/match_rows.go
@@ -200,6 +200,16 @@ func (e *StorageExecutor) evaluateWithWhereCondition(ctx context.Context, whereC
 		return e.parseValue(ctx, expr), false
 	}
 
+	// A function call anywhere in the predicate has to go to the general
+	// evaluator before the string-surgery branches below see it: they resolve
+	// operands by locating a dot, and the dot inside `coalesce(a.name, 'X')`
+	// makes them look up a variable named "coalesce(a".
+	if strings.Contains(whereClause, "(") {
+		nodeCtx, edgeCtx := withWhereValueContext(values)
+		return evaluateExpressionBoolWithContext(e, ctx,
+			substituteWithWhereLabelTests(whereClause, values), nodeCtx, edgeCtx)
+	}
+
 	// Handle IS NULL / IS NOT NULL
 	if strings.Contains(upperClause, " IS NOT NULL") {
 		idx := strings.Index(upperClause, " IS NOT NULL")
@@ -212,6 +222,24 @@ func (e *StorageExecutor) evaluateWithWhereCondition(ctx context.Context, whereC
 		varName := strings.TrimSpace(whereClause[:idx])
 		val, exists := resolveValue(varName)
 		return !exists || val == nil
+	}
+
+	// Predicates this function cannot decompose by string surgery -- label
+	// tests (n:Label), boolean combinations, and any expression containing a
+	// function call -- are handed to the general expression evaluator, which
+	// already understands them. Splitting `toUpper(w.name) = 'X'` on "=" and
+	// resolving the left side by looking for a dot finds the dot *inside* the
+	// call and looks up a variable named "toUpper(w", which never resolves.
+	if variable, labels, ok := parseWithWhereLabelTest(whereClause); ok {
+		return withWhereNodeHasAllLabels(values[variable], labels)
+	}
+	if withWhereNeedsFullEvaluator(whereClause) {
+		nodeCtx, edgeCtx := withWhereValueContext(values)
+		// Label tests are resolved here and substituted as boolean literals so
+		// that combinations like `n:A OR n:B` work. The general evaluator
+		// handles the booleans but does not accept the `var:Label` form.
+		resolved := substituteWithWhereLabelTests(whereClause, values)
+		return evaluateExpressionBoolWithContext(e, ctx, resolved, nodeCtx, edgeCtx)
 	}
 
 	// Handle comparison operators
@@ -241,7 +269,196 @@ func (e *StorageExecutor) evaluateWithWhereCondition(ctx context.Context, whereC
 		}
 	}
 
-	return true // No recognized condition, include all
+	// A predicate none of the paths above recognised falls through as a
+	// pass-through, which is long-standing behaviour pinned by
+	// TestEvaluateWithWhereCondition_DirectBranches. It is worth knowing that
+	// this makes an unsupported filter behave as no filter at all rather than
+	// as an error; the label-test and function-call paths above exist because
+	// two such predicates were reaching here and silently admitting every row.
+	return true
+}
+
+// withWhereNeedsFullEvaluator reports whether a WITH-attached WHERE predicate
+// has to go through the general expression evaluator rather than this
+// function's operator splitting. Function calls break the split because the
+// call's own parentheses and dots confuse left/right resolution; label tests
+// and boolean combinations have no operator to split on at all.
+func withWhereNeedsFullEvaluator(whereClause string) bool {
+	if strings.ContainsAny(whereClause, "(") {
+		return true
+	}
+	upper := strings.ToUpper(whereClause)
+	for _, tok := range []string{" AND ", " OR ", " XOR ", "NOT "} {
+		if strings.Contains(upper, tok) {
+			return true
+		}
+	}
+	// A bare label test such as `n:Workload` or `n:A:B`.
+	return withWhereIsLabelTest(whereClause)
+}
+
+// parseWithWhereLabelTest splits a bare label test such as `n:Workload` or
+// `n:A:B` into its variable and required labels. Label tests carry no
+// comparison operator, so operator splitting never sees them, and the general
+// expression evaluator does not accept the `var:Label` form either -- it has to
+// be evaluated here.
+func parseWithWhereLabelTest(whereClause string) (string, []string, bool) {
+	if !withWhereIsLabelTest(whereClause) {
+		return "", nil, false
+	}
+	parts := strings.Split(strings.TrimSpace(whereClause), ":")
+	if len(parts) < 2 {
+		return "", nil, false
+	}
+	variable := strings.TrimSpace(parts[0])
+	labels := make([]string, 0, len(parts)-1)
+	for _, part := range parts[1:] {
+		labels = append(labels, strings.TrimSpace(part))
+	}
+	return variable, labels, true
+}
+
+// withWhereNodeHasAllLabels reports whether a bound value is a node carrying
+// every required label. Cypher's `n:A:B` is a conjunction, so every label must
+// be present; a value that is not a node cannot satisfy a label test.
+func withWhereNodeHasAllLabels(value interface{}, required []string) bool {
+	node, ok := value.(*storage.Node)
+	if !ok || node == nil {
+		return false
+	}
+	for _, want := range required {
+		found := false
+		for _, have := range node.Labels {
+			if have == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// withWhereIsLabelTest reports whether the predicate is a bare label test,
+// which carries no comparison operator and so is invisible to operator
+// splitting.
+func withWhereIsLabelTest(whereClause string) bool {
+	trimmed := strings.TrimSpace(whereClause)
+	if !strings.Contains(trimmed, ":") {
+		return false
+	}
+	if strings.ContainsAny(trimmed, "<>=!'\"") {
+		return false
+	}
+	for _, part := range strings.Split(trimmed, ":") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r != '_' && !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// substituteWithWhereLabelTests replaces every `var:Label` test in a predicate
+// with the boolean literal it evaluates to, so a predicate combining label
+// tests with AND/OR/NOT can be handed to the general expression evaluator,
+// which understands the boolean operators but not the label-test form.
+//
+// Only tokens shaped exactly like an identifier followed by one or more
+// `:Label` segments are rewritten, and only outside string literals, so a colon
+// inside quoted text or a map literal is left alone.
+func substituteWithWhereLabelTests(whereClause string, values map[string]interface{}) string {
+	var out strings.Builder
+	inSingle, inDouble := false, false
+	i := 0
+	for i < len(whereClause) {
+		c := whereClause[i]
+		switch {
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+		}
+		if inSingle || inDouble {
+			out.WriteByte(c)
+			i++
+			continue
+		}
+		if !isWithWhereIdentStart(c) || (i > 0 && isWithWhereIdentPart(whereClause[i-1])) {
+			out.WriteByte(c)
+			i++
+			continue
+		}
+		j := i
+		for j < len(whereClause) && isWithWhereIdentPart(whereClause[j]) {
+			j++
+		}
+		if j >= len(whereClause) || whereClause[j] != ':' {
+			out.WriteString(whereClause[i:j])
+			i = j
+			continue
+		}
+		variable := whereClause[i:j]
+		labels := []string{}
+		k := j
+		for k < len(whereClause) && whereClause[k] == ':' {
+			k++
+			start := k
+			for k < len(whereClause) && isWithWhereIdentPart(whereClause[k]) {
+				k++
+			}
+			if start == k {
+				labels = nil
+				break
+			}
+			labels = append(labels, whereClause[start:k])
+		}
+		if len(labels) == 0 {
+			out.WriteString(whereClause[i:j])
+			i = j
+			continue
+		}
+		if withWhereNodeHasAllLabels(values[variable], labels) {
+			out.WriteString("true")
+		} else {
+			out.WriteString("false")
+		}
+		i = k
+	}
+	return out.String()
+}
+
+func isWithWhereIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isWithWhereIdentPart(c byte) bool {
+	return isWithWhereIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+// withWhereValueContext splits the computed WITH values into the node and edge
+// maps the general expression evaluator expects. Non-graph values (scalars,
+// lists, aggregates) are not representable in those maps and are left out; a
+// predicate over them is handled by this function's own operator paths.
+func withWhereValueContext(values map[string]interface{}) (map[string]*storage.Node, map[string]*storage.Edge) {
+	nodeCtx := make(map[string]*storage.Node)
+	edgeCtx := make(map[string]*storage.Edge)
+	for name, val := range values {
+		switch v := val.(type) {
+		case *storage.Node:
+			nodeCtx[name] = v
+		case *storage.Edge:
+			edgeCtx[name] = v
+		}
+	}
+	return nodeCtx, edgeCtx
 }
 
 // filterNodesByWhereClause filters nodes based on a WHERE clause condition.

--- a/pkg/cypher/match_with_rel.go
+++ b/pkg/cypher/match_with_rel.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	cypherfn "github.com/orneryd/nornicdb/pkg/cypher/fn"
 	"github.com/orneryd/nornicdb/pkg/storage"
 )
 
@@ -711,6 +712,7 @@ func (e *StorageExecutor) executeMatchRelationshipsWithClause(ctx context.Contex
 // evaluateWhereOnComputedRow evaluates a WHERE condition on computed values
 func (e *StorageExecutor) evaluateWhereOnComputedRow(ctx context.Context, whereClause string, values map[string]interface{}) bool {
 	whereClause = strings.TrimSpace(whereClause)
+	upperClause := strings.ToUpper(whereClause)
 
 	// Handle AND
 	if idx := strings.Index(strings.ToUpper(whereClause), " AND "); idx > 0 {
@@ -724,6 +726,15 @@ func (e *StorageExecutor) evaluateWhereOnComputedRow(ctx context.Context, whereC
 		left := whereClause[:idx]
 		right := whereClause[idx+4:]
 		return e.evaluateWhereOnComputedRow(ctx, left, values) || e.evaluateWhereOnComputedRow(ctx, right, values)
+	}
+
+	if strings.HasSuffix(upperClause, " IS NOT NULL") {
+		expr := strings.TrimSpace(whereClause[:len(whereClause)-len(" IS NOT NULL")])
+		return e.evaluateExpressionFromValues(expr, values) != nil
+	}
+	if strings.HasSuffix(upperClause, " IS NULL") {
+		expr := strings.TrimSpace(whereClause[:len(whereClause)-len(" IS NULL")])
+		return e.evaluateExpressionFromValues(expr, values) == nil
 	}
 
 	// Handle a bare label test such as `n:Workload` or `n:A:B`. It carries no
@@ -833,6 +844,31 @@ func (e *StorageExecutor) evaluateExpressionFromValues(expr string, values map[s
 
 	// Handle function calls
 	if strings.Contains(expr, "(") && strings.Contains(expr, ")") {
+		if name, inner, ok := parseFunctionCallWS(expr); ok &&
+			(strings.EqualFold(name, "toLower") || strings.EqualFold(name, "toUpper")) {
+			nodeCtx, edgeCtx := withWhereValueContext(values)
+			functionCtx := cypherfn.Context{
+				Nodes: nodeCtx,
+				Rels:  edgeCtx,
+				Eval: func(argExpr string) (interface{}, error) {
+					value := e.evaluateExpressionFromValues(argExpr, values)
+					if literal, ok := value.(string); ok && literal == strings.TrimSpace(argExpr) {
+						if parsed, parsedOK := parseLiteralValueFromComputedRow(argExpr); parsedOK {
+							value = parsed
+						}
+					}
+					return value, nil
+				},
+				Now: time.Now,
+			}
+			if value, found, err := cypherfn.EvaluateFunction(name, e.splitFunctionArgs(inner), functionCtx); found {
+				if err != nil {
+					return nil
+				}
+				return value
+			}
+		}
+
 		if isFunctionCall(expr, "datetime") {
 			inner := strings.TrimSpace(expr[9 : len(expr)-1])
 			if inner == "" {

--- a/pkg/cypher/match_with_rel.go
+++ b/pkg/cypher/match_with_rel.go
@@ -726,6 +726,14 @@ func (e *StorageExecutor) evaluateWhereOnComputedRow(ctx context.Context, whereC
 		return e.evaluateWhereOnComputedRow(ctx, left, values) || e.evaluateWhereOnComputedRow(ctx, right, values)
 	}
 
+	// Handle a bare label test such as `n:Workload` or `n:A:B`. It carries no
+	// comparison operator, so without this branch it falls through to the
+	// pass-through at the end of this function and admits every row -- the
+	// filter is silently not applied.
+	if variable, labels, ok := parseWithWhereLabelTest(whereClause); ok {
+		return withWhereNodeHasAllLabels(values[variable], labels)
+	}
+
 	// Handle comparison operators
 	for _, op := range []string{">=", "<=", "<>", "!=", "=", ">", "<"} {
 		if idx := strings.Index(whereClause, op); idx > 0 {

--- a/pkg/cypher/with_where_filter_bugs_test.go
+++ b/pkg/cypher/with_where_filter_bugs_test.go
@@ -1,0 +1,92 @@
+// Regression tests for three Cypher evaluation defects observed against
+// Neo4j 5.x community as the reference implementation. Each test states the
+// Neo4j-measured result in its comment; a failure means NornicDB diverges from
+// that reference.
+
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func setupWithWhereFixture(t *testing.T, store storage.Engine) {
+	t.Helper()
+	ctx := context.Background()
+	exec := NewStorageExecutor(store)
+	for _, q := range []string{
+		`CREATE (f:Function {uid: 'fn1', name: 'Caller'})`,
+		`CREATE (a:CloudAction {action: 's3:GetObject'})`,
+		`CREATE (w:Workload {id: 'w1', name: 'checkout'})`,
+		`MATCH (f:Function {uid: 'fn1'}) MATCH (a:CloudAction {action: 's3:GetObject'}) CREATE (f)-[:INVOKES_CLOUD_ACTION]->(a)`,
+		`MATCH (f:Function {uid: 'fn1'}) MATCH (w:Workload {id: 'w1'}) CREATE (f)-[:RUNS_IN]->(w)`,
+	} {
+		_, err := exec.Execute(ctx, q, nil)
+		require.NoError(t, err, "fixture query failed: %s", q)
+	}
+}
+
+// A WHERE attached to a WITH must filter. Neo4j 5 returns 1; a label test in
+// this clause position is currently dropped, so every node comes back.
+func TestBug_WithAttachedWhereLabelTestIsIgnored(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+	setupWithWhereFixture(t, store)
+
+	result, err := exec.Execute(ctx, `MATCH (n) WITH n WHERE n:Workload RETURN count(*) AS c`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.EqualValues(t, 1, result.Rows[0][0],
+		"WITH-attached WHERE must filter by label; Neo4j 5 returns 1")
+}
+
+// The same predicate placed before the WITH is the documented workaround and
+// must keep working — it is the control for the test above.
+func TestBug_WhereBeforeWithStillFilters(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+	setupWithWhereFixture(t, store)
+
+	result, err := exec.Execute(ctx, `MATCH (n) WHERE n:Workload WITH n RETURN count(*) AS c`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.EqualValues(t, 1, result.Rows[0][0])
+}
+
+// A function call on a bound variable inside a WITH-attached WHERE must be
+// evaluated, not short-circuited to NULL. Neo4j 5 returns 1.
+func TestBug_WithAttachedWhereFunctionCallEvaluatesNull(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+	setupWithWhereFixture(t, store)
+
+	result, err := exec.Execute(ctx,
+		`MATCH (w:Workload) WITH w WHERE toUpper(w.name) = 'CHECKOUT' RETURN count(*) AS c`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.EqualValues(t, 1, result.Rows[0][0],
+		"toUpper on a bound variable must evaluate; Neo4j 5 returns 1")
+}
+
+// A disjunction of label tests in a WITH-attached WHERE is the shape real
+// traversal whitelists use. Neo4j 5 returns 2 here (the Workload and the
+// CloudAction), not 3.
+func TestBug_WithAttachedWhereLabelDisjunction(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+	setupWithWhereFixture(t, store)
+
+	result, err := exec.Execute(ctx,
+		`MATCH (n) WITH n WHERE n:Workload OR n:CloudAction RETURN count(*) AS c`, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+	require.EqualValues(t, 2, result.Rows[0][0],
+		"a disjunction of label tests must filter; Neo4j 5 returns 2")
+}

--- a/pkg/cypher/with_where_filter_bugs_test.go
+++ b/pkg/cypher/with_where_filter_bugs_test.go
@@ -74,6 +74,35 @@ func TestBug_WithAttachedWhereFunctionCallEvaluatesNull(t *testing.T) {
 		"toUpper on a bound variable must evaluate; Neo4j 5 returns 1")
 }
 
+func TestBug_WithAttachedWhereFunctionCallOnComputedValues(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+	setupWithWhereFixture(t, store)
+
+	t.Run("function result is null after path traversal", func(t *testing.T) {
+		result, err := exec.Execute(ctx, `
+			MATCH (f:Function)-[*1..2]->(impacted)
+			WITH impacted WHERE coalesce(impacted.id, 'X') IS NULL
+			RETURN count(*) AS c`, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Rows, 1)
+		require.EqualValues(t, 0, result.Rows[0][0],
+			"a non-null coalesce result must not pass IS NULL; Neo4j 5 returns 0")
+	})
+
+	t.Run("function consumes a scalar WITH alias", func(t *testing.T) {
+		result, err := exec.Execute(ctx, `
+			MATCH (w:Workload)
+			WITH w.name AS name WHERE toUpper(name) = 'CHECKOUT'
+			RETURN count(*) AS c`, nil)
+		require.NoError(t, err)
+		require.Len(t, result.Rows, 1)
+		require.EqualValues(t, 1, result.Rows[0][0],
+			"functions in a WITH-attached WHERE must retain scalar aliases; Neo4j 5 returns 1")
+	})
+}
+
 // A disjunction of label tests in a WITH-attached WHERE is the shape real
 // traversal whitelists use. Neo4j 5 returns 2 here (the Workload and the
 // CloudAction), not 3.

--- a/pkg/cypher/with_where_filter_units_test.go
+++ b/pkg/cypher/with_where_filter_units_test.go
@@ -1,0 +1,322 @@
+// Unit tests for the WITH-attached WHERE predicate helpers. These cover the
+// branches the end-to-end regression tests in with_where_filter_bugs_test.go
+// cannot reach directly: malformed input, non-node bindings, quoting, and
+// concurrent evaluation.
+
+package cypher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/orneryd/nornicdb/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithWhereIsLabelTest(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple label test", "n:Workload", true},
+		{"conjunction of labels", "n:A:B", true},
+		{"underscore and digits", "n_1:Label_2", true},
+		{"surrounding whitespace", "  n:Workload  ", true},
+		{"no colon at all", "n.name", false},
+		{"comparison operator present", "n:Workload = 1", false},
+		{"single quote present", "n:'Workload'", false},
+		{"double quote present", "n:\"Workload\"", false},
+		{"empty segment after colon", "n:", false},
+		{"empty segment before colon", ":Workload", false},
+		{"double colon leaves an empty segment", "n::Workload", false},
+		{"property access is not a label test", "n:a.b", false},
+		{"empty string", "", false},
+		{"whitespace only", "   ", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, withWhereIsLabelTest(tc.input))
+		})
+	}
+}
+
+func TestParseWithWhereLabelTest(t *testing.T) {
+	t.Run("single label", func(t *testing.T) {
+		variable, labels, ok := parseWithWhereLabelTest("n:Workload")
+		require.True(t, ok)
+		assert.Equal(t, "n", variable)
+		assert.Equal(t, []string{"Workload"}, labels)
+	})
+
+	t.Run("conjunction keeps every label", func(t *testing.T) {
+		variable, labels, ok := parseWithWhereLabelTest("node:A:B:C")
+		require.True(t, ok)
+		assert.Equal(t, "node", variable)
+		assert.Equal(t, []string{"A", "B", "C"}, labels)
+	})
+
+	t.Run("rejects a non-label predicate", func(t *testing.T) {
+		_, _, ok := parseWithWhereLabelTest("n.name = 'x'")
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects empty input", func(t *testing.T) {
+		_, _, ok := parseWithWhereLabelTest("")
+		assert.False(t, ok)
+	})
+}
+
+func TestWithWhereNodeHasAllLabels(t *testing.T) {
+	node := &storage.Node{Labels: []string{"Workload", "Deployable"}}
+
+	cases := []struct {
+		name     string
+		value    interface{}
+		required []string
+		want     bool
+	}{
+		{"single label present", node, []string{"Workload"}, true},
+		{"every label present", node, []string{"Workload", "Deployable"}, true},
+		{"order does not matter", node, []string{"Deployable", "Workload"}, true},
+		{"one label missing fails the conjunction", node, []string{"Workload", "Absent"}, false},
+		{"label absent", node, []string{"Absent"}, false},
+		{"no labels required is vacuously true", node, nil, true},
+		{"nil node cannot satisfy a label test", (*storage.Node)(nil), []string{"Workload"}, false},
+		{"missing binding cannot satisfy a label test", nil, []string{"Workload"}, false},
+		{"scalar binding is not a node", int64(7), []string{"Workload"}, false},
+		{"edge binding is not a node", &storage.Edge{Type: "RUNS_IN"}, []string{"Workload"}, false},
+		{"node with no labels", &storage.Node{}, []string{"Workload"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, withWhereNodeHasAllLabels(tc.value, tc.required))
+		})
+	}
+}
+
+func TestWithWhereNeedsFullEvaluator(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"function call", "toUpper(a.name) = 'X'", true},
+		{"conjunction", "a.x = 1 AND a.y = 2", true},
+		{"disjunction", "a.x = 1 OR a.y = 2", true},
+		{"exclusive or", "a.x = 1 XOR a.y = 2", true},
+		{"negation", "NOT a.x = 1", true},
+		{"lower-case boolean operator", "a.x = 1 and a.y = 2", true},
+		{"bare label test", "n:Workload", true},
+		{"plain comparison needs no help", "a.name = 'x'", false},
+		{"plain null check needs no help", "a.name IS NULL", false},
+		{"empty predicate", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, withWhereNeedsFullEvaluator(tc.input))
+		})
+	}
+}
+
+func TestSubstituteWithWhereLabelTests(t *testing.T) {
+	workload := &storage.Node{Labels: []string{"Workload"}}
+	values := map[string]interface{}{
+		"n":      workload,
+		"scalar": int64(3),
+	}
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"matching label becomes true", "n:Workload", "true"},
+		{"non-matching label becomes false", "n:Absent", "false"},
+		{"disjunction of both", "n:Workload OR n:Absent", "true OR false"},
+		{"conjunction of labels on one variable", "n:Workload:Absent", "false"},
+		{"unknown variable is false", "missing:Workload", "false"},
+		{"non-node binding is false", "scalar:Workload", "false"},
+		{"predicate with no label test is unchanged", "n.name = 'x'", "n.name = 'x'"},
+		{"colon inside a single-quoted string is left alone", "n.name = 'a:b'", "n.name = 'a:b'"},
+		{"colon inside a double-quoted string is left alone", "n.name = \"a:b\"", "n.name = \"a:b\""},
+		{"empty predicate", "", ""},
+		{"trailing colon is not a label test", "n:", "n:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, substituteWithWhereLabelTests(tc.input, values))
+		})
+	}
+}
+
+func TestWithWhereValueContext(t *testing.T) {
+	node := &storage.Node{Labels: []string{"Workload"}}
+	edge := &storage.Edge{Type: "RUNS_IN"}
+
+	t.Run("splits nodes and edges and drops scalars", func(t *testing.T) {
+		nodes, edges := withWhereValueContext(map[string]interface{}{
+			"n":      node,
+			"rel":    edge,
+			"count":  int64(3),
+			"name":   "checkout",
+			"nilVal": nil,
+		})
+		assert.Equal(t, map[string]*storage.Node{"n": node}, nodes)
+		assert.Equal(t, map[string]*storage.Edge{"rel": edge}, edges)
+	})
+
+	t.Run("empty input yields empty non-nil maps", func(t *testing.T) {
+		nodes, edges := withWhereValueContext(map[string]interface{}{})
+		assert.NotNil(t, nodes)
+		assert.NotNil(t, edges)
+		assert.Empty(t, nodes)
+		assert.Empty(t, edges)
+	})
+
+	t.Run("nil input is safe", func(t *testing.T) {
+		nodes, edges := withWhereValueContext(nil)
+		assert.Empty(t, nodes)
+		assert.Empty(t, edges)
+	})
+}
+
+// Concurrent evaluation must be safe: the claim path evaluates these predicates
+// from several workers at once, and the helpers read shared bound values.
+func TestEvaluateWithWhereConditionConcurrent(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	values := map[string]interface{}{
+		"n":   &storage.Node{Labels: []string{"Workload"}, Properties: map[string]interface{}{"name": "checkout"}},
+		"num": int64(10),
+	}
+
+	predicates := []struct {
+		clause string
+		want   bool
+	}{
+		{"n:Workload", true},
+		{"n:Absent", false},
+		{"n:Workload OR n:Absent", true},
+		{"num >= 10", true},
+		{"num > 11", false},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tc := predicates[i%len(predicates)]
+			got := exec.evaluateWithWhereCondition(ctx, tc.clause, values)
+			assert.Equal(t, tc.want, got, "predicate %q under concurrency", tc.clause)
+		}(i)
+	}
+	wg.Wait()
+}
+
+// The end-to-end path must also hold under concurrent execution, not just the
+// helpers in isolation.
+func TestWithAttachedWhereConcurrentQueries(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+	setupWithWhereFixture(t, store)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := exec.Execute(ctx, `MATCH (n) WITH n WHERE n:Workload RETURN count(*) AS c`, nil)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if len(result.Rows) != 1 {
+				errs <- fmt.Errorf("got %d rows, want 1", len(result.Rows))
+				return
+			}
+			if fmt.Sprintf("%v", result.Rows[0][0]) != "1" {
+				errs <- fmt.Errorf("got count %v, want 1", result.Rows[0][0])
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent query failed: %v", err)
+	}
+}
+
+// The operand resolver reads properties off bound nodes and edges, and must
+// treat a nil binding as an absent value rather than dereferencing it.
+func TestEvaluateWithWhereConditionResolvesBoundProperties(t *testing.T) {
+	store := storage.NewNamespacedEngine(newTestMemoryEngine(t), "test")
+	exec := NewStorageExecutor(store)
+	ctx := context.Background()
+
+	node := &storage.Node{Labels: []string{"Workload"}, Properties: map[string]interface{}{"name": "checkout"}}
+	edge := &storage.Edge{Type: "RUNS_IN", Properties: map[string]interface{}{"reason": "declared"}}
+
+	cases := []struct {
+		name   string
+		clause string
+		values map[string]interface{}
+		want   bool
+	}{
+		{
+			name:   "node property matches",
+			clause: "n.name = 'checkout'",
+			values: map[string]interface{}{"n": node},
+			want:   true,
+		},
+		{
+			name:   "node property does not match",
+			clause: "n.name = 'other'",
+			values: map[string]interface{}{"n": node},
+			want:   false,
+		},
+		{
+			name:   "edge property matches",
+			clause: "rel.reason = 'declared'",
+			values: map[string]interface{}{"rel": edge},
+			want:   true,
+		},
+		{
+			name:   "edge property does not match",
+			clause: "rel.reason = 'inferred'",
+			values: map[string]interface{}{"rel": edge},
+			want:   false,
+		},
+		{
+			name:   "nil node binding is treated as absent, not dereferenced",
+			clause: "n.name IS NULL",
+			values: map[string]interface{}{"n": (*storage.Node)(nil)},
+			want:   true,
+		},
+		{
+			name:   "nil edge binding is treated as absent, not dereferenced",
+			clause: "rel.reason IS NULL",
+			values: map[string]interface{}{"rel": (*storage.Edge)(nil)},
+			want:   true,
+		},
+		{
+			name:   "property absent from a present node",
+			clause: "n.missing IS NULL",
+			values: map[string]interface{}{"n": node},
+			want:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, exec.evaluateWithWhereCondition(ctx, tc.clause, tc.values))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #299.

A `WHERE` attached to a `WITH` was not evaluated as a filter for two kinds of predicate, and it failed in **opposite directions** depending on which kind. Neither errored.

## Measured against Neo4j 5.x community

Same fixture, same statements, Neo4j as the reference implementation:

| Query | Neo4j 5 | Before | After |
| --- | ---: | ---: | ---: |
| `MATCH (n) WITH n WHERE n:Workload RETURN count(*)` | 1 | **3** | 1 |
| `MATCH (n) WHERE n:Workload WITH n RETURN count(*)` | 1 | 1 | 1 |
| `WITH a WHERE toUpper(a.name) = 'CHECKOUT'` | 1 | **0** | 1 |
| `WITH a WHERE a.name = 'checkout'` | 1 | 1 | 1 |
| `WITH a WHERE coalesce(a.name,'X') IS NULL` | 0 | **1** | 0 |

Rows 2 and 4 are controls and were already correct — the predicate moved before the `WITH`, and a bare property comparison. They are in the test file to keep the fix honest about what it changed.

## What was wrong

Two evaluators, one per execution path, share the same shape: handle `IS NULL`/`IS NOT NULL` and six comparison operators, then fall through to `return true`.

**Label tests** carry no comparison operator, so they reached that pass-through and admitted every row — the filter silently did nothing.

**Function calls** were split on the operator, and the operand resolver separates variable from property by locating a dot. In `toUpper(a.name)` it finds the dot *inside the call* and looks up a variable named `toUpper(a`, which never resolves — so the comparison was false for every row and the filter excluded everything.

## What changed

- Label tests are parsed and evaluated against the bound node, including the `n:A:B` conjunction form.
- Label tests inside boolean combinations (`n:A OR n:B`) are substituted as boolean literals before the predicate goes to the general expression evaluator, which understands the operators but not the `var:Label` form. Substitution skips quoted regions so a colon inside a string literal is left alone.
- Predicates containing a function call are routed to the general evaluator ahead of the string-surgery branches that cannot parse them.

**Both evaluators needed it.** `evaluateWithWhereCondition` (`match_rows.go`) serves the simple-MATCH path and `evaluateWhereOnComputedRow` (`match_with_rel.go`) serves path traversal. Fixing only the first left this still unfiltered, which is the shape a scoped label whitelist actually uses:

```cypher
MATCH (s:Repository {id:'r1'})-[*1..3]->(impacted)
WITH impacted WHERE impacted:Workload OR impacted:CloudResource
RETURN impacted.id
```

## Deliberately not changed

The pass-through for wholly unrecognised predicates is pinned as intentional by `TestEvaluateWithWhereCondition_DirectBranches` ("Unknown pattern defaults to pass-through"), so it is left alone and documented in place instead.

It is worth flagging that it makes an unsupported filter behave as *no filter* rather than as an error, which is how both defects here stayed invisible. Whether that default should change seems like a maintainer decision rather than something a bug-fix PR should settle, so I have not touched it — happy to follow up either way.

## Verification

`pkg/cypher`, `pkg/storage` and `pkg/bolt` all pass. Five regression tests added, each stating the Neo4j-measured expectation in its comment so a future divergence is legible without re-deriving the reference.

Two related defects found while investigating are filed separately with reproductions and are **not** addressed here: #297 (`collect()` after two `MATCH` clauses returns no rows) and #298 (subscripting a collected list loses the node). I did not attempt those — I do not know those execution paths well enough to scope a fix confidently.

## AGENTS.md compliance

| Requirement | Result |
| --- | --- |
| Test-driven bug fix (failing test → verify fails → fix → verify passes → regression tests) | Followed; the five regression tests were written and confirmed failing before any change |
| Coverage ≥95% for core logic (`cypher`) | **100%** on all nine new/changed helpers |
| Edge cases (nil, empty, boundary) | Malformed label tests, non-node bindings, nil node/edge, missing bindings, empty and nil value maps |
| Error paths | Non-matching predicates, absent properties, unresolvable variables |
| Concurrency | 64 goroutines over the helper, 32 concurrent end-to-end queries |
| `go test -race` | Clean, 0 data races |
| Table-driven subtests | Yes, in the structure AGENTS.md documents |
| File size <2500 lines | `match_rows.go` 1132, `match_with_rel.go` 1302, tests 92 and 322 |
| `gofmt` | Clean |
| `go vet` | No findings in these files (the package's pre-existing `sync.Once` copy warnings in `cypher_helpers_extra_test.go` are on `main` and untouched here) |

Per-function coverage:

```
evaluateWithWhereCondition      100.0%
withWhereNeedsFullEvaluator     100.0%
parseWithWhereLabelTest         100.0%
withWhereNodeHasAllLabels       100.0%
withWhereIsLabelTest            100.0%
substituteWithWhereLabelTests   100.0%
isWithWhereIdentStart           100.0%
isWithWhereIdentPart            100.0%
withWhereValueContext           100.0%
```

One unreachable guard was removed rather than tested: `parseWithWhereLabelTest` checked `len(parts) < 2` after `withWhereIsLabelTest` had already established a colon with non-empty segments either side, so it could not be reached. A comment records why indexing is safe.
